### PR TITLE
Coordinator integration harness: scripted runner + fake agent (#27)

### DIFF
--- a/coordinator/test/integration/fake-agent.test.ts
+++ b/coordinator/test/integration/fake-agent.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { startFakeAgent, type FakeAgent } from "./fake-agent.js";
+
+let agent: FakeAgent;
+
+afterEach(async () => {
+  if (agent) await agent.stop();
+});
+
+describe("FakeAgent", () => {
+  beforeEach(async () => {
+    agent = await startFakeAgent({ agentId: "gcp-gemini" });
+  });
+
+  it("serves /health", async () => {
+    const res = await fetch(`${agent.url}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, agent_id: "gcp-gemini" });
+  });
+
+  it("default /bid declines with capability", async () => {
+    const res = await fetch(`${agent.url}/bid`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task_id: "t-1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      task_id: "t-1",
+      agent_id: "gcp-gemini",
+      status: "no_bid",
+      reason: "capability",
+    });
+    expect(agent.bidCalls).toBe(1);
+  });
+
+  it("default /execute returns a canned successful result", async () => {
+    const res = await fetch(`${agent.url}/execute`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task_id: "t-1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      task_id: "t-1",
+      agent_id: "gcp-gemini",
+      output: expect.stringContaining("gcp-gemini"),
+    });
+    expect(agent.executeCalls).toBe(1);
+  });
+});
+
+describe("FakeAgent with overrides", () => {
+  it("custom onBid returns a real bid", async () => {
+    agent = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (taskId) => ({
+        task_id: taskId,
+        agent_id: "aws-nova",
+        tier: "frontier",
+        model_family: "nova",
+        model_id: "amazon.nova-pro",
+        est_input_tokens: 1000,
+        est_output_tokens: 500,
+        price_in_usd_per_mtoken: 0.8,
+        price_out_usd_per_mtoken: 3.2,
+        bid_usd: 0.0024,
+        expires_at: "2026-05-20T13:00:00Z",
+        signature: "stub",
+      }),
+    });
+
+    const res = await fetch(`${agent.url}/bid`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task_id: "t-2" }),
+    });
+    expect(await res.json()).toMatchObject({
+      agent_id: "aws-nova",
+      tier: "frontier",
+      bid_usd: 0.0024,
+    });
+  });
+});

--- a/coordinator/test/integration/fake-agent.ts
+++ b/coordinator/test/integration/fake-agent.ts
@@ -1,0 +1,97 @@
+import { serve, type ServerType } from "@hono/node-server";
+import type { AddressInfo } from "node:net";
+import { Hono } from "hono";
+import type { AgentId, BidResponse, Result } from "@agent-tasker/protocol";
+
+// Stand-in agent server. The real AuctionRunner (#47 + #52 + #53) will
+// POST to /bid and /execute on each agent's base URL; this harness lets
+// us stand up a configurable fake on an ephemeral port and assert on what
+// the runner did. Today it has no consumer in coordinator/ but the unit
+// tests in fake-agent.test.ts pin its behavior so the harness is ready
+// to drop in when the real runner lands.
+
+export interface FakeAgentOptions {
+  agentId: AgentId;
+  // Bid handler. Called with the announced taskId. Default: declines.
+  onBid?: (taskId: string) => BidResponse;
+  // Execute handler. Called with the awarded taskId. Default: returns a
+  // canned successful result.
+  onExecute?: (taskId: string) => Result;
+}
+
+export interface FakeAgent {
+  readonly agentId: AgentId;
+  readonly url: string;
+  // Number of /bid and /execute calls observed. Reset per instance.
+  bidCalls: number;
+  executeCalls: number;
+  stop(): Promise<void>;
+}
+
+export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent> {
+  const agentId = opts.agentId;
+  const state = { bidCalls: 0, executeCalls: 0 };
+
+  const onBid =
+    opts.onBid ??
+    ((taskId: string): BidResponse => ({
+      task_id: taskId,
+      agent_id: agentId,
+      status: "no_bid",
+      reason: "capability",
+    }));
+
+  const onExecute =
+    opts.onExecute ??
+    ((taskId: string): Result => ({
+      task_id: taskId,
+      agent_id: agentId,
+      output: `stub output from ${agentId}`,
+      actual_usage: { input_tokens: 100, output_tokens: 50 },
+    }));
+
+  const app = new Hono();
+  app.get("/health", (c) => c.json({ ok: true, agent_id: agentId }));
+
+  app.post("/bid", async (c) => {
+    state.bidCalls += 1;
+    const body = (await c.req.json()) as { task_id?: string };
+    if (!body.task_id) return c.json({ error: "task_id required" }, 400);
+    return c.json(onBid(body.task_id));
+  });
+
+  app.post("/execute", async (c) => {
+    state.executeCalls += 1;
+    const body = (await c.req.json()) as { task_id?: string };
+    if (!body.task_id) return c.json({ error: "task_id required" }, 400);
+    return c.json(onExecute(body.task_id));
+  });
+
+  const server: ServerType = await new Promise((resolve) => {
+    const s = serve({ fetch: app.fetch, port: 0 }, () => resolve(s));
+  });
+
+  const address = server.address() as AddressInfo | null;
+  if (!address || typeof address === "string") {
+    throw new Error("fake agent server failed to bind to an address");
+  }
+  const url = `http://127.0.0.1:${address.port}`;
+
+  const agent: FakeAgent = {
+    agentId,
+    url,
+    get bidCalls() {
+      return state.bidCalls;
+    },
+    get executeCalls() {
+      return state.executeCalls;
+    },
+    async stop() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+
+  return agent;
+}

--- a/coordinator/test/integration/lifecycle.test.ts
+++ b/coordinator/test/integration/lifecycle.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { TaskId } from "@agent-tasker/protocol";
+import { createApp } from "../../src/api/app.js";
+import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
+import { GetTaskResponseSchema, CreateTaskResponseSchema } from "../../src/api/schemas.js";
+import { ScriptedAuctionRunner } from "./scripted-runner.js";
+
+// End-to-end exercise of: client POST → coordinator creates task →
+// ScriptedAuctionRunner runs a synthesized auction against the ledger →
+// client GET observes the settled state.
+//
+// Does not exercise the real auction-runner code (#47/#52/#53). It does
+// pin the contract those issues have to honor: same LedgerStore API,
+// same status transitions, same projected response shape.
+
+const PRICING_SNAPSHOT = [
+  {
+    model_id: "gemini-2-5-pro",
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10.0,
+    effective_date: "2026-05-15",
+  },
+];
+
+describe("coordinator lifecycle (POST → script → GET)", () => {
+  it("happy path: bidding → awarded → executing → completed", async () => {
+    const store = new InMemoryLedgerStore();
+    const runner = new ScriptedAuctionRunner(async (taskId: TaskId) => {
+      // Two agents bid; gcp-gemini undercuts aws-nova.
+      await store.recordBidResponse({
+        taskId,
+        response: {
+          task_id: taskId,
+          agent_id: "gcp-gemini",
+          tier: "frontier",
+          model_family: "gemini",
+          model_id: "gemini-2-5-pro",
+          est_input_tokens: 4000,
+          est_output_tokens: 1000,
+          price_in_usd_per_mtoken: 1.25,
+          price_out_usd_per_mtoken: 10.0,
+          bid_usd: 0.015,
+          expires_at: "2026-05-20T13:00:00Z",
+          signature: "stub",
+        },
+        pricingSnapshot: PRICING_SNAPSHOT,
+      });
+      await store.recordBidResponse({
+        taskId,
+        response: {
+          task_id: taskId,
+          agent_id: "aws-nova",
+          tier: "frontier",
+          model_family: "nova",
+          model_id: "amazon.nova-pro",
+          est_input_tokens: 4000,
+          est_output_tokens: 1000,
+          price_in_usd_per_mtoken: 0.8,
+          price_out_usd_per_mtoken: 3.2,
+          bid_usd: 0.0064,
+          expires_at: "2026-05-20T13:00:00Z",
+          signature: "stub",
+        },
+        pricingSnapshot: PRICING_SNAPSHOT,
+      });
+
+      // Vickrey: lowest bid wins, second-lowest is the price.
+      await store.awardTask({
+        taskId,
+        winnerAgentId: "aws-nova",
+        auctionPriceUsd: 0.015,
+        winningBidUsd: 0.0064,
+      });
+      await store.markExecuting(taskId);
+      await store.completeTask({
+        taskId,
+        result: {
+          task_id: taskId,
+          agent_id: "aws-nova",
+          output: "summary",
+          actual_usage: { input_tokens: 4100, output_tokens: 950 },
+        },
+      });
+    });
+
+    const app = createApp({ store, runner });
+
+    const createRes = await app.request("/tasks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "summarize the transcript" }),
+    });
+    expect(createRes.status).toBe(202);
+    const created = CreateTaskResponseSchema.parse(await createRes.json());
+
+    // Wait for the scripted auction to walk the task through its lifecycle.
+    await runner.settle(created.task_id);
+
+    const getRes = await app.request(`/tasks/${created.task_id}`);
+    expect(getRes.status).toBe(200);
+    const fetched = GetTaskResponseSchema.parse(await getRes.json());
+
+    expect(fetched.status).toBe("completed");
+    expect(fetched.winner_agent_id).toBe("aws-nova");
+    expect(fetched.auction_price_usd).toBe(0.015);
+    expect(fetched.winning_bid_usd).toBe(0.0064);
+    expect(fetched.result?.output).toBe("summary");
+
+    // Underlying ledger has both bid records.
+    const bids = await store.listBids(created.task_id);
+    expect(bids.map((b) => b.agent_id).sort()).toEqual(["aws-nova", "gcp-gemini"]);
+  });
+
+  it("failure path: all agents decline → task marked failed with reason", async () => {
+    const store = new InMemoryLedgerStore();
+    const runner = new ScriptedAuctionRunner(async (taskId: TaskId) => {
+      await store.recordBidResponse({
+        taskId,
+        response: {
+          task_id: taskId,
+          agent_id: "gcp-gemini",
+          status: "no_bid",
+          reason: "context_overflow",
+        },
+        pricingSnapshot: PRICING_SNAPSHOT,
+      });
+      await store.failTask({
+        taskId,
+        reason: "all agents declined: context_overflow",
+      });
+    });
+
+    const app = createApp({ store, runner });
+    const createRes = await app.request("/tasks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "huge task" }),
+    });
+    const created = CreateTaskResponseSchema.parse(await createRes.json());
+    await runner.settle(created.task_id);
+
+    const getRes = await app.request(`/tasks/${created.task_id}`);
+    const fetched = GetTaskResponseSchema.parse(await getRes.json());
+    expect(fetched.status).toBe("failed");
+    expect(fetched.failure_reason).toContain("context_overflow");
+  });
+});

--- a/coordinator/test/integration/scripted-runner.ts
+++ b/coordinator/test/integration/scripted-runner.ts
@@ -1,0 +1,29 @@
+import type { TaskId } from "@agent-tasker/protocol";
+import type { AuctionRunner } from "../../src/auction/runner.js";
+
+// Test helper. Calls `script(taskId)` whenever the coordinator's POST
+// /tasks handler kicks off a new task. The script is expected to drive
+// the ledger through the auction states (record bids, award, execute,
+// complete or fail), simulating what the real AuctionRunner will do once
+// #47/#52/#53 land.
+//
+// Returns a promise that the test can await on a per-task basis, so
+// assertions can wait for the ledger to reach a settled state before
+// reading GET /tasks/:id.
+export class ScriptedAuctionRunner implements AuctionRunner {
+  private readonly settlements = new Map<TaskId, Promise<void>>();
+
+  constructor(private readonly script: (taskId: TaskId) => Promise<void>) {}
+
+  start(taskId: TaskId): void {
+    this.settlements.set(taskId, this.script(taskId));
+  }
+
+  // Returns a promise that resolves when the scripted lifecycle for this
+  // task has finished. Throws if `start` was never called for `taskId`.
+  settle(taskId: TaskId): Promise<void> {
+    const settlement = this.settlements.get(taskId);
+    if (!settlement) throw new Error(`no settlement registered for task ${taskId}`);
+    return settlement;
+  }
+}


### PR DESCRIPTION
## Summary
End-to-end exercise of the coordinator's HTTP API + state machine + ledger, plus the `FakeAgent` server scaffolding ready for the real `AuctionRunner` (#47/#52/#53) to plug into.

Two pieces, both under `coordinator/test/integration/`:

- **`scripted-runner.ts`** — `ScriptedAuctionRunner` implements `AuctionRunner` by calling a per-test `script(taskId)` on `start()`, recording the returned promise, and exposing `settle(taskId)` so test bodies can await the synthesized auction before reading `GET /tasks/:id`. Stands in for the missing real runner; becomes unnecessary once the real one lands but still useful as a deterministic test fixture.

- **`fake-agent.ts`** — `startFakeAgent(opts)` returns a `FakeAgent` with `{url, bidCalls, executeCalls, stop()}`. Spins a Hono server on an ephemeral port serving `/health`, `/bid`, `/execute` with sensible defaults and per-test handler overrides. **No coordinator code calls FakeAgent yet** — `fake-agent.test.ts` pins behavior so the harness is ready to drop in. When the real runner lands, point its per-agent config at the `FakeAgent.url`s and assert on `bidCalls` / `executeCalls`.

- **`lifecycle.test.ts`** — two end-to-end scenarios:
  1. **Happy path:** two-bidder Vickrey; lower bidder wins, price = second-lowest. `ScriptedAuctionRunner` walks `bidding → awarded → executing → completed`. `POST` returns 202; `settle()` awaits; `GET` projects the completed shape with winner, prices, result.
  2. **Failure path:** single agent declines (`no_bid` / `context_overflow`). Runner records the decline and calls `failTask`. `GET` shows `failed` + `failure_reason`.

Together these pin the contract #47/#52/#53 will need to honor: same `LedgerStore` API, same status transitions, same projected response shape.

Coordinator now has **46 tests** across 6 files; all green.

Closes #27

## Test plan
- [x] 6 new tests pass (2 lifecycle, 4 fake-agent)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm build` all clean
- [ ] CI green
- [ ] When real `AuctionRunner` lands: swap `ScriptedAuctionRunner` out in `lifecycle.test.ts`, wire `FakeAgent` URLs in, run against real HTTP fan-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)