### PR TITLE
Add /protocol schemas, tier mapping, and pricing fallbacks (#13, #14, #15)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,11 @@ importers:
         specifier: workspace:*
         version: link:../protocol
 
-  protocol: {}
+  protocol:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
 
 packages:
 
@@ -127,6 +131,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@turbo/darwin-64@2.9.12':
@@ -163,3 +170,5 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  zod@3.25.76: {}

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -16,5 +16,8 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
   }
 }

--- a/protocol/src/agents.ts
+++ b/protocol/src/agents.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const AGENT_IDS = ["aws-claude", "aws-nova", "azure-gpt", "gcp-gemini"] as const;
+export const AgentIdSchema = z.enum(AGENT_IDS);
+export type AgentId = z.infer<typeof AgentIdSchema>;
+
+export const MODEL_FAMILIES = ["claude", "nova", "gpt", "gemini"] as const;
+export const ModelFamilySchema = z.enum(MODEL_FAMILIES);
+export type ModelFamily = z.infer<typeof ModelFamilySchema>;
+
+export const AGENT_MODEL_FAMILY: Record<AgentId, ModelFamily> = {
+  "aws-claude": "claude",
+  "aws-nova": "nova",
+  "azure-gpt": "gpt",
+  "gcp-gemini": "gemini",
+};

--- a/protocol/src/index.ts
+++ b/protocol/src/index.ts
@@ -1,1 +1,6 @@
-export const PROTOCOL_VERSION = "0.0.0";
+export const PROTOCOL_VERSION = "0.1.0";
+
+export * from "./agents.js";
+export * from "./tiers.js";
+export * from "./pricing.js";
+export * from "./schemas.js";

--- a/protocol/src/pricing.ts
+++ b/protocol/src/pricing.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const PricingEntrySchema = z.object({
+  model_id: z.string().min(1),
+  price_in_usd_per_mtoken: z.number().nonnegative(),
+  price_out_usd_per_mtoken: z.number().nonnegative(),
+  effective_date: z.string().date(),
+});
+export type PricingEntry = z.infer<typeof PricingEntrySchema>;
+
+// Last-resort fallback prices, used only when the daily refresh job AND its
+// last-known-good cache are both unavailable (see CLAUDE.md → Pricing data).
+// These are conservative published-list-price snapshots and MUST be verified
+// before being relied on; the daily refresh in DynamoDB is the source of
+// truth. Quarterly review tracked by issue #41.
+// Units: USD per 1,000,000 tokens.
+export const FALLBACK_PRICING: Record<string, PricingEntry> = {
+  // AWS Bedrock — Anthropic
+  "anthropic.claude-haiku-3-5": {
+    model_id: "anthropic.claude-haiku-3-5",
+    price_in_usd_per_mtoken: 0.8,
+    price_out_usd_per_mtoken: 4.0,
+    effective_date: "2026-05-15",
+  },
+  "anthropic.claude-sonnet-4-6": {
+    model_id: "anthropic.claude-sonnet-4-6",
+    price_in_usd_per_mtoken: 3.0,
+    price_out_usd_per_mtoken: 15.0,
+    effective_date: "2026-05-15",
+  },
+
+  // AWS Bedrock — Amazon Nova
+  "amazon.nova-micro": {
+    model_id: "amazon.nova-micro",
+    price_in_usd_per_mtoken: 0.035,
+    price_out_usd_per_mtoken: 0.14,
+    effective_date: "2026-05-15",
+  },
+  "amazon.nova-lite": {
+    model_id: "amazon.nova-lite",
+    price_in_usd_per_mtoken: 0.06,
+    price_out_usd_per_mtoken: 0.24,
+    effective_date: "2026-05-15",
+  },
+  "amazon.nova-pro": {
+    model_id: "amazon.nova-pro",
+    price_in_usd_per_mtoken: 0.8,
+    price_out_usd_per_mtoken: 3.2,
+    effective_date: "2026-05-15",
+  },
+
+  // Azure OpenAI
+  "gpt-5-mini": {
+    model_id: "gpt-5-mini",
+    price_in_usd_per_mtoken: 0.25,
+    price_out_usd_per_mtoken: 2.0,
+    effective_date: "2026-05-15",
+  },
+  "gpt-5": {
+    model_id: "gpt-5",
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10.0,
+    effective_date: "2026-05-15",
+  },
+
+  // GCP Vertex AI
+  "gemini-2-5-flash": {
+    model_id: "gemini-2-5-flash",
+    price_in_usd_per_mtoken: 0.3,
+    price_out_usd_per_mtoken: 2.5,
+    effective_date: "2026-05-15",
+  },
+  "gemini-2-5-pro": {
+    model_id: "gemini-2-5-pro",
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10.0,
+    effective_date: "2026-05-15",
+  },
+};
+
+// Compute bid_usd identically across all four agents. Pure function so the
+// coordinator can re-derive it from a bid record for audit replay.
+export function computeBidUsd(params: {
+  est_input_tokens: number;
+  est_output_tokens: number;
+  price_in_usd_per_mtoken: number;
+  price_out_usd_per_mtoken: number;
+}): number {
+  return (
+    (params.est_input_tokens / 1_000_000) * params.price_in_usd_per_mtoken +
+    (params.est_output_tokens / 1_000_000) * params.price_out_usd_per_mtoken
+  );
+}

--- a/protocol/src/schemas.ts
+++ b/protocol/src/schemas.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { AgentIdSchema, ModelFamilySchema } from "./agents.js";
+import { TierSchema } from "./tiers.js";
+
+const NonNegInt = z.number().int().nonnegative();
+const NonNegNum = z.number().nonnegative();
+const Iso8601 = z.string().datetime({ offset: true });
+
+export const TaskIdSchema = z.string().min(1);
+export type TaskId = z.infer<typeof TaskIdSchema>;
+
+// Attachments are content-hash-only by default to avoid cross-cloud egress
+// of large payloads; agents pull bytes from a signed URL when one is set.
+export const AttachmentSchema = z.object({
+  content_hash: z.string().min(1),
+  url: z.string().url().optional(),
+  mime_type: z.string().optional(),
+  byte_size: NonNegInt.optional(),
+});
+export type Attachment = z.infer<typeof AttachmentSchema>;
+
+// What the client submits to POST /tasks.
+export const TaskSpecSchema = z.object({
+  prompt: z.string().min(1),
+  attachments: z.array(AttachmentSchema).optional(),
+  min_tier: TierSchema.optional(),
+  callback_url: z.string().url().optional(),
+  deadline: Iso8601.optional(),
+});
+export type TaskSpec = z.infer<typeof TaskSpecSchema>;
+
+// Bid returned by an agent's /bid handler.
+export const BidSchema = z.object({
+  task_id: TaskIdSchema,
+  agent_id: AgentIdSchema,
+  tier: TierSchema,
+  model_family: ModelFamilySchema,
+  // Exact pinned id for audit only; not exposed to winner selection.
+  model_id: z.string().min(1),
+  est_input_tokens: NonNegInt,
+  est_output_tokens: NonNegInt,
+  price_in_usd_per_mtoken: NonNegNum,
+  price_out_usd_per_mtoken: NonNegNum,
+  bid_usd: NonNegNum,
+  expires_at: Iso8601,
+  signature: z.string().min(1),
+});
+export type Bid = z.infer<typeof BidSchema>;
+
+export const NO_BID_REASONS = [
+  "context_overflow",
+  "policy",
+  "capability",
+  "internal_error",
+] as const;
+export const NoBidReasonSchema = z.enum(NO_BID_REASONS);
+export type NoBidReason = z.infer<typeof NoBidReasonSchema>;
+
+// Decline-to-bid. Reason codes bucket separately from real bids so they
+// don't pollute MAPE.
+export const NoBidSchema = z.object({
+  task_id: TaskIdSchema,
+  agent_id: AgentIdSchema,
+  status: z.literal("no_bid"),
+  reason: NoBidReasonSchema,
+});
+export type NoBid = z.infer<typeof NoBidSchema>;
+
+// Coordinator parses /bid responses as one of these.
+export const BidResponseSchema = z.union([BidSchema, NoBidSchema]);
+export type BidResponse = z.infer<typeof BidResponseSchema>;
+
+export function isNoBid(response: BidResponse): response is NoBid {
+  return "status" in response && response.status === "no_bid";
+}
+
+// Award sent to the winner. Vickrey: auction_price_usd is the second-lowest
+// bid; original_bid_usd is the winner's own bid (recorded for accuracy).
+export const AwardSchema = z.object({
+  task_id: TaskIdSchema,
+  agent_id: AgentIdSchema,
+  auction_price_usd: NonNegNum,
+  original_bid_usd: NonNegNum,
+  expires_at: Iso8601,
+  signature: z.string().min(1),
+});
+export type Award = z.infer<typeof AwardSchema>;
+
+// Reject sent to losers; signed so the agent can verify the round closed.
+export const RejectSchema = z.object({
+  task_id: TaskIdSchema,
+  agent_id: AgentIdSchema,
+  signature: z.string().min(1),
+});
+export type Reject = z.infer<typeof RejectSchema>;
+
+export const ActualUsageSchema = z.object({
+  input_tokens: NonNegInt,
+  output_tokens: NonNegInt,
+});
+export type ActualUsage = z.infer<typeof ActualUsageSchema>;
+
+// Result returned by the winner's /execute handler.
+export const ResultSchema = z.object({
+  task_id: TaskIdSchema,
+  agent_id: AgentIdSchema,
+  output: z.string(),
+  actual_usage: ActualUsageSchema,
+});
+export type Result = z.infer<typeof ResultSchema>;
+
+// Lifecycle states surfaced through GET /tasks/:id.
+export const TASK_STATUSES = [
+  "bidding",
+  "awarded",
+  "executing",
+  "completed",
+  "failed",
+] as const;
+export const TaskStatusSchema = z.enum(TASK_STATUSES);
+export type TaskStatus = z.infer<typeof TaskStatusSchema>;
+
+// Phase claim in the coordinator-signed JWT.
+export const JWT_PHASES = ["bid", "award", "execute", "reject"] as const;
+export const JwtPhaseSchema = z.enum(JWT_PHASES);
+export type JwtPhase = z.infer<typeof JwtPhaseSchema>;

--- a/protocol/src/tiers.ts
+++ b/protocol/src/tiers.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { AgentId } from "./agents.js";
+
+export const TIERS = ["small", "medium", "frontier"] as const;
+export const TierSchema = z.enum(TIERS);
+export type Tier = z.infer<typeof TierSchema>;
+
+const TIER_RANK: Record<Tier, number> = {
+  small: 0,
+  medium: 1,
+  frontier: 2,
+};
+
+export function compareTier(a: Tier, b: Tier): number {
+  return TIER_RANK[a] - TIER_RANK[b];
+}
+
+export function meetsMinTier(bidTier: Tier, minTier: Tier | undefined): boolean {
+  if (minTier === undefined) return true;
+  return TIER_RANK[bidTier] >= TIER_RANK[minTier];
+}
+
+// Reference mapping of canonical model IDs per (agent, tier). Documentation
+// only — actual deploys pin model_id via Terraform/env per CLAUDE.md.
+// `null` means the family has no offering at that tier and the agent must
+// decline-to-bid (`capability`) if min_tier matches that slot.
+export const CANONICAL_TIER_MODELS: Record<AgentId, Record<Tier, string | null>> = {
+  "aws-claude": {
+    small: "anthropic.claude-haiku-3-5",
+    medium: null,
+    frontier: "anthropic.claude-sonnet-4-6",
+  },
+  "aws-nova": {
+    small: "amazon.nova-micro",
+    medium: "amazon.nova-lite",
+    frontier: "amazon.nova-pro",
+  },
+  "azure-gpt": {
+    small: "gpt-5-mini",
+    medium: null,
+    frontier: "gpt-5",
+  },
+  "gcp-gemini": {
+    small: "gemini-2-5-flash",
+    medium: null,
+    frontier: "gemini-2-5-pro",
+  },
+};


### PR DESCRIPTION
Lands the Tier 0 protocol package so coordinator and agent code can be
written against a typed contract before any cloud is provisioned.

- schemas.ts: Zod schemas for TaskSpec, Bid, NoBid (+ BidResponse union
  and isNoBid narrowing helper), Award, Reject, Result, ActualUsage,
  Attachment, plus TaskStatus and JwtPhase enums. All token/USD fields
  validate non-negative; expires_at/deadline validate ISO-8601 with
  offset.
- agents.ts: AgentId enum (aws-claude, aws-nova, azure-gpt, gcp-gemini),
  ModelFamily enum, and AGENT_MODEL_FAMILY mapping between them.
- tiers.ts: Tier enum (small | medium | frontier), compareTier and
  meetsMinTier helpers for the coordinator's min_tier filter, and a
  CANONICAL_TIER_MODELS reference map (documentation; real model_id is
  pinned per deploy).
- pricing.ts: PricingEntry schema, FALLBACK_PRICING constants (USD per
  Mtoken, dated 2026-05-15) used only when both the daily refresh job
  and last-known-good cache are unavailable, and a computeBidUsd helper
  so all four agents derive bid_usd identically.

PROTOCOL_VERSION bumped 0.0.0 -> 0.1.0.

Verified with `pnpm run typecheck` across all 11 workspace tasks and a
manual round-trip parse smoke test against the compiled dist.

https://claude.ai/code/session_01AJBxh2p9RcvL2y8y5V4Eya