### PR TITLE
Terraform: JWKS GCS bucket for public keys (#26)

### DIFF
--- a/infra/coordinator/jwks.tf
+++ b/infra/coordinator/jwks.tf
@@ -1,0 +1,75 @@
+# JWKS hosting for coordinator-minted task JWTs. Each agent's verifier
+# fetches https://storage.googleapis.com/{bucket}/jwks.json, caches it, and
+# verifies tokens against whichever key matches the `kid` header.
+#
+# Phase 1 keeps this on a public GCS bucket — no LB, no Cloud CDN, no custom
+# domain. GCP fronts the bucket with its own HTTPS, signed by Google's cert.
+# Justification:
+#
+#   - JWKS docs are public by definition; nothing here is sensitive.
+#   - Both Phase 1 agents share a GCP project with the coordinator, so
+#     intra-cloud egress is free and cross-cloud caching tuning isn't yet
+#     load-bearing.
+#   - One Terraform resource instead of ~six (backend bucket, URL map, HTTPS
+#     proxy, forwarding rule, managed SSL cert, DNS record).
+#
+# Promote to LB + Cloud CDN + custom domain when the AWS/Nova or Azure/GPT
+# agents land (Phase 2/3) and edge caching for cross-cloud verifiers starts
+# to matter. The bucket itself stays as the origin; only the front door
+# changes.
+
+resource "google_storage_bucket" "jwks" {
+  project = var.project_id
+
+  # GCP bucket names are globally unique; include the project_id so dev/prod
+  # never collide.
+  name     = "${local.name_prefix}-jwks-${var.project_id}"
+  location = var.jwks_bucket_location
+
+  uniform_bucket_level_access = true
+  public_access_prevention    = "inherited"
+
+  # Versioning gives us a rollback path if a bad JWKS is published during
+  # key rotation. The lifecycle rule bounds object-version retention so we
+  # don't accumulate forever — JWKS docs are tiny but discipline matters.
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    condition {
+      num_newer_versions = 10
+      with_state         = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # See firestore.tf for the deletion_policy/delete_protection reasoning. Same
+  # pattern: env-aware GCP-side protection plus a Terraform-side ABANDON so
+  # accidental destroy doesn't nuke published keys.
+  force_destroy = !var.jwks_delete_protection
+}
+
+# Anonymous read on objects — agents need to fetch jwks.json without any auth
+# token (chicken-and-egg: the JWKS is what they'd use to verify auth).
+# Restricted to objectViewer (read), not legacy objectReader (list).
+resource "google_storage_bucket_iam_member" "jwks_public_read" {
+  bucket = google_storage_bucket.jwks.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+# The JWKS document itself is published by the coordinator at runtime (see
+# follow-up PR — the publish helper lives in coordinator/src/jwks/ and runs
+# on key generation / rotation). Terraform deliberately doesn't manage the
+# object contents — its lifetime is operational, not declarative.
+#
+# Rotation flow (operator + code together):
+#   1. Generate the incoming key. Publish a JWKS containing BOTH old + new
+#      public keys.
+#   2. Wait at least max(token TTL, JWKS cache TTL) so every in-flight token
+#      can verify under whichever key signed it.
+#   3. Flip the coordinator's active signing key to the new one.
+#   4. Publish a JWKS containing only the new public key.

--- a/infra/coordinator/outputs.tf
+++ b/infra/coordinator/outputs.tf
@@ -7,3 +7,13 @@ output "firestore_location_id" {
   description = "Location the Firestore database was provisioned in. Cannot be changed after creation."
   value       = google_firestore_database.default.location_id
 }
+
+output "jwks_bucket_name" {
+  description = "Name of the GCS bucket holding the JWKS document. Used by the coordinator's publish helper when rotating keys."
+  value       = google_storage_bucket.jwks.name
+}
+
+output "jwks_public_url" {
+  description = "Stable public URL each agent's verifier fetches to read coordinator public keys. Object `jwks.json` is published out-of-band by the coordinator at startup / key rotation."
+  value       = "https://storage.googleapis.com/${google_storage_bucket.jwks.name}/jwks.json"
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -42,3 +42,15 @@ variable "firestore_delete_protection" {
   type        = bool
   default     = false
 }
+
+variable "jwks_bucket_location" {
+  description = "Location for the JWKS GCS bucket. Multi-region (`US`, `EU`) recommended for low-latency reads from anywhere; single-region (`us-central1`, etc.) is cheaper. Phase 1 traffic is intra-project so this rarely matters."
+  type        = string
+  default     = "US"
+}
+
+variable "jwks_delete_protection" {
+  description = "Whether `terraform destroy` is allowed to delete the JWKS bucket. False in dev for iteration; true in prod so accidental destroys don't drop the published public keys (which would break every in-flight token)."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
Public-read GCS bucket that hosts coordinator-signed JWT public keys. Phase 1 keeps it simple: agents fetch `https://storage.googleapis.com/{bucket}/jwks.json` directly, fronted by GCP's own HTTPS. **No** external LB, Cloud CDN, custom domain, or managed SSL cert (deferred until Phase 2/3 when cross-cloud verifiers care about edge caching).

**Bucket details:**
- Globally-unique name `${name_prefix}-jwks-${project_id}`
- Uniform bucket-level access; `public_access_prevention = "inherited"`
- Versioning on, lifecycle caps at 10 ARCHIVED versions (rollback path during rotation without unbounded accumulation)
- `roles/storage.objectViewer` for `allUsers` (read-only, no list) — required because verifiers fetch the JWKS *before* they have any auth token
- `force_destroy` mirrors `var.jwks_delete_protection`; dev iterates freely, prod requires deliberate flag flip
- New outputs: `jwks_bucket_name`, `jwks_public_url`

**Deferred to a follow-up PR** (paired with key generation): the actual publish helper (`jose.exportJWK` + GCS upload). Same pattern as deferring `SecretManagerKeyProvider` from #25.

**Rotation flow** (documented in `jwks.tf`):
1. Generate new key; publish JWKS containing OLD + NEW.
2. Wait at least `max(token TTL, JWKS cache TTL)`.
3. Flip coordinator's active signing key.
4. Publish JWKS containing only NEW.

Closes #26

## Test plan
- [x] `terraform validate` passes (CI Terraform job)
- [x] `terraform fmt -check` passes
- [ ] After `terraform apply` in dev: bucket exists, anonymous read works (`curl https://storage.googleapis.com/{bucket}/`)
- [ ] Confirm `gsutil ls` shows `versioning: enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)