### PR TITLE
Add Terraform: DynamoDB ledger table for the coordinator (#19)

### DIFF
--- a/infra/coordinator/backend.hcl.example
+++ b/infra/coordinator/backend.hcl.example
@@ -1,0 +1,11 @@
+# Copy to backend.hcl per environment and pass to:
+#   terraform init -backend-config=backend.hcl
+#
+# The bucket and lock table must exist before init (chicken-and-egg with
+# Terraform-managed state). Bootstrap them by hand or with a separate root.
+
+bucket         = "agent-tasker-tfstate-CHANGEME"
+key            = "coordinator/dev/terraform.tfstate"
+region         = "us-east-1"
+dynamodb_table = "agent-tasker-tflocks"
+encrypt        = true

--- a/infra/coordinator/ledger.tf
+++ b/infra/coordinator/ledger.tf
@@ -1,0 +1,60 @@
+# Single-table ledger for the auction.
+#
+# Item shapes (see CLAUDE.md → Storage and /protocol schemas):
+#
+#   PK (task_id)         SK                      agent_id     notes
+#   ────────────────     ────────────────────    ─────────    ─────────────────────────────
+#   <uuid>               task                    —            task root + status
+#   <uuid>               bid#aws-claude          aws-claude   per-agent bid (or no_bid)
+#   <uuid>               bid#aws-nova            aws-nova
+#   <uuid>               award                   <winner>     award; carries winner agent_id
+#   <uuid>               reject#aws-nova         aws-nova
+#   <uuid>               result#aws-claude       aws-claude   /execute output + actual_usage
+#   <uuid>               settle#aws-claude       aws-claude   bookkeeping: bid vs actual MAPE
+#
+# The agent_id attribute is *sparse* — set only on items that belong to a
+# specific agent. Coordinator-only items (the task root) omit it and are
+# excluded from the GSI, which keeps per-agent scans clean.
+resource "aws_dynamodb_table" "ledger" {
+  name         = "${local.name_prefix}-ledger"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "task_id"
+  range_key    = "sk"
+
+  attribute {
+    name = "task_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  attribute {
+    name = "agent_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "created_at"
+    type = "S"
+  }
+
+  # Per-agent rolling stats: MAPE rollups, win rate by tier, decline rate by
+  # reason. Sort by created_at so recent windows are a single Query.
+  global_secondary_index {
+    name            = "agent_id-created_at-index"
+    hash_key        = "agent_id"
+    range_key       = "created_at"
+    projection_type = "ALL"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+}

--- a/infra/coordinator/main.tf
+++ b/infra/coordinator/main.tf
@@ -1,0 +1,20 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+locals {
+  name_prefix = "${var.project}-${var.env}"
+
+  common_tags = merge(
+    {
+      Project = var.project
+      Env     = var.env
+      Module  = "coordinator"
+    },
+    var.tags,
+  )
+}

--- a/infra/coordinator/outputs.tf
+++ b/infra/coordinator/outputs.tf
@@ -1,0 +1,19 @@
+output "ledger_table_name" {
+  description = "Name of the DynamoDB ledger table."
+  value       = aws_dynamodb_table.ledger.name
+}
+
+output "ledger_table_arn" {
+  description = "ARN of the DynamoDB ledger table."
+  value       = aws_dynamodb_table.ledger.arn
+}
+
+output "ledger_agent_index_name" {
+  description = "Name of the GSI keyed on agent_id."
+  value       = "agent_id-created_at-index"
+}
+
+output "ledger_agent_index_arn" {
+  description = "ARN of the agent_id GSI (useful for IAM policies)."
+  value       = "${aws_dynamodb_table.ledger.arn}/index/agent_id-created_at-index"
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -1,0 +1,27 @@
+variable "project" {
+  description = "Project name prefix used for all resources."
+  type        = string
+  default     = "agent-tasker"
+}
+
+variable "env" {
+  description = "Environment name (e.g. dev, staging, prod). Used in resource names."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,16}$", var.env))
+    error_message = "env must be 1-16 chars of [a-z0-9-]."
+  }
+}
+
+variable "region" {
+  description = "AWS region for the coordinator stack."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "tags" {
+  description = "Extra tags to merge onto every resource."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/coordinator/versions.tf
+++ b/infra/coordinator/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+
+  # Backend is left as a partial config so each environment supplies its own
+  # bucket / lock table at init time:
+  #
+  #   terraform init -backend-config=backend.hcl
+  #
+  # See backend.hcl.example for the expected keys.
+  backend "s3" {}
+}


### PR DESCRIPTION
Single-table design per CLAUDE.md → Storage. PK=task_id, SK=phase#agent_id
(bid#aws-claude, award, result#aws-nova, etc.). Sparse GSI on agent_id +
created_at supports per-agent rolling stats (MAPE rollups, win rate,
decline rate).

On-demand billing so the table is free at idle. PITR + SSE on. Module
uses a partial S3 backend; see backend.hcl.example.