### PR TITLE
Terraform: Firestore Native DB + bids composite indexes (#20)

### DIFF
--- a/infra/coordinator/firestore.tf
+++ b/infra/coordinator/firestore.tf
@@ -1,0 +1,76 @@
+# Native-mode Firestore for the coordinator's ledger and the daily pricing
+# snapshots. A GCP project can hold one Firestore database; we use the
+# `(default)` name so future modules (pricing refresh function, eval replay,
+# BigQuery export) can reference it without coordinating naming.
+#
+# Schema lives in code, not Terraform — only the database container and the
+# composite indexes that collection-group queries require are defined here.
+# Per CLAUDE.md → Storage:
+#
+#   tasks/{task_id}                        -- root task doc
+#   tasks/{task_id}/bids/{agent_id}        -- per-agent bid records
+#   tasks/{task_id}/awards/{n}             -- award + (potential) re-auctions
+#   tasks/{task_id}/results/{agent_id}     -- /execute results
+#   pricing/{model_id}/snapshots/{date}    -- immutable daily price snapshots
+#
+# Indexes target the `bids` subcollection via COLLECTION_GROUP scope so we can
+# query per-agent activity across all tasks without scanning every parent.
+
+resource "google_firestore_database" "default" {
+  project     = var.project_id
+  name        = "(default)"
+  location_id = var.firestore_location
+  type        = "FIRESTORE_NATIVE"
+
+  # Concurrency mode: OPTIMISTIC keeps single-document write latency low;
+  # transaction conflicts surface as retryable errors in the SDK, which is the
+  # right behavior for the coordinator's auction state machine.
+  concurrency_mode = "OPTIMISTIC"
+
+  delete_protection_state = var.firestore_delete_protection ? "DELETE_PROTECTION_ENABLED" : "DELETE_PROTECTION_DISABLED"
+
+  # `ABANDON` means `terraform destroy` removes the resource from state but
+  # leaves the database in GCP, so accidental destroys never silently delete
+  # the ledger. Re-import is straightforward if state diverges.
+  deletion_policy = "ABANDON"
+}
+
+# Per-agent rolling stats: read recent bids for one agent. Used for MAPE
+# rollups, win-rate dashboards, decline-rate cuts.
+resource "google_firestore_index" "bids_by_agent_recency" {
+  project     = var.project_id
+  database    = google_firestore_database.default.name
+  collection  = "bids"
+  query_scope = "COLLECTION_GROUP"
+
+  fields {
+    field_path = "agent_id"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "timestamp"
+    order      = "DESCENDING"
+  }
+}
+
+# Per-(agent, phase) cuts so decline-rate by reason and bid-vs-no_bid splits
+# don't pay for a full scan + in-memory filter on every dashboard refresh.
+resource "google_firestore_index" "bids_by_agent_phase_recency" {
+  project     = var.project_id
+  database    = google_firestore_database.default.name
+  collection  = "bids"
+  query_scope = "COLLECTION_GROUP"
+
+  fields {
+    field_path = "agent_id"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "phase"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "timestamp"
+    order      = "DESCENDING"
+  }
+}

--- a/infra/coordinator/outputs.tf
+++ b/infra/coordinator/outputs.tf
@@ -1,0 +1,9 @@
+output "firestore_database_name" {
+  description = "Logical name of the Firestore database — always `(default)` for the project's primary database."
+  value       = google_firestore_database.default.name
+}
+
+output "firestore_location_id" {
+  description = "Location the Firestore database was provisioned in. Cannot be changed after creation."
+  value       = google_firestore_database.default.location_id
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -30,3 +30,15 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "firestore_location" {
+  description = "Firestore database location. Multi-region (`nam5`, `eur3`) recommended for durability; single-region (`us-central1`, etc.) is cheaper. One Firestore database per project — once set this cannot change."
+  type        = string
+  default     = "nam5"
+}
+
+variable "firestore_delete_protection" {
+  description = "Whether the GCP-side delete-protection flag is enabled on the Firestore database. Defaults to disabled so dev environments can iterate quickly; set to true in prod to require a Terraform-driven flag flip before destroy is permitted."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
Creates the `(default)` Firestore database in the coordinator project plus the two composite indexes the ledger queries need. Replaces the pre-pivot DynamoDB design.

**Database** (`google_firestore_database.default`):
- `FIRESTORE_NATIVE`, `nam5` multi-region by default (variable)
- `OPTIMISTIC` concurrency — keeps single-doc write latency low; transaction conflicts surface as retryable SDK errors, the right behavior for the auction state machine
- `delete_protection_state` is per-env (off in dev for iteration, on in prod via the new `firestore_delete_protection` variable)
- `deletion_policy = ABANDON` — accidental `terraform destroy` removes from state but leaves the ledger in GCP

**Indexes** (both COLLECTION_GROUP scoped on `bids`):
- `(agent_id ASC, timestamp DESC)` — per-agent rolling stats, MAPE/win-rate rollups
- `(agent_id ASC, phase ASC, timestamp DESC)` — decline-rate by reason and bid-vs-no_bid splits without a full scan

Schema lives in code (subcollections under `tasks/{task_id}` plus `pricing/{model_id}/snapshots/{date}`); only the database container and the indexes collection-group queries actually require are defined here.

Outputs `firestore_database_name` and `firestore_location_id` so downstream modules (pricing refresh, eval replay, BigQuery export) don't have to coordinate naming.

Closes #20

## Test plan
- [x] `terraform validate` passes (CI Terraform job covers this)
- [x] `terraform fmt -check` passes
- [ ] After `terraform apply` in a real dev project: verify the database appears in the Firestore console with `(default)` name and `nam5` location
- [ ] Verify both composite indexes show "Enabled" state in the Indexes tab (index builds take a few minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)