### PR TITLE
Coordinator auction state machine + ledger persistence (#24)

### DIFF
--- a/coordinator/package.json
+++ b/coordinator/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@agent-tasker/protocol": "workspace:*",
-    "jose": "^6.2.3"
+    "@google-cloud/firestore": "^8.6.0",
+    "jose": "^6.2.3",
+    "zod": "^3.25.76"
   }
 }

--- a/coordinator/src/auction/index.ts
+++ b/coordinator/src/auction/index.ts
@@ -1,0 +1,1 @@
+export * from "./state-machine.js";

--- a/coordinator/src/auction/state-machine.ts
+++ b/coordinator/src/auction/state-machine.ts
@@ -1,0 +1,42 @@
+import type { TaskStatus } from "@agent-tasker/protocol";
+
+// Auction lifecycle per CLAUDE.md → Bidding protocol. Terminal states have no
+// outgoing transitions; re-auction on /execute failure (#53) is modeled as a
+// *new* task lifecycle that links back to the original via a parent reference,
+// not as a transition out of `failed`.
+export const VALID_TRANSITIONS: Record<TaskStatus, readonly TaskStatus[]> = {
+  bidding: ["awarded", "failed"],
+  awarded: ["executing", "failed"],
+  executing: ["completed", "failed"],
+  completed: [],
+  failed: [],
+};
+
+export function canTransition(from: TaskStatus, to: TaskStatus): boolean {
+  return VALID_TRANSITIONS[from].includes(to);
+}
+
+export class InvalidTransitionError extends Error {
+  constructor(
+    readonly taskId: string,
+    readonly from: TaskStatus,
+    readonly to: TaskStatus,
+  ) {
+    super(`Task ${taskId}: invalid transition ${from} -> ${to}`);
+    this.name = "InvalidTransitionError";
+  }
+}
+
+export class TaskNotFoundError extends Error {
+  constructor(readonly taskId: string) {
+    super(`Task ${taskId} not found`);
+    this.name = "TaskNotFoundError";
+  }
+}
+
+export class TaskAlreadyExistsError extends Error {
+  constructor(readonly taskId: string) {
+    super(`Task ${taskId} already exists`);
+    this.name = "TaskAlreadyExistsError";
+  }
+}

--- a/coordinator/src/index.ts
+++ b/coordinator/src/index.ts
@@ -1,2 +1,4 @@
 export { PROTOCOL_VERSION } from "@agent-tasker/protocol";
 export * from "./jwt/index.js";
+export * from "./auction/index.js";
+export * from "./ledger/index.js";

--- a/coordinator/src/ledger/firestore-store.ts
+++ b/coordinator/src/ledger/firestore-store.ts
@@ -1,0 +1,211 @@
+import {
+  Firestore,
+  type CollectionReference,
+  type DocumentReference,
+  type Transaction,
+} from "@google-cloud/firestore";
+import type { TaskId, TaskStatus } from "@agent-tasker/protocol";
+import {
+  InvalidTransitionError,
+  TaskAlreadyExistsError,
+  TaskNotFoundError,
+  canTransition,
+} from "../auction/state-machine.js";
+import type {
+  AwardTaskInput,
+  CompleteTaskInput,
+  CreateTaskInput,
+  FailTaskInput,
+  LedgerStore,
+  RecordBidResponseInput,
+} from "./store.js";
+import { BidRecordSchema, TaskRecordSchema, type BidRecord, type TaskRecord } from "./types.js";
+
+// Production-backed ledger store. Schema validation on read defends against
+// drift between deployed code and historical documents — any field rename
+// or removed enum value surfaces as a Zod parse error rather than a
+// silent undefined downstream.
+export class FirestoreLedgerStore implements LedgerStore {
+  private readonly tasksCollection: CollectionReference;
+
+  constructor(private readonly firestore: Firestore) {
+    this.tasksCollection = firestore.collection("tasks");
+  }
+
+  async createTask(input: CreateTaskInput): Promise<TaskRecord> {
+    const ref = this.taskRef(input.taskId);
+    const now = nowIso(input.now);
+    const record: TaskRecord = {
+      task_id: input.taskId,
+      status: "bidding",
+      spec: input.spec,
+      created_at: now,
+      updated_at: now,
+    };
+    try {
+      await ref.create(stripUndefined(record));
+    } catch (err: unknown) {
+      if (isAlreadyExists(err)) throw new TaskAlreadyExistsError(input.taskId);
+      throw err;
+    }
+    return record;
+  }
+
+  async getTask(taskId: TaskId): Promise<TaskRecord | null> {
+    const snap = await this.taskRef(taskId).get();
+    if (!snap.exists) return null;
+    return TaskRecordSchema.parse(snap.data());
+  }
+
+  async recordBidResponse(input: RecordBidResponseInput): Promise<BidRecord> {
+    const taskRef = this.taskRef(input.taskId);
+    const bidRef = taskRef.collection("bids").doc(input.response.agent_id);
+
+    return this.firestore.runTransaction(async (tx) => {
+      const task = await this.readTask(tx, taskRef, input.taskId);
+      if (task.status !== "bidding") {
+        throw new InvalidTransitionError(input.taskId, task.status, "bidding");
+      }
+      const record: BidRecord = {
+        task_id: input.taskId,
+        agent_id: input.response.agent_id,
+        timestamp: nowIso(input.now),
+        phase: "bid",
+        response: input.response,
+        pricing_snapshot: input.pricingSnapshot,
+      };
+      tx.set(bidRef, stripUndefined(record));
+      return record;
+    });
+  }
+
+  async listBids(taskId: TaskId): Promise<BidRecord[]> {
+    const snap = await this.taskRef(taskId).collection("bids").orderBy("timestamp", "asc").get();
+    return snap.docs.map((d) => BidRecordSchema.parse(d.data()));
+  }
+
+  async awardTask(input: AwardTaskInput): Promise<TaskRecord> {
+    const ref = this.taskRef(input.taskId);
+    return this.firestore.runTransaction(async (tx) => {
+      const task = await this.readTask(tx, ref, input.taskId);
+
+      if (
+        task.status === "awarded" &&
+        task.winner_agent_id === input.winnerAgentId &&
+        task.auction_price_usd === input.auctionPriceUsd &&
+        task.winning_bid_usd === input.winningBidUsd
+      ) {
+        return task;
+      }
+      this.requireTransition(input.taskId, task.status, "awarded");
+
+      const next: TaskRecord = {
+        ...task,
+        status: "awarded",
+        updated_at: nowIso(input.now),
+        winner_agent_id: input.winnerAgentId,
+        auction_price_usd: input.auctionPriceUsd,
+        winning_bid_usd: input.winningBidUsd,
+      };
+      tx.set(ref, stripUndefined(next));
+      return next;
+    });
+  }
+
+  async markExecuting(taskId: TaskId, now?: Date): Promise<TaskRecord> {
+    const ref = this.taskRef(taskId);
+    return this.firestore.runTransaction(async (tx) => {
+      const task = await this.readTask(tx, ref, taskId);
+      if (task.status === "executing") return task;
+      this.requireTransition(taskId, task.status, "executing");
+      const next: TaskRecord = { ...task, status: "executing", updated_at: nowIso(now) };
+      tx.set(ref, stripUndefined(next));
+      return next;
+    });
+  }
+
+  async completeTask(input: CompleteTaskInput): Promise<TaskRecord> {
+    const ref = this.taskRef(input.taskId);
+    return this.firestore.runTransaction(async (tx) => {
+      const task = await this.readTask(tx, ref, input.taskId);
+      if (
+        task.status === "completed" &&
+        task.result &&
+        task.result.output === input.result.output
+      ) {
+        return task;
+      }
+      this.requireTransition(input.taskId, task.status, "completed");
+      const next: TaskRecord = {
+        ...task,
+        status: "completed",
+        updated_at: nowIso(input.now),
+        result: input.result,
+      };
+      tx.set(ref, stripUndefined(next));
+      return next;
+    });
+  }
+
+  async failTask(input: FailTaskInput): Promise<TaskRecord> {
+    const ref = this.taskRef(input.taskId);
+    return this.firestore.runTransaction(async (tx) => {
+      const task = await this.readTask(tx, ref, input.taskId);
+      if (task.status === "failed" && task.failure_reason === input.reason) return task;
+      this.requireTransition(input.taskId, task.status, "failed");
+      const next: TaskRecord = {
+        ...task,
+        status: "failed",
+        updated_at: nowIso(input.now),
+        failure_reason: input.reason,
+      };
+      tx.set(ref, stripUndefined(next));
+      return next;
+    });
+  }
+
+  private taskRef(taskId: TaskId): DocumentReference {
+    return this.tasksCollection.doc(taskId);
+  }
+
+  private async readTask(
+    tx: Transaction,
+    ref: DocumentReference,
+    taskId: TaskId,
+  ): Promise<TaskRecord> {
+    const snap = await tx.get(ref);
+    if (!snap.exists) throw new TaskNotFoundError(taskId);
+    return TaskRecordSchema.parse(snap.data());
+  }
+
+  private requireTransition(taskId: TaskId, from: TaskStatus, to: TaskStatus): void {
+    if (!canTransition(from, to)) {
+      throw new InvalidTransitionError(taskId, from, to);
+    }
+  }
+}
+
+function nowIso(now?: Date): string {
+  return (now ?? new Date()).toISOString();
+}
+
+// Firestore refuses to write `undefined` values. Strip them before set/create
+// so optional fields stay absent rather than persisting as null.
+function stripUndefined<T extends Record<string, unknown>>(value: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+interface FirestoreError {
+  code?: number;
+}
+
+// gRPC code 6 = ALREADY_EXISTS — thrown by DocumentReference#create when the
+// doc already exists. We translate to a typed error so callers don't need to
+// know the SDK's error shape.
+function isAlreadyExists(err: unknown): err is FirestoreError {
+  return typeof err === "object" && err !== null && (err as FirestoreError).code === 6;
+}

--- a/coordinator/src/ledger/in-memory-store.ts
+++ b/coordinator/src/ledger/in-memory-store.ts
@@ -1,0 +1,183 @@
+import type { TaskId } from "@agent-tasker/protocol";
+import {
+  InvalidTransitionError,
+  TaskAlreadyExistsError,
+  TaskNotFoundError,
+  canTransition,
+} from "../auction/state-machine.js";
+import type {
+  AwardTaskInput,
+  CompleteTaskInput,
+  CreateTaskInput,
+  FailTaskInput,
+  LedgerStore,
+  RecordBidResponseInput,
+} from "./store.js";
+import type { BidRecord, TaskRecord } from "./types.js";
+
+// In-memory ledger backing — single-process, single-test usage. Maps are
+// keyed by taskId for tasks and by `${taskId}:${agent_id}` for bids.
+// Returned objects are defensive-cloned so a caller can't mutate stored
+// state by holding a reference (which Firestore-backed callers can't do
+// either).
+export class InMemoryLedgerStore implements LedgerStore {
+  private readonly tasks = new Map<string, TaskRecord>();
+  private readonly bids = new Map<string, BidRecord>();
+
+  async createTask(input: CreateTaskInput): Promise<TaskRecord> {
+    if (this.tasks.has(input.taskId)) {
+      throw new TaskAlreadyExistsError(input.taskId);
+    }
+    const now = nowIso(input.now);
+    const record: TaskRecord = {
+      task_id: input.taskId,
+      status: "bidding",
+      spec: input.spec,
+      created_at: now,
+      updated_at: now,
+    };
+    this.tasks.set(input.taskId, record);
+    return clone(record);
+  }
+
+  async getTask(taskId: TaskId): Promise<TaskRecord | null> {
+    const record = this.tasks.get(taskId);
+    return record ? clone(record) : null;
+  }
+
+  async recordBidResponse(input: RecordBidResponseInput): Promise<BidRecord> {
+    const task = this.requireTask(input.taskId);
+    // Bid responses are only meaningful during the bidding window; reject
+    // late writes loudly rather than silently dropping data.
+    if (task.status !== "bidding") {
+      throw new InvalidTransitionError(input.taskId, task.status, "bidding");
+    }
+    const record: BidRecord = {
+      task_id: input.taskId,
+      agent_id: input.response.agent_id,
+      timestamp: nowIso(input.now),
+      phase: "bid",
+      response: input.response,
+      pricing_snapshot: input.pricingSnapshot,
+    };
+    this.bids.set(bidKey(input.taskId, input.response.agent_id), record);
+    return clone(record);
+  }
+
+  async listBids(taskId: TaskId): Promise<BidRecord[]> {
+    const prefix = `${taskId}:`;
+    const out: BidRecord[] = [];
+    for (const [key, record] of this.bids) {
+      if (key.startsWith(prefix)) out.push(clone(record));
+    }
+    out.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    return out;
+  }
+
+  async awardTask(input: AwardTaskInput): Promise<TaskRecord> {
+    const task = this.requireTask(input.taskId);
+
+    // Idempotent reassertion: same winner + same prices on an already-awarded
+    // task returns the existing record unchanged.
+    if (
+      task.status === "awarded" &&
+      task.winner_agent_id === input.winnerAgentId &&
+      task.auction_price_usd === input.auctionPriceUsd &&
+      task.winning_bid_usd === input.winningBidUsd
+    ) {
+      return clone(task);
+    }
+
+    if (!canTransition(task.status, "awarded")) {
+      throw new InvalidTransitionError(input.taskId, task.status, "awarded");
+    }
+
+    const next: TaskRecord = {
+      ...task,
+      status: "awarded",
+      updated_at: nowIso(input.now),
+      winner_agent_id: input.winnerAgentId,
+      auction_price_usd: input.auctionPriceUsd,
+      winning_bid_usd: input.winningBidUsd,
+    };
+    this.tasks.set(input.taskId, next);
+    return clone(next);
+  }
+
+  async markExecuting(taskId: TaskId, now?: Date): Promise<TaskRecord> {
+    const task = this.requireTask(taskId);
+
+    if (task.status === "executing") return clone(task);
+
+    if (!canTransition(task.status, "executing")) {
+      throw new InvalidTransitionError(taskId, task.status, "executing");
+    }
+
+    const next: TaskRecord = { ...task, status: "executing", updated_at: nowIso(now) };
+    this.tasks.set(taskId, next);
+    return clone(next);
+  }
+
+  async completeTask(input: CompleteTaskInput): Promise<TaskRecord> {
+    const task = this.requireTask(input.taskId);
+
+    if (task.status === "completed" && task.result && task.result.output === input.result.output) {
+      return clone(task);
+    }
+
+    if (!canTransition(task.status, "completed")) {
+      throw new InvalidTransitionError(input.taskId, task.status, "completed");
+    }
+
+    const next: TaskRecord = {
+      ...task,
+      status: "completed",
+      updated_at: nowIso(input.now),
+      result: input.result,
+    };
+    this.tasks.set(input.taskId, next);
+    return clone(next);
+  }
+
+  async failTask(input: FailTaskInput): Promise<TaskRecord> {
+    const task = this.requireTask(input.taskId);
+
+    if (task.status === "failed" && task.failure_reason === input.reason) {
+      return clone(task);
+    }
+
+    if (!canTransition(task.status, "failed")) {
+      throw new InvalidTransitionError(input.taskId, task.status, "failed");
+    }
+
+    const next: TaskRecord = {
+      ...task,
+      status: "failed",
+      updated_at: nowIso(input.now),
+      failure_reason: input.reason,
+    };
+    this.tasks.set(input.taskId, next);
+    return clone(next);
+  }
+
+  private requireTask(taskId: TaskId): TaskRecord {
+    const task = this.tasks.get(taskId);
+    if (!task) throw new TaskNotFoundError(taskId);
+    return task;
+  }
+}
+
+function bidKey(taskId: TaskId, agentId: string): string {
+  return `${taskId}:${agentId}`;
+}
+
+function nowIso(now?: Date): string {
+  return (now ?? new Date()).toISOString();
+}
+
+// Defensive deep-clone of plain objects. Records hold only JSON-serializable
+// values (strings, numbers, arrays, nested plain objects); structuredClone is
+// available in Node 22 and faster than JSON round-trip.
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/coordinator/src/ledger/index.ts
+++ b/coordinator/src/ledger/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./store.js";
+export * from "./in-memory-store.js";
+export * from "./firestore-store.js";

--- a/coordinator/src/ledger/store.ts
+++ b/coordinator/src/ledger/store.ts
@@ -1,0 +1,93 @@
+import type {
+  ActualUsage,
+  AgentId,
+  BidResponse,
+  PricingEntry,
+  Result,
+  TaskId,
+  TaskSpec,
+} from "@agent-tasker/protocol";
+import type { BidRecord, TaskRecord } from "./types.js";
+
+// Persistence layer for the auction. All transition methods are idempotent at
+// the document-key level — retrying the same call with the same input
+// produces the same end state and never resurrects a terminal task.
+//
+// Two implementations:
+//   - InMemoryLedgerStore  (./in-memory-store.ts) for tests and local dev
+//   - FirestoreLedgerStore (./firestore-store.ts) for production
+//
+// New methods land here as the auction grows (awards subcollection for
+// re-auction tracking #53, results subcollection for per-attempt outputs).
+export interface LedgerStore {
+  // Create a brand-new task in the `bidding` state. Throws
+  // TaskAlreadyExistsError if `taskId` is already on file — coordinator
+  // generates fresh ULIDs per POST /tasks so this should never collide in
+  // practice; failing loud is the right move if it does.
+  createTask(input: CreateTaskInput): Promise<TaskRecord>;
+
+  // Returns null if not found. Callers needing strictness throw
+  // TaskNotFoundError themselves.
+  getTask(taskId: TaskId): Promise<TaskRecord | null>;
+
+  // Idempotent: keyed by (taskId, response.agent_id). Re-writing the same
+  // response overwrites; re-writing a different response from the same agent
+  // replaces the prior one (final-write-wins). Per-task lifetime is short
+  // enough that this corner is mostly theoretical.
+  recordBidResponse(input: RecordBidResponseInput): Promise<BidRecord>;
+
+  listBids(taskId: TaskId): Promise<BidRecord[]>;
+
+  // Transitions bidding → awarded. Idempotent only if the *same* winner +
+  // pricing is reasserted; throws InvalidTransitionError if status has
+  // already moved past `awarded` (i.e. someone else has already executed).
+  awardTask(input: AwardTaskInput): Promise<TaskRecord>;
+
+  // Transitions awarded → executing. Idempotent if already executing.
+  markExecuting(taskId: TaskId, now?: Date): Promise<TaskRecord>;
+
+  // Transitions executing → completed. Idempotent if the same result is
+  // reasserted.
+  completeTask(input: CompleteTaskInput): Promise<TaskRecord>;
+
+  // Move into the terminal `failed` state from any non-terminal state.
+  // Re-auction (#53) happens at a higher layer — this just records that
+  // the current attempt is over.
+  failTask(input: FailTaskInput): Promise<TaskRecord>;
+}
+
+export interface CreateTaskInput {
+  taskId: TaskId;
+  spec: TaskSpec;
+  now?: Date;
+}
+
+export interface RecordBidResponseInput {
+  taskId: TaskId;
+  response: BidResponse;
+  pricingSnapshot: PricingEntry[];
+  now?: Date;
+}
+
+export interface AwardTaskInput {
+  taskId: TaskId;
+  winnerAgentId: AgentId;
+  auctionPriceUsd: number;
+  winningBidUsd: number;
+  now?: Date;
+}
+
+export interface CompleteTaskInput {
+  taskId: TaskId;
+  result: Result;
+  // actualUsage is part of result per protocol — listed here as a reminder
+  // that completeTask should also update MAPE rollups in a follow-up (#66).
+  actualUsage?: ActualUsage;
+  now?: Date;
+}
+
+export interface FailTaskInput {
+  taskId: TaskId;
+  reason: string;
+  now?: Date;
+}

--- a/coordinator/src/ledger/types.ts
+++ b/coordinator/src/ledger/types.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import {
+  AgentIdSchema,
+  BidResponseSchema,
+  PricingEntrySchema,
+  ResultSchema,
+  TaskIdSchema,
+  TaskSpecSchema,
+  TaskStatusSchema,
+} from "@agent-tasker/protocol";
+
+const Iso8601 = z.string().datetime({ offset: true });
+
+// Root document at tasks/{task_id}. Holds task spec, current lifecycle
+// status, and post-settlement totals. The winner_agent_id / pricing /
+// result fields are populated as the task progresses; their presence is a
+// derived signal of how far through the lifecycle a task is, but `status`
+// remains the source of truth for transition gating.
+export const TaskRecordSchema = z.object({
+  task_id: TaskIdSchema,
+  status: TaskStatusSchema,
+  spec: TaskSpecSchema,
+  created_at: Iso8601,
+  updated_at: Iso8601,
+
+  // Populated when status moves into `awarded`.
+  winner_agent_id: AgentIdSchema.optional(),
+  auction_price_usd: z.number().nonnegative().optional(), // Vickrey: second-lowest bid
+  winning_bid_usd: z.number().nonnegative().optional(), //   winner's own bid (for MAPE)
+
+  // Populated when status moves into `completed`.
+  result: ResultSchema.optional(),
+
+  // Populated when status moves into `failed`. Free-form so re-auction logic
+  // (#53) can record both agent-attributable failures and infra failures.
+  failure_reason: z.string().optional(),
+});
+export type TaskRecord = z.infer<typeof TaskRecordSchema>;
+
+// Per-agent bid record at tasks/{task_id}/bids/{agent_id}. Each agent has
+// at most one bid record per task — retried writes overwrite the prior one
+// with the same content (idempotent at the doc-key level).
+//
+// `pricing_snapshot` captures the prices the bidder used so MAPE replay
+// remains reproducible even after the pricing collection rolls forward.
+export const BidRecordSchema = z.object({
+  task_id: TaskIdSchema,
+  agent_id: AgentIdSchema,
+  timestamp: Iso8601,
+  phase: z.literal("bid"),
+  response: BidResponseSchema,
+  pricing_snapshot: z.array(PricingEntrySchema),
+});
+export type BidRecord = z.infer<typeof BidRecordSchema>;

--- a/coordinator/test/auction/state-machine.test.ts
+++ b/coordinator/test/auction/state-machine.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { TASK_STATUSES, type TaskStatus } from "@agent-tasker/protocol";
+import { VALID_TRANSITIONS, canTransition } from "../../src/auction/state-machine.js";
+
+describe("VALID_TRANSITIONS", () => {
+  it("covers every status", () => {
+    const covered = new Set(Object.keys(VALID_TRANSITIONS));
+    for (const status of TASK_STATUSES) {
+      expect(covered.has(status), `missing entry for ${status}`).toBe(true);
+    }
+  });
+
+  it("terminal states have no outgoing transitions", () => {
+    expect(VALID_TRANSITIONS.completed).toEqual([]);
+    expect(VALID_TRANSITIONS.failed).toEqual([]);
+  });
+
+  it("every non-terminal state can transition to failed", () => {
+    const nonTerminal: TaskStatus[] = ["bidding", "awarded", "executing"];
+    for (const status of nonTerminal) {
+      expect(VALID_TRANSITIONS[status]).toContain("failed");
+    }
+  });
+
+  it("happy-path is bidding -> awarded -> executing -> completed", () => {
+    expect(canTransition("bidding", "awarded")).toBe(true);
+    expect(canTransition("awarded", "executing")).toBe(true);
+    expect(canTransition("executing", "completed")).toBe(true);
+  });
+
+  it("rejects skipping states", () => {
+    expect(canTransition("bidding", "executing")).toBe(false);
+    expect(canTransition("bidding", "completed")).toBe(false);
+    expect(canTransition("awarded", "completed")).toBe(false);
+  });
+});

--- a/coordinator/test/ledger/in-memory-store.test.ts
+++ b/coordinator/test/ledger/in-memory-store.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { AgentId, Bid, NoBid, PricingEntry, Result, TaskSpec } from "@agent-tasker/protocol";
+import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
+import {
+  InvalidTransitionError,
+  TaskAlreadyExistsError,
+  TaskNotFoundError,
+} from "../../src/auction/state-machine.js";
+
+const TASK_ID = "task-test-1";
+
+const SPEC: TaskSpec = {
+  prompt: "summarize the attached transcript",
+};
+
+const PRICING: PricingEntry[] = [
+  {
+    model_id: "gemini-2-5-flash",
+    price_in_usd_per_mtoken: 0.3,
+    price_out_usd_per_mtoken: 2.5,
+    effective_date: "2026-05-15",
+  },
+];
+
+function makeBid(agentId: AgentId, bidUsd: number): Bid {
+  return {
+    task_id: TASK_ID,
+    agent_id: agentId,
+    tier: "frontier",
+    model_family: "gemini",
+    model_id: "gemini-2-5-pro",
+    est_input_tokens: 4000,
+    est_output_tokens: 1000,
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10.0,
+    bid_usd: bidUsd,
+    expires_at: "2026-05-20T12:00:00Z",
+    signature: "stub",
+  };
+}
+
+function makeNoBid(agentId: AgentId): NoBid {
+  return {
+    task_id: TASK_ID,
+    agent_id: agentId,
+    status: "no_bid",
+    reason: "capability",
+  };
+}
+
+function makeResult(agentId: AgentId): Result {
+  return {
+    task_id: TASK_ID,
+    agent_id: agentId,
+    output: "summary text",
+    actual_usage: { input_tokens: 4100, output_tokens: 950 },
+  };
+}
+
+let store: InMemoryLedgerStore;
+
+beforeEach(() => {
+  store = new InMemoryLedgerStore();
+});
+
+describe("createTask", () => {
+  it("creates a task in the bidding state with matching timestamps", async () => {
+    const now = new Date("2026-05-20T10:00:00Z");
+    const record = await store.createTask({ taskId: TASK_ID, spec: SPEC, now });
+    expect(record.status).toBe("bidding");
+    expect(record.spec).toEqual(SPEC);
+    expect(record.created_at).toBe(now.toISOString());
+    expect(record.updated_at).toBe(now.toISOString());
+  });
+
+  it("throws TaskAlreadyExistsError on duplicate task_id", async () => {
+    await store.createTask({ taskId: TASK_ID, spec: SPEC });
+    await expect(store.createTask({ taskId: TASK_ID, spec: SPEC })).rejects.toThrow(
+      TaskAlreadyExistsError,
+    );
+  });
+
+  it("returned record is a clone — caller mutation doesn't leak", async () => {
+    const record = await store.createTask({ taskId: TASK_ID, spec: SPEC });
+    record.status = "completed";
+    const fetched = await store.getTask(TASK_ID);
+    expect(fetched?.status).toBe("bidding");
+  });
+});
+
+describe("getTask", () => {
+  it("returns null for unknown task_id", async () => {
+    expect(await store.getTask("missing")).toBeNull();
+  });
+});
+
+describe("recordBidResponse", () => {
+  beforeEach(async () => {
+    await store.createTask({ taskId: TASK_ID, spec: SPEC });
+  });
+
+  it("stores a bid and lists it back", async () => {
+    const bid = makeBid("gcp-gemini", 0.02);
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: bid,
+      pricingSnapshot: PRICING,
+    });
+    const bids = await store.listBids(TASK_ID);
+    expect(bids).toHaveLength(1);
+    expect(bids[0]?.phase).toBe("bid");
+    expect(bids[0]?.response).toEqual(bid);
+    expect(bids[0]?.pricing_snapshot).toEqual(PRICING);
+  });
+
+  it("stores a no_bid alongside a bid from a different agent", async () => {
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.02),
+      pricingSnapshot: PRICING,
+    });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeNoBid("aws-nova"),
+      pricingSnapshot: PRICING,
+    });
+    const bids = await store.listBids(TASK_ID);
+    expect(bids).toHaveLength(2);
+    const byAgent = Object.fromEntries(bids.map((b) => [b.agent_id, b]));
+    expect(byAgent["gcp-gemini"]?.response).toMatchObject({ bid_usd: 0.02 });
+    expect(byAgent["aws-nova"]?.response).toMatchObject({
+      status: "no_bid",
+      reason: "capability",
+    });
+  });
+
+  it("is idempotent on (task_id, agent_id) — final write wins", async () => {
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.05),
+      pricingSnapshot: PRICING,
+    });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.02),
+      pricingSnapshot: PRICING,
+    });
+    const bids = await store.listBids(TASK_ID);
+    expect(bids).toHaveLength(1);
+    expect(bids[0]?.response).toMatchObject({ bid_usd: 0.02 });
+  });
+
+  it("rejects writes after the bidding window has closed", async () => {
+    await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+    await expect(
+      store.recordBidResponse({
+        taskId: TASK_ID,
+        response: makeBid("aws-nova", 0.04),
+        pricingSnapshot: PRICING,
+      }),
+    ).rejects.toThrow(InvalidTransitionError);
+  });
+
+  it("throws TaskNotFoundError when the task is unknown", async () => {
+    await expect(
+      store.recordBidResponse({
+        taskId: "missing",
+        response: makeBid("gcp-gemini", 0.02),
+        pricingSnapshot: PRICING,
+      }),
+    ).rejects.toThrow(TaskNotFoundError);
+  });
+});
+
+describe("awardTask", () => {
+  beforeEach(async () => {
+    await store.createTask({ taskId: TASK_ID, spec: SPEC });
+  });
+
+  it("transitions bidding -> awarded and records winner + prices", async () => {
+    const record = await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+    expect(record.status).toBe("awarded");
+    expect(record.winner_agent_id).toBe("gcp-gemini");
+    expect(record.auction_price_usd).toBe(0.05);
+    expect(record.winning_bid_usd).toBe(0.02);
+  });
+
+  it("is idempotent when the same winner + prices are reasserted", async () => {
+    const first = await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+    const second = await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+    expect(second.updated_at).toBe(first.updated_at);
+  });
+
+  it("rejects awarding a different winner once the task is already awarded", async () => {
+    await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+    await expect(
+      store.awardTask({
+        taskId: TASK_ID,
+        winnerAgentId: "aws-nova",
+        auctionPriceUsd: 0.04,
+        winningBidUsd: 0.03,
+      }),
+    ).rejects.toThrow(InvalidTransitionError);
+  });
+});
+
+describe("markExecuting / completeTask / failTask", () => {
+  beforeEach(async () => {
+    await store.createTask({ taskId: TASK_ID, spec: SPEC });
+    await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+  });
+
+  it("markExecuting transitions awarded -> executing", async () => {
+    const record = await store.markExecuting(TASK_ID);
+    expect(record.status).toBe("executing");
+  });
+
+  it("markExecuting is idempotent", async () => {
+    const first = await store.markExecuting(TASK_ID);
+    const second = await store.markExecuting(TASK_ID);
+    expect(second.updated_at).toBe(first.updated_at);
+  });
+
+  it("completeTask transitions executing -> completed and stores the result", async () => {
+    await store.markExecuting(TASK_ID);
+    const result = makeResult("gcp-gemini");
+    const record = await store.completeTask({ taskId: TASK_ID, result });
+    expect(record.status).toBe("completed");
+    expect(record.result).toEqual(result);
+  });
+
+  it("completeTask rejects directly from awarded (must mark executing first)", async () => {
+    await expect(
+      store.completeTask({ taskId: TASK_ID, result: makeResult("gcp-gemini") }),
+    ).rejects.toThrow(InvalidTransitionError);
+  });
+
+  it("failTask works from any non-terminal state and records the reason", async () => {
+    const failed = await store.failTask({ taskId: TASK_ID, reason: "agent timeout" });
+    expect(failed.status).toBe("failed");
+    expect(failed.failure_reason).toBe("agent timeout");
+  });
+
+  it("failTask is rejected from a terminal state", async () => {
+    await store.markExecuting(TASK_ID);
+    await store.completeTask({ taskId: TASK_ID, result: makeResult("gcp-gemini") });
+    await expect(store.failTask({ taskId: TASK_ID, reason: "too late" })).rejects.toThrow(
+      InvalidTransitionError,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 8.59.4(eslint@10.4.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@22.19.18)(vite@8.0.13(@types/node@22.19.18)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.18)(vite@8.0.13(@types/node@22.19.18)(yaml@2.9.0))
 
   agent:
     dependencies:
@@ -89,9 +89,15 @@ importers:
       '@agent-tasker/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@google-cloud/firestore':
+        specifier: ^8.6.0
+        version: 8.6.0
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   eval:
     dependencies:
@@ -161,6 +167,19 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@google-cloud/firestore@8.6.0':
+    resolution: {integrity: sha512-TdvZHfwQj5B5CSDEgDqyrhdVqtOSupmBXDQPasMAJiC64tjsGvyMooNiC43fdk1TsUHeklyoZ6/vQ1TjWKVMbg==}
+    engines: {node: '>=18'}
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -181,8 +200,15 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -190,8 +216,46 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
@@ -443,6 +507,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -450,9 +518,17 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -462,13 +538,28 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -482,12 +573,27 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -505,8 +611,26 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -514,6 +638,10 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -577,6 +705,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -595,6 +726,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -610,10 +745,33 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
@@ -622,6 +780,31 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -640,9 +823,16 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -655,8 +845,14 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -666,6 +862,12 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -761,9 +963,18 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -776,6 +987,14 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -787,8 +1006,24 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -806,6 +1041,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -813,6 +1051,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -837,21 +1079,48 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
+  protobufjs@7.6.0:
+    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+    engines: {node: '>=12.0.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
+    engines: {node: '>=18'}
+
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
 
   rolldown@1.0.1:
     resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
@@ -891,9 +1160,23 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -903,9 +1186,23 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
+  teeny-request@10.1.2:
+    resolution: {integrity: sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -956,6 +1253,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@8.0.13:
     resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
@@ -1041,6 +1341,10 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1059,14 +1363,37 @@ packages:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
     engines: {node: '>=20'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1127,6 +1454,28 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@google-cloud/firestore@8.6.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      fast-deep-equal: 3.1.3
+      functional-red-black-tree: 1.0.1
+      google-gax: 5.0.6
+      protobufjs: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.0
+      yargs: 17.7.2
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1143,7 +1492,18 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -1152,7 +1512,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oxc-project/types@0.130.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
@@ -1385,6 +1772,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1396,17 +1785,35 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
 
   assertion-error@2.0.1: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
+
+  buffer-equal-constant-time@1.0.1: {}
 
   chai@6.2.2: {}
 
@@ -1419,6 +1826,18 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.1
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -1426,6 +1845,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
     dependencies:
@@ -1435,11 +1856,34 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   environment@1.1.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -1519,6 +1963,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -1528,6 +1974,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -1545,14 +1996,95 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fsevents@2.3.3:
     optional: true
+
+  functional-red-black-tree@1.0.1: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.1
+      duplexify: 4.1.3
+      google-auth-library: 10.6.2
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.6.0
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -1562,7 +2094,11 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
@@ -1574,13 +2110,34 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jose@6.2.3: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -1661,6 +2218,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -1668,6 +2227,10 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  long@5.3.2: {}
+
+  lru-cache@10.4.3: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -1679,13 +2242,33 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  object-hash@3.0.0: {}
+
   obug@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@7.0.0:
     dependencies:
@@ -1708,9 +2291,16 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -1728,14 +2318,52 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.6.0
+
+  protobufjs@7.6.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.18
+      long: 5.3.2
+
   punycode@2.3.1: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  require-directory@2.1.1: {}
 
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   rfdc@1.4.1: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
 
   rolldown@1.0.1:
     dependencies:
@@ -1757,6 +2385,8 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.1
       '@rolldown/binding-win32-arm64-msvc': 1.0.1
       '@rolldown/binding-win32-x64-msvc': 1.0.1
+
+  safe-buffer@5.2.1: {}
 
   semver@7.8.0: {}
 
@@ -1786,7 +2416,25 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   string-argv@0.3.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -1799,9 +2447,28 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  stubs@3.0.0: {}
+
+  teeny-request@10.1.2:
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   tinybench@2.9.0: {}
 
@@ -1853,6 +2520,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  util-deprecate@1.0.2: {}
+
   vite@8.0.13(@types/node@22.19.18)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -1865,7 +2534,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest@4.1.6(@types/node@22.19.18)(vite@8.0.13(@types/node@22.19.18)(yaml@2.9.0)):
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.18)(vite@8.0.13(@types/node@22.19.18)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@22.19.18)(yaml@2.9.0))
@@ -1888,9 +2557,12 @@ snapshots:
       vite: 8.0.13(@types/node@22.19.18)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.18
     transitivePeerDependencies:
       - msw
+
+  web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:
@@ -1909,14 +2581,42 @@ snapshots:
       string-width: 8.2.1
       strip-ansi: 7.2.0
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
+  y18n@5.0.8: {}
+
   yaml@2.9.0:
     optional: true
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
The auction lifecycle (`bidding → awarded → executing → completed`, with `failed` reachable from any non-terminal state) now has both a state-machine definition and a persistence interface, with two implementations: **in-memory** for tests, **Firestore** for production. Transitions are idempotent and gated atomically.

### Module layout
```
coordinator/src/
  auction/
    state-machine.ts    VALID_TRANSITIONS, canTransition, typed errors
  ledger/
    types.ts            Zod schemas for TaskRecord and BidRecord
                        (field name `timestamp` matches index from #20)
    store.ts            LedgerStore interface + input shapes
    in-memory-store.ts  Map-backed, defensive structuredClone on read
    firestore-store.ts  Production — runTransaction-wrapped writes,
                        Zod parse on every read for schema-drift defense
```

### Idempotency model
- `recordBidResponse` keyed by `(task_id, agent_id)` — final-write-wins
- `awardTask` / `markExecuting` / `completeTask` / `failTask` check current status inside the transaction; reasserting the same transition with the same payload is a no-op return; reasserting with a *different* payload (e.g. different winner) throws `InvalidTransitionError`

### Out of scope (separate issues)
- Vickrey winner selection (#47) — `awardTask` takes the winner + price as inputs
- Adaptive bid timeout (#52), re-auction on /execute failure (#53)
- HTTP handlers (#22, #23)
- Awards/results subcollections — root task record holds current winner+result; per-attempt subcollections come when re-auction needs them

### Deps
Coordinator gains direct `zod` and `@google-cloud/firestore` deps. zod was already transitively available via `/protocol`; making it direct prevents `tsc` from breaking when `/protocol` isn't yet in `node_modules` during cold builds.

Closes #24

## Test plan
- [x] `pnpm test` → 29/29 passing (state-machine table coverage, happy path, idempotency, late-write rejection, terminal-state guards, defensive cloning)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm build` all clean
- [ ] CI green
- [ ] Integration test against real Firestore in `infra/coordinator`-applied dev project lands with #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)