### PR TITLE
Align /protocol with post-pivot GCP-centric design

### DIFF
--- a/protocol/src/agents.ts
+++ b/protocol/src/agents.ts
@@ -1,16 +1,19 @@
 import { z } from "zod";
 
-export const AGENT_IDS = ["aws-claude", "aws-nova", "azure-gpt", "gcp-gemini"] as const;
+export const AGENT_IDS = ["aws-nova", "azure-gpt", "gcp-gemini", "gcp-orchestrator"] as const;
 export const AgentIdSchema = z.enum(AGENT_IDS);
 export type AgentId = z.infer<typeof AgentIdSchema>;
 
-export const MODEL_FAMILIES = ["claude", "nova", "gpt", "gemini"] as const;
+export const MODEL_FAMILIES = ["gemini", "gpt", "nova"] as const;
 export const ModelFamilySchema = z.enum(MODEL_FAMILIES);
 export type ModelFamily = z.infer<typeof ModelFamilySchema>;
 
+// Both GCP agents resolve to the Gemini model family — they contrast on
+// runtime/capability (direct Vertex SDK vs Gemini Enterprise Agent Platform),
+// not on the underlying LLM. See CLAUDE.md → Per-cloud agent implementation.
 export const AGENT_MODEL_FAMILY: Record<AgentId, ModelFamily> = {
-  "aws-claude": "claude",
   "aws-nova": "nova",
   "azure-gpt": "gpt",
   "gcp-gemini": "gemini",
+  "gcp-orchestrator": "gemini",
 };

--- a/protocol/src/pricing.ts
+++ b/protocol/src/pricing.ts
@@ -11,24 +11,10 @@ export type PricingEntry = z.infer<typeof PricingEntrySchema>;
 // Last-resort fallback prices, used only when the daily refresh job AND its
 // last-known-good cache are both unavailable (see CLAUDE.md → Pricing data).
 // These are conservative published-list-price snapshots and MUST be verified
-// before being relied on; the daily refresh in DynamoDB is the source of
+// before being relied on; the daily refresh in Firestore is the source of
 // truth. Quarterly review tracked by issue #41.
 // Units: USD per 1,000,000 tokens.
 export const FALLBACK_PRICING: Record<string, PricingEntry> = {
-  // AWS Bedrock — Anthropic
-  "anthropic.claude-haiku-3-5": {
-    model_id: "anthropic.claude-haiku-3-5",
-    price_in_usd_per_mtoken: 0.8,
-    price_out_usd_per_mtoken: 4.0,
-    effective_date: "2026-05-15",
-  },
-  "anthropic.claude-sonnet-4-6": {
-    model_id: "anthropic.claude-sonnet-4-6",
-    price_in_usd_per_mtoken: 3.0,
-    price_out_usd_per_mtoken: 15.0,
-    effective_date: "2026-05-15",
-  },
-
   // AWS Bedrock — Amazon Nova
   "amazon.nova-micro": {
     model_id: "amazon.nova-micro",

--- a/protocol/src/tiers.ts
+++ b/protocol/src/tiers.ts
@@ -25,11 +25,6 @@ export function meetsMinTier(bidTier: Tier, minTier: Tier | undefined): boolean 
 // `null` means the family has no offering at that tier and the agent must
 // decline-to-bid (`capability`) if min_tier matches that slot.
 export const CANONICAL_TIER_MODELS: Record<AgentId, Record<Tier, string | null>> = {
-  "aws-claude": {
-    small: "anthropic.claude-haiku-3-5",
-    medium: null,
-    frontier: "anthropic.claude-sonnet-4-6",
-  },
   "aws-nova": {
     small: "amazon.nova-micro",
     medium: "amazon.nova-lite",
@@ -41,6 +36,15 @@ export const CANONICAL_TIER_MODELS: Record<AgentId, Record<Tier, string | null>>
     frontier: "gpt-5",
   },
   "gcp-gemini": {
+    small: "gemini-2-5-flash",
+    medium: null,
+    frontier: "gemini-2-5-pro",
+  },
+  // GAEP-backed orchestrator. Bid LLM is Gemini Flash; execution is a
+  // GAEP composite over Gemini 2.5 Pro. Bids declare `frontier` since the
+  // underlying execution model is Pro-class — competitive advantage is in
+  // the runtime layer, not raw model quality. See CLAUDE.md → Quality floor.
+  "gcp-orchestrator": {
     small: "gemini-2-5-flash",
     medium: null,
     frontier: "gemini-2-5-pro",


### PR DESCRIPTION
## Summary
The 2026-05-18 pivot (commit 15cd054) reshaped the agent roster to `{GCP/Gemini, GCP/Orchestrator (GAEP), AWS/Nova, Azure/GPT}`, but the Zod schemas in `/protocol` were not updated at the same time — they still carried the pre-pivot `aws-claude` agent and Anthropic pricing rows. JWT signing (#25) needs `AgentIdSchema` to validate the `aud` claim, so this cleanup has to land before that PR.

- `agents.ts`: drop `aws-claude` from `AGENT_IDS` / `AGENT_MODEL_FAMILY`; drop `claude` from `MODEL_FAMILIES`; add `gcp-orchestrator` (`gemini` family — both GCP agents share the model family and contrast on the runtime layer per CLAUDE.md).
- `tiers.ts`: drop `aws-claude` row from `CANONICAL_TIER_MODELS`; add a `gcp-orchestrator` row (bid = Gemini Flash, frontier = Gemini 2.5 Pro — the GAEP execution target).
- `pricing.ts`: remove the two `anthropic.*` rows from `FALLBACK_PRICING`; fix the stale "daily refresh in DynamoDB" comment to point at Firestore.

No JWT/signing code yet — that lands in #25.

## Test plan
- [x] `pnpm typecheck` passes locally (11/11 workspaces)
- [x] `pnpm lint` clean
- [x] `pnpm format` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)