### PR TITLE
Coordinator HTTP API: POST /tasks + GET /tasks/:id (#22, #23)

### DIFF
--- a/coordinator/package.json
+++ b/coordinator/package.json
@@ -14,7 +14,9 @@
   "dependencies": {
     "@agent-tasker/protocol": "workspace:*",
     "@google-cloud/firestore": "^8.6.0",
+    "hono": "^4.12.21",
     "jose": "^6.2.3",
+    "ulid": "^3.0.2",
     "zod": "^3.25.76"
   }
 }

--- a/coordinator/src/api/app.ts
+++ b/coordinator/src/api/app.ts
@@ -1,0 +1,49 @@
+import { Hono } from "hono";
+import type { AuctionRunner } from "../auction/runner.js";
+import type { LedgerStore } from "../ledger/store.js";
+import { handleGetTask } from "./handlers/get-task.js";
+import { handlePostTasks } from "./handlers/post-tasks.js";
+
+export interface CreateAppOptions {
+  store: LedgerStore;
+  runner: AuctionRunner;
+  // Override for tests that need a deterministic task_id.
+  idGenerator?: () => string;
+}
+
+// Returns a fresh Hono app wired with the coordinator's client-facing routes.
+// One factory per Cloud Run instance / per test — never share Hono apps
+// across tests because the same dependency closures get baked in.
+export function createApp(opts: CreateAppOptions) {
+  const app = new Hono();
+
+  app.get("/healthz", (c) => c.text("ok"));
+
+  app.post("/tasks", (c) =>
+    handlePostTasks(c, {
+      store: opts.store,
+      runner: opts.runner,
+      ...(opts.idGenerator ? { idGenerator: opts.idGenerator } : {}),
+    }),
+  );
+
+  app.get("/tasks/:id", (c) => handleGetTask(c, { store: opts.store }));
+
+  // Unhandled-error envelope so the SPA always sees a structured body
+  // rather than Hono's default text/html. Coordinator-internal failures
+  // bubble up here (e.g. Firestore unavailable) — runtime details stay
+  // server-side; the client gets a stable code.
+  app.onError((err, c) => {
+    console.error("coordinator unhandled error", err);
+    return c.json(
+      { error: { code: "internal_error", message: "coordinator failed to handle request" } },
+      500,
+    );
+  });
+
+  app.notFound((c) =>
+    c.json({ error: { code: "not_found", message: `no route for ${c.req.path}` } }, 404),
+  );
+
+  return app;
+}

--- a/coordinator/src/api/handlers/get-task.ts
+++ b/coordinator/src/api/handlers/get-task.ts
@@ -1,0 +1,40 @@
+import type { Context } from "hono";
+import type { LedgerStore } from "../../ledger/store.js";
+import type { TaskRecord } from "../../ledger/types.js";
+import type { GetTaskResponse } from "../schemas.js";
+
+export interface GetTaskDeps {
+  store: LedgerStore;
+}
+
+export async function handleGetTask(c: Context, deps: GetTaskDeps): Promise<Response> {
+  const taskId = c.req.param("id");
+  if (!taskId) {
+    return c.json({ error: { code: "invalid_request", message: "missing task id" } }, 400);
+  }
+
+  const record = await deps.store.getTask(taskId);
+  if (!record) {
+    return c.json({ error: { code: "not_found", message: `task ${taskId} not found` } }, 404);
+  }
+
+  return c.json(projectTaskRecord(record));
+}
+
+// Projection from the internal TaskRecord (which includes the spec, etc.)
+// to the public GET /tasks/:id response shape. The spec isn't echoed back
+// — the client sent it and doesn't need to read it from us.
+function projectTaskRecord(record: TaskRecord): GetTaskResponse {
+  const response: GetTaskResponse = {
+    task_id: record.task_id,
+    status: record.status,
+    created_at: record.created_at,
+    updated_at: record.updated_at,
+  };
+  if (record.winner_agent_id !== undefined) response.winner_agent_id = record.winner_agent_id;
+  if (record.auction_price_usd !== undefined) response.auction_price_usd = record.auction_price_usd;
+  if (record.winning_bid_usd !== undefined) response.winning_bid_usd = record.winning_bid_usd;
+  if (record.result !== undefined) response.result = record.result;
+  if (record.failure_reason !== undefined) response.failure_reason = record.failure_reason;
+  return response;
+}

--- a/coordinator/src/api/handlers/post-tasks.ts
+++ b/coordinator/src/api/handlers/post-tasks.ts
@@ -1,0 +1,51 @@
+import type { Context } from "hono";
+import { ulid } from "ulid";
+import type { AuctionRunner } from "../../auction/runner.js";
+import type { LedgerStore } from "../../ledger/store.js";
+import { CreateTaskRequestSchema, type CreateTaskResponse } from "../schemas.js";
+
+export interface PostTasksDeps {
+  store: LedgerStore;
+  runner: AuctionRunner;
+  // Optional override for tests / deterministic ID generation. Defaults to ulid().
+  idGenerator?: () => string;
+}
+
+export async function handlePostTasks(c: Context, deps: PostTasksDeps): Promise<Response> {
+  const body = await safeJson(c);
+  const parsed = CreateTaskRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      {
+        error: {
+          code: "invalid_request",
+          message: parsed.error.issues
+            .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+            .join("; "),
+        },
+      },
+      400,
+    );
+  }
+
+  const taskId = (deps.idGenerator ?? ulid)();
+  await deps.store.createTask({ taskId, spec: parsed.data });
+
+  // Fire-and-forget auction kickoff. See AuctionRunner JSDoc for the
+  // lifetime expectations on Cloud Run (`cpu_idle = false`).
+  deps.runner.start(taskId);
+
+  const url = new URL(c.req.url);
+  const statusUrl = `${url.origin}/tasks/${taskId}`;
+
+  const response: CreateTaskResponse = { task_id: taskId, status_url: statusUrl };
+  return c.json(response, 202);
+}
+
+async function safeJson(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return null;
+  }
+}

--- a/coordinator/src/api/index.ts
+++ b/coordinator/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./app.js";
+export * from "./schemas.js";

--- a/coordinator/src/api/schemas.ts
+++ b/coordinator/src/api/schemas.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import {
+  AgentIdSchema,
+  ResultSchema,
+  TaskIdSchema,
+  TaskSpecSchema,
+  TaskStatusSchema,
+} from "@agent-tasker/protocol";
+
+// Public client API for the coordinator. Lives in coordinator/src/api/
+// rather than /protocol because it's client-coordinator, not
+// coordinator-agent. Promote to /protocol if a non-SPA consumer ever
+// needs to share the shape.
+
+// POST /tasks → 202 { task_id, status_url }
+export const CreateTaskRequestSchema = TaskSpecSchema;
+export type CreateTaskRequest = z.infer<typeof CreateTaskRequestSchema>;
+
+export const CreateTaskResponseSchema = z.object({
+  task_id: TaskIdSchema,
+  status_url: z.string().url(),
+});
+export type CreateTaskResponse = z.infer<typeof CreateTaskResponseSchema>;
+
+// GET /tasks/:id → 200 { status, ... }
+// `output` / `winner_agent_id` / `auction_price_usd` / `failure_reason`
+// are present-or-absent depending on `status`. Clients should branch on
+// `status` first and read the rest only when defined.
+export const GetTaskResponseSchema = z.object({
+  task_id: TaskIdSchema,
+  status: TaskStatusSchema,
+  created_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({ offset: true }),
+  winner_agent_id: AgentIdSchema.optional(),
+  auction_price_usd: z.number().nonnegative().optional(),
+  winning_bid_usd: z.number().nonnegative().optional(),
+  result: ResultSchema.optional(),
+  failure_reason: z.string().optional(),
+});
+export type GetTaskResponse = z.infer<typeof GetTaskResponseSchema>;
+
+// Shared error envelope. Coordinator only emits structured errors; the SPA
+// is expected to surface `code` for branching and `message` for display.
+export const ErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.string().min(1),
+    message: z.string().min(1),
+  }),
+});
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;

--- a/coordinator/src/auction/index.ts
+++ b/coordinator/src/auction/index.ts
@@ -1,1 +1,2 @@
 export * from "./state-machine.js";
+export * from "./runner.js";

--- a/coordinator/src/auction/runner.ts
+++ b/coordinator/src/auction/runner.ts
@@ -1,0 +1,31 @@
+import type { TaskId } from "@agent-tasker/protocol";
+
+// Kicks off the auction asynchronously for a freshly-created task. POST
+// /tasks calls `start()` and returns 202 immediately — the runner is
+// responsible for the announce/bid/award/execute/settle round-trip and any
+// re-auctions, writing progress to the ledger as it goes.
+//
+// Phase 1: in-process fire-and-forget on Cloud Run (`cpu_idle = false`,
+// memory bumped enough to keep the instance alive for the full auction).
+// The bid round is capped at 5s and execution is mostly time waiting on
+// the agent's HTTP response, so a single Cloud Run instance comfortably
+// runs hundreds of concurrent auctions without queuing.
+//
+// Phase 2+: graduate to Cloud Tasks if the in-process model starts losing
+// auctions during instance autoscale-down or if we want to centralize
+// retry policy. The interface is intentionally narrow so a queue-based
+// runner is a drop-in replacement.
+export interface AuctionRunner {
+  start(taskId: TaskId): void;
+}
+
+// Records `start()` calls without doing any work. Used by tests and by
+// early-Phase-1 deploys where the real runner (#47 + #52 + #53) hasn't
+// landed yet. Production wiring substitutes a real runner.
+export class StubAuctionRunner implements AuctionRunner {
+  readonly started: TaskId[] = [];
+
+  start(taskId: TaskId): void {
+    this.started.push(taskId);
+  }
+}

--- a/coordinator/src/index.ts
+++ b/coordinator/src/index.ts
@@ -2,3 +2,4 @@ export { PROTOCOL_VERSION } from "@agent-tasker/protocol";
 export * from "./jwt/index.js";
 export * from "./auction/index.js";
 export * from "./ledger/index.js";
+export * from "./api/index.js";

--- a/coordinator/test/api/app.test.ts
+++ b/coordinator/test/api/app.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/app.js";
+import { StubAuctionRunner } from "../../src/auction/runner.js";
+import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
+import { CreateTaskResponseSchema, GetTaskResponseSchema } from "../../src/api/schemas.js";
+
+const idGenerator = (() => {
+  let n = 0;
+  return () => `01TASKTEST${(++n).toString().padStart(16, "0")}`;
+})();
+
+let store: InMemoryLedgerStore;
+let runner: StubAuctionRunner;
+let app: ReturnType<typeof createApp>;
+
+beforeEach(() => {
+  store = new InMemoryLedgerStore();
+  runner = new StubAuctionRunner();
+  app = createApp({ store, runner, idGenerator });
+});
+
+async function post(body: unknown): Promise<Response> {
+  return app.request("/tasks", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("GET /healthz", () => {
+  it("returns 200 ok", async () => {
+    const res = await app.request("/healthz");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+});
+
+describe("POST /tasks", () => {
+  it("creates a task, returns 202 with task_id + status_url, and kicks off the runner", async () => {
+    const res = await post({ prompt: "summarize the transcript" });
+    expect(res.status).toBe(202);
+    const body = CreateTaskResponseSchema.parse(await res.json());
+    expect(body.task_id).toMatch(/^01TASKTEST/);
+    expect(body.status_url).toContain(`/tasks/${body.task_id}`);
+
+    const stored = await store.getTask(body.task_id);
+    expect(stored?.status).toBe("bidding");
+    expect(stored?.spec.prompt).toBe("summarize the transcript");
+
+    expect(runner.started).toEqual([body.task_id]);
+  });
+
+  it("400s on missing prompt", async () => {
+    const res = await post({});
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("invalid_request");
+    expect(body.error.message).toMatch(/prompt/i);
+    expect(runner.started).toEqual([]);
+  });
+
+  it("400s on malformed JSON body", async () => {
+    const res = await post("{not json");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_request");
+  });
+
+  it("accepts optional fields (min_tier, deadline, callback_url, attachments)", async () => {
+    const res = await post({
+      prompt: "complex multi-step task",
+      min_tier: "frontier",
+      deadline: "2026-05-21T00:00:00Z",
+      callback_url: "https://client.example.com/done",
+      attachments: [{ content_hash: "sha256:abc" }],
+    });
+    expect(res.status).toBe(202);
+    const body = CreateTaskResponseSchema.parse(await res.json());
+    const stored = await store.getTask(body.task_id);
+    expect(stored?.spec.min_tier).toBe("frontier");
+    expect(stored?.spec.attachments).toHaveLength(1);
+  });
+});
+
+describe("GET /tasks/:id", () => {
+  it("returns 404 for unknown id", async () => {
+    const res = await app.request("/tasks/does-not-exist");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("not_found");
+  });
+
+  it("returns the projected task record (status, timestamps, optional fields absent before settlement)", async () => {
+    await post({ prompt: "task one" });
+    const taskId = runner.started[0]!;
+    const res = await app.request(`/tasks/${taskId}`);
+    expect(res.status).toBe(200);
+    const body = GetTaskResponseSchema.parse(await res.json());
+    expect(body.task_id).toBe(taskId);
+    expect(body.status).toBe("bidding");
+    expect(body.created_at).toBeDefined();
+    expect(body.winner_agent_id).toBeUndefined();
+    expect(body.result).toBeUndefined();
+  });
+
+  it("surfaces winner / pricing after award", async () => {
+    await post({ prompt: "task one" });
+    const taskId = runner.started[0]!;
+    await store.awardTask({
+      taskId,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+
+    const res = await app.request(`/tasks/${taskId}`);
+    const body = GetTaskResponseSchema.parse(await res.json());
+    expect(body.status).toBe("awarded");
+    expect(body.winner_agent_id).toBe("gcp-gemini");
+    expect(body.auction_price_usd).toBe(0.05);
+    expect(body.winning_bid_usd).toBe(0.02);
+  });
+
+  it("surfaces result after completion", async () => {
+    await post({ prompt: "task one" });
+    const taskId = runner.started[0]!;
+    await store.awardTask({
+      taskId,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+    await store.markExecuting(taskId);
+    await store.completeTask({
+      taskId,
+      result: {
+        task_id: taskId,
+        agent_id: "gcp-gemini",
+        output: "done",
+        actual_usage: { input_tokens: 100, output_tokens: 50 },
+      },
+    });
+
+    const res = await app.request(`/tasks/${taskId}`);
+    const body = GetTaskResponseSchema.parse(await res.json());
+    expect(body.status).toBe("completed");
+    expect(body.result?.output).toBe("done");
+  });
+
+  it("surfaces failure_reason on failure", async () => {
+    await post({ prompt: "task one" });
+    const taskId = runner.started[0]!;
+    await store.failTask({ taskId, reason: "all agents declined" });
+
+    const res = await app.request(`/tasks/${taskId}`);
+    const body = GetTaskResponseSchema.parse(await res.json());
+    expect(body.status).toBe("failed");
+    expect(body.failure_reason).toBe("all agents declined");
+  });
+});
+
+describe("404 handler", () => {
+  it("returns a structured error envelope for unknown routes", async () => {
+    const res = await app.request("/no-such-route");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("not_found");
+    expect(body.error.message).toContain("/no-such-route");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,15 @@ importers:
       '@google-cloud/firestore':
         specifier: ^8.6.0
         version: 8.6.0
+      hono:
+        specifier: ^4.12.21
+        version: 4.12.21
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      ulid:
+        specifier: ^3.0.2
+        version: 3.0.2
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -798,6 +804,10 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
+    engines: {node: '>=16.9.0'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -1246,6 +1256,10 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
     hasBin: true
 
   undici-types@6.21.0:
@@ -2072,6 +2086,8 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  hono@4.12.21: {}
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -2513,6 +2529,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  ulid@3.0.2: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary
Public client-facing API. Async by design — SPA POSTs a task, gets a 202 + `task_id` immediately, polls GET for status. Matches the contract in CLAUDE.md → Client-facing API.

Bundled because the two handlers share the same Hono app, schemas, and error envelope — splitting was pure boilerplate.

**Stack:**
- **Hono** — small, ESM-first, designed for Node/Cloud Run/Workers; easy `app.request()` testing with no socket
- **ulid** — sortable-by-time 26-char task IDs

**Layout** (`coordinator/src/api/`):
- `schemas.ts` — Zod for `CreateTaskRequest/Response`, `GetTaskResponse`, `ErrorResponse`. Lives in coordinator (not `/protocol`) because it's client-coordinator, not coordinator-agent
- `handlers/post-tasks.ts` — validate, mint ULID, persist, fire-and-forget runner, return 202
- `handlers/get-task.ts` — load, project internal `TaskRecord` to the public response shape (spec is not echoed back)
- `app.ts` — `createApp({ store, runner, idGenerator? })` factory with structured 404/onError envelopes and `GET /healthz`

**Auction kickoff** (`coordinator/src/auction/runner.ts`):
- `AuctionRunner.start(taskId)` — fire-and-forget interface
- `StubAuctionRunner` records calls; used by every test today and by early Phase 1 deploys before the real runner exists
- **Phase 1 deploy plan:** in-process fire-and-forget on Cloud Run with `cpu_idle = false` so the instance stays alive for the full ~5s bid window + execution. Graduate to Cloud Tasks in Phase 2 if instance autoscale-down starts losing auctions
- Real runner lands with #47 (Vickrey) + #52 (adaptive timeout) + #53 (re-auction)

Closes #22
Closes #23

## Test plan
- [x] 11 new tests pass; coordinator total is now 40/40
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm build` all clean
- [ ] CI green
- [ ] After Cloud Run deploy lands (#21): `curl -XPOST $URL/tasks -d '{"prompt":"hello"}'` returns 202 with a working `status_url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)