### PR TITLE
Deploy the coordinator to Cloud Run (#21)

### DIFF
--- a/coordinator/.dockerignore
+++ b/coordinator/.dockerignore
@@ -1,0 +1,10 @@
+**/node_modules/
+**/dist/
+**/.terraform/
+**/*.tsbuildinfo
+.git/
+.github/
+.husky/
+docs/
+*.md
+.DS_Store

--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -1,0 +1,39 @@
+# Multi-stage build for the coordinator. Stage 1 installs and builds the
+# whole monorepo; stage 2 uses `pnpm deploy` to copy the coordinator + its
+# production deps (including the @agent-tasker/protocol workspace dep) into
+# a self-contained /app directory; stage 3 is the runtime image.
+#
+# Result: ~200MB compressed image with no dev deps, no source, no tooling.
+#
+# Build from the repo root:
+#   docker build -f coordinator/Dockerfile -t coordinator:dev .
+#
+# Push to Artifact Registry (image repo path comes from the `coordinator_image_repo` Terraform output):
+#   gcloud auth configure-docker LOCATION-docker.pkg.dev
+#   docker tag coordinator:dev LOCATION-docker.pkg.dev/PROJECT/REPO/coordinator:TAG
+#   docker push LOCATION-docker.pkg.dev/PROJECT/REPO/coordinator:TAG
+
+FROM node:22-alpine AS build
+RUN corepack enable
+WORKDIR /workspace
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY protocol/ ./protocol/
+COPY agent/ ./agent/
+COPY coordinator/ ./coordinator/
+COPY infra/ ./infra/
+COPY eval/ ./eval/
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter '@agent-tasker/coordinator...' build
+# pnpm deploy bundles the coordinator + its production deps as a flat
+# package at /app (workspace deps copied in as real node_modules entries).
+RUN pnpm --filter @agent-tasker/coordinator deploy --prod /app
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=build /app ./
+ENV NODE_ENV=production
+ENV PORT=8080
+EXPOSE 8080
+# Run as the non-root `node` user that the official Node image provides.
+USER node
+CMD ["node", "dist/server.js"]

--- a/coordinator/package.json
+++ b/coordinator/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@agent-tasker/protocol": "workspace:*",
     "@google-cloud/firestore": "^8.6.0",
+    "@hono/node-server": "^2.0.3",
     "hono": "^4.12.21",
     "jose": "^6.2.3",
     "ulid": "^3.0.2",

--- a/coordinator/src/server.ts
+++ b/coordinator/src/server.ts
@@ -1,0 +1,30 @@
+import { serve } from "@hono/node-server";
+import { Firestore } from "@google-cloud/firestore";
+import { createApp } from "./api/app.js";
+import { StubAuctionRunner } from "./auction/runner.js";
+import { FirestoreLedgerStore } from "./ledger/firestore-store.js";
+
+// Cloud Run entrypoint. Reads config from env vars set in Terraform
+// (infra/coordinator/cloud_run.tf), wires the Firestore-backed ledger
+// and a stub auction runner, and serves the Hono app on $PORT.
+//
+// The real AuctionRunner (#47 + #52 + #53) replaces StubAuctionRunner
+// without changing this entrypoint — server.ts owns wiring, not policy.
+
+const port = Number(process.env["PORT"] ?? 8080);
+const projectId = process.env["GCP_PROJECT_ID"];
+
+if (!projectId) {
+  console.error("GCP_PROJECT_ID env var is required");
+  process.exit(1);
+}
+
+const firestore = new Firestore({ projectId });
+const store = new FirestoreLedgerStore(firestore);
+const runner = new StubAuctionRunner();
+
+const app = createApp({ store, runner });
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`coordinator listening on :${info.port} (project ${projectId})`);
+});

--- a/infra/coordinator/artifact_registry.tf
+++ b/infra/coordinator/artifact_registry.tf
@@ -1,0 +1,10 @@
+# Docker repository for coordinator container images. Per-service repos
+# keep listings sane and let per-service cleanup policies diverge later
+# (e.g. coordinator retains 30 days, agent images retain 14 — TBD).
+resource "google_artifact_registry_repository" "coordinator" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = "${local.name_prefix}-coordinator"
+  description   = "Container images for the coordinator service"
+  format        = "DOCKER"
+}

--- a/infra/coordinator/cloud_run.tf
+++ b/infra/coordinator/cloud_run.tf
@@ -1,0 +1,128 @@
+# Cloud Run service for the coordinator's public HTTP API.
+#
+# Phase 1 deploy shape:
+# - `min_instance_count = 0` — scales to zero at idle so cost matches usage.
+# - `max_instance_count` is capped by var to avoid runaway autoscale.
+# - `startup_cpu_boost = true` so cold-start initialization (Firestore
+#   client + Hono app) doesn't time-out.
+# - `cpu_idle = false` keeps CPU allocated for the full request lifetime
+#   *including* the fire-and-forget AuctionRunner.start() that the POST
+#   /tasks handler kicks off (see CLAUDE.md → Phase 1 deploy plan).
+# - Public ingress + `allUsers` invoker — the coordinator is the SPA's
+#   API. CORS is handled in Hono middleware (TBD when SPA lands).
+#
+# Custom domain + managed TLS cert are deliberately *not* here; the
+# auto-generated *.run.app URL works for Phase 1 dev. Domain mapping
+# lands as a small follow-up once a domain is registered.
+
+resource "google_service_account" "coordinator_runtime" {
+  project      = var.project_id
+  account_id   = "${local.name_prefix}-coordinator"
+  display_name = "Coordinator runtime SA"
+  description  = "Identity for the coordinator Cloud Run service — reads/writes Firestore, publishes JWKS"
+}
+
+# Firestore (ledger + pricing reads/writes). datastore.user is the role
+# that covers both Firestore Native and Datastore modes — name is legacy.
+resource "google_project_iam_member" "coordinator_firestore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.coordinator_runtime.email}"
+}
+
+# Publish/overwrite the JWKS object during key generation + rotation.
+# Scoped to the JWKS bucket only via a bucket-level IAM member.
+resource "google_storage_bucket_iam_member" "coordinator_jwks_writer" {
+  bucket = google_storage_bucket.jwks.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.coordinator_runtime.email}"
+}
+
+# Cloud Logging writes (Cloud Run already grants this implicitly to the
+# default SA; explicit binding here keeps custom-SA deploys symmetric).
+resource "google_project_iam_member" "coordinator_logs" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.coordinator_runtime.email}"
+}
+
+resource "google_cloud_run_v2_service" "coordinator" {
+  project  = var.project_id
+  location = var.region
+  name     = "${local.name_prefix}-coordinator"
+
+  deletion_protection = var.coordinator_delete_protection
+
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = google_service_account.coordinator_runtime.email
+    timeout         = "${var.coordinator_request_timeout_seconds}s"
+
+    scaling {
+      min_instance_count = var.coordinator_min_instances
+      max_instance_count = var.coordinator_max_instances
+    }
+
+    containers {
+      image = var.coordinator_image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        cpu_idle          = false # see file header
+        startup_cpu_boost = true
+
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "JWKS_BUCKET"
+        value = google_storage_bucket.jwks.name
+      }
+    }
+  }
+
+  # Don't roll back to an old revision if a new deploy fails — that masks
+  # bugs. Operator picks the revision explicitly on rollback.
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  # Skip Terraform plan churn on fields that the gcloud / CI deploy
+  # pipeline updates (image tag rolls forward on every push, client tag
+  # gets stamped by gcloud).
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+    ]
+  }
+
+  depends_on = [
+    google_project_iam_member.coordinator_firestore,
+    google_storage_bucket_iam_member.coordinator_jwks_writer,
+    google_project_iam_member.coordinator_logs,
+  ]
+}
+
+# Public invoker — SPA hits this URL directly. Swap to authenticated-only
+# (`roles/run.invoker` granted to specific SAs) when the SPA grows an
+# auth layer.
+resource "google_cloud_run_v2_service_iam_member" "coordinator_public" {
+  project  = google_cloud_run_v2_service.coordinator.project
+  location = google_cloud_run_v2_service.coordinator.location
+  name     = google_cloud_run_v2_service.coordinator.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/infra/coordinator/outputs.tf
+++ b/infra/coordinator/outputs.tf
@@ -17,3 +17,18 @@ output "jwks_public_url" {
   description = "Stable public URL each agent's verifier fetches to read coordinator public keys. Object `jwks.json` is published out-of-band by the coordinator at startup / key rotation."
   value       = "https://storage.googleapis.com/${google_storage_bucket.jwks.name}/jwks.json"
 }
+
+output "coordinator_url" {
+  description = "Auto-generated Cloud Run URL for the coordinator. SPA points at this. Replace with a custom-domain mapping when one is registered."
+  value       = google_cloud_run_v2_service.coordinator.uri
+}
+
+output "coordinator_service_account_email" {
+  description = "Coordinator runtime SA. Agents (in their own Terraform modules) grant this principal `roles/run.invoker` so it can call /bid /award /execute /reject."
+  value       = google_service_account.coordinator_runtime.email
+}
+
+output "coordinator_image_repo" {
+  description = "Artifact Registry path agent CI/CD pushes coordinator images to. Format: LOCATION-docker.pkg.dev/PROJECT/REPO."
+  value       = "${google_artifact_registry_repository.coordinator.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.coordinator.repository_id}"
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -54,3 +54,33 @@ variable "jwks_delete_protection" {
   type        = bool
   default     = false
 }
+
+variable "coordinator_image" {
+  description = "Fully-qualified container image for the coordinator Cloud Run service (e.g. us-central1-docker.pkg.dev/PROJECT/agent-tasker-dev-coordinator/coordinator:abc123). Defaults to Google's hello placeholder so `terraform apply` succeeds on a fresh project before the real image has been built and pushed."
+  type        = string
+  default     = "gcr.io/cloudrun/hello"
+}
+
+variable "coordinator_min_instances" {
+  description = "Minimum Cloud Run instances. Zero scales to nothing at idle; bump to 1 for prod-grade warm-start behavior."
+  type        = number
+  default     = 0
+}
+
+variable "coordinator_max_instances" {
+  description = "Cloud Run autoscale cap. Acts as a cost backstop more than a capacity ceiling — the in-process auction kickoff per request is cheap."
+  type        = number
+  default     = 10
+}
+
+variable "coordinator_request_timeout_seconds" {
+  description = "Per-request timeout. Must exceed the adaptive bid window cap (5s from CLAUDE.md) plus expected execute latency. 60s gives plenty of headroom."
+  type        = number
+  default     = 60
+}
+
+variable "coordinator_delete_protection" {
+  description = "Cloud Run service-level delete protection. False in dev for iteration; true in prod."
+  type        = bool
+  default     = false
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@google-cloud/firestore':
         specifier: ^8.6.0
         version: 8.6.0
+      '@hono/node-server':
+        specifier: ^2.0.3
+        version: 2.0.3(hono@4.12.21)
       hono:
         specifier: ^4.12.21
         version: 4.12.21
@@ -185,6 +188,12 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@2.0.3':
+    resolution: {integrity: sha512-a0jV+/HRe3G5zjFID3zObAQFdkl6zpxTuqktdDDXS3MJKcrZIkB8OkLpNBlY/WXFqv2HF4a0takPej+aNFczWA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1489,6 +1498,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.0
       yargs: 17.7.2
+
+  '@hono/node-server@2.0.3(hono@4.12.21)':
+    dependencies:
+      hono: 4.12.21
 
   '@humanfs/core@0.19.2':
     dependencies:


### PR DESCRIPTION
## Summary
Cloud Run service + Artifact Registry repo + runtime SA + container image for the coordinator. **No custom domain or managed TLS yet** — auto-generated `*.run.app` URL works for Phase 1 dev; domain mapping is a small follow-up once a domain is registered.

### Infra (`infra/coordinator/`)
- **`artifact_registry.tf`** — per-service Docker repo; per-service rather than one shared so cleanup policies can diverge.
- **`cloud_run.tf`**:
  - Runtime SA `${name_prefix}-coordinator` with three IAM bindings: `roles/datastore.user` (Firestore), `roles/storage.objectAdmin` (scoped to JWKS bucket only), `roles/logging.logWriter`.
  - `google_cloud_run_v2_service`: ingress all, scale-to-zero (min=0, var-capped max=10), **`cpu_idle = false`** so in-process auction kickoff outlives the request (per CLAUDE.md Phase 1 deploy plan), `startup_cpu_boost = true`, 60s request timeout.
  - `allUsers` invoker — coordinator is the SPA's API.
  - `lifecycle.ignore_changes = [client, client_version]` so gcloud-stamped fields don't drive plan churn.
- **`variables.tf`** — `coordinator_image` defaults to `gcr.io/cloudrun/hello` so `terraform apply` succeeds on a fresh project before the real image is built.
- **`outputs.tf`** — `coordinator_url` (SPA target), `coordinator_service_account_email` (agents grant this `roles/run.invoker`), `coordinator_image_repo` (Artifact Registry path for `docker push`).

### Container (`coordinator/`)
- **`Dockerfile`** — multi-stage Node 22 alpine. Stage 1 turbo-builds the monorepo; stage 2 `pnpm deploy --prod` copies coordinator + production deps (workspace deps materialized as real `node_modules` entries) into `/app`; stage 3 runtime with no source/tooling/dev deps. Runs as non-root `node`.
- **`.dockerignore`** — keeps `node_modules`, `dist`, `.terraform`, `docs` out of the build context.
- **`src/server.ts`** — Cloud Run entrypoint. Reads `GCP_PROJECT_ID` + `PORT`; wires `FirestoreLedgerStore` + `StubAuctionRunner` + `createApp`; serves via `@hono/node-server`. Real `AuctionRunner` (#47/#52/#53) drops in here without changing the entrypoint.

### Deploy flow
```sh
docker build -f coordinator/Dockerfile -t coordinator:dev .
docker tag coordinator:dev <coordinator_image_repo>/coordinator:TAG
docker push <coordinator_image_repo>/coordinator:TAG
terraform apply -var coordinator_image=<coordinator_image_repo>/coordinator:TAG
```

Closes #21

## Test plan
- [x] `terraform validate` + `terraform fmt -check` pass
- [x] Coordinator builds (`pnpm build`) — `server.ts` compiles against strict tsconfig
- [x] All 40 unit tests still pass
- [ ] After `terraform apply` in dev: `gcloud run services describe` shows the service is RUNNING, `curl $URL/healthz` returns `ok`
- [ ] Build + push the real image (placeholder still in tf default), re-apply, `curl $URL/tasks -XPOST -d '{"prompt":"hello"}'` returns 202

🤖 Generated with [Claude Code](https://claude.com/claude-code)