### PR TITLE
Shared agent JWT verification middleware (#62)

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -15,11 +15,15 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@agent-tasker/protocol": "workspace:*"
+    "@agent-tasker/protocol": "workspace:*",
+    "hono": "^4.12.21",
+    "jose": "^6.2.3",
+    "zod": "^3.25.76"
   }
 }

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,1 +1,2 @@
 export { PROTOCOL_VERSION } from "@agent-tasker/protocol";
+export * from "./jwt/index.js";

--- a/agent/src/jwt/index.ts
+++ b/agent/src/jwt/index.ts
@@ -1,0 +1,2 @@
+export * from "./verify.js";
+export * from "./middleware.js";

--- a/agent/src/jwt/middleware.ts
+++ b/agent/src/jwt/middleware.ts
@@ -1,0 +1,48 @@
+import type { Context, Next } from "hono";
+import type { JwtPhase, TaskTokenClaims } from "@agent-tasker/protocol";
+import { TokenVerificationError, type TaskTokenVerifier } from "./verify.js";
+
+// Key under which verified claims are attached to Hono's context. Handlers
+// read via `getTokenClaims(c)` so the consumer never types this string.
+export const TOKEN_CLAIMS_CONTEXT_KEY = "__taskTokenClaims";
+
+// Hono middleware factory. Returns a middleware that rejects requests
+// missing or failing JWT verification with a structured 401, and on
+// success attaches the parsed claims to the Hono context.
+//
+// Usage in an agent's `/bid` handler:
+//
+//   app.post("/bid",
+//     requireTaskToken(verifier, "bid"),
+//     async (c) => { const claims = getTokenClaims(c); ... });
+export function requireTaskToken(verifier: TaskTokenVerifier, expectedPhase: JwtPhase) {
+  return async (c: Context, next: Next): Promise<Response | void> => {
+    const auth = c.req.header("authorization") ?? c.req.header("Authorization");
+    if (!auth || !auth.toLowerCase().startsWith("bearer ")) {
+      return c.json({ error: { code: "unauthorized", message: "missing bearer token" } }, 401);
+    }
+    const token = auth.slice("bearer ".length).trim();
+    try {
+      const claims = await verifier.verify(token, expectedPhase);
+      c.set(TOKEN_CLAIMS_CONTEXT_KEY, claims);
+    } catch (err) {
+      const message =
+        err instanceof TokenVerificationError ? err.message : "token verification failed";
+      return c.json({ error: { code: "unauthorized", message } }, 401);
+    }
+    await next();
+  };
+}
+
+// Read verified claims set by `requireTaskToken` upstream. Throws if the
+// middleware wasn't wired — that's a programmer error, not a runtime
+// concern, so no graceful fallback.
+export function getTokenClaims(c: Context): TaskTokenClaims {
+  const claims = c.get(TOKEN_CLAIMS_CONTEXT_KEY) as TaskTokenClaims | undefined;
+  if (!claims) {
+    throw new Error(
+      "getTokenClaims called without requireTaskToken middleware upstream of the handler",
+    );
+  }
+  return claims;
+}

--- a/agent/src/jwt/verify.ts
+++ b/agent/src/jwt/verify.ts
@@ -1,0 +1,74 @@
+import { jwtVerify, type JWTVerifyGetKey } from "jose";
+import {
+  COORDINATOR_ISSUER,
+  TaskTokenClaimsSchema,
+  type AgentId,
+  type JwtPhase,
+  type TaskTokenClaims,
+} from "@agent-tasker/protocol";
+
+// Production wiring uses `createRemoteJWKSet(new URL(JWKS_URL), { cacheMaxAge })`
+// from `jose` for `getKey` — that handles JWKS fetch + caching + transparent
+// key rotation. Tests pass `createLocalJWKSet(...)` against an in-memory
+// keypair so they don't need a fake JWKS HTTP server.
+export interface TaskTokenVerifierOptions {
+  getKey: JWTVerifyGetKey;
+  expectedAudience: AgentId;
+  // Seconds of clock skew the verifier tolerates either side of `exp` / `iat`.
+  // Defaults to 5; production deploys can crank this down once clock sync is
+  // measured.
+  clockTolerance?: number;
+}
+
+export interface TaskTokenVerifier {
+  verify(token: string, expectedPhase: JwtPhase): Promise<TaskTokenClaims>;
+}
+
+// Thrown for every recoverable token-verification failure (bad signature,
+// wrong audience, wrong phase, expired, malformed claims). Callers can
+// catch this class once instead of branching on jose error subclasses.
+export class TokenVerificationError extends Error {
+  override readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "TokenVerificationError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+export function createTaskTokenVerifier(opts: TaskTokenVerifierOptions): TaskTokenVerifier {
+  return {
+    async verify(token, expectedPhase) {
+      let payload: unknown;
+      try {
+        const result = await jwtVerify(token, opts.getKey, {
+          issuer: COORDINATOR_ISSUER,
+          audience: opts.expectedAudience,
+          algorithms: ["RS256"],
+          clockTolerance: opts.clockTolerance ?? 5,
+        });
+        payload = result.payload;
+      } catch (err) {
+        throw new TokenVerificationError(`jwt verification failed: ${(err as Error).message}`, err);
+      }
+
+      const parsed = TaskTokenClaimsSchema.safeParse(payload);
+      if (!parsed.success) {
+        throw new TokenVerificationError(
+          `token claims do not match schema: ${parsed.error.issues
+            .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+            .join("; ")}`,
+        );
+      }
+
+      if (parsed.data.phase !== expectedPhase) {
+        throw new TokenVerificationError(
+          `expected phase ${expectedPhase}, got ${parsed.data.phase}`,
+        );
+      }
+
+      return parsed.data;
+    },
+  };
+}

--- a/agent/test/jwt/middleware.test.ts
+++ b/agent/test/jwt/middleware.test.ts
@@ -1,0 +1,101 @@
+import { Hono } from "hono";
+import {
+  SignJWT,
+  createLocalJWKSet,
+  exportJWK,
+  exportPKCS8,
+  generateKeyPair,
+  importPKCS8,
+  type JWK,
+} from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+import { COORDINATOR_ISSUER, TOKEN_TTL_SECONDS } from "@agent-tasker/protocol";
+import { getTokenClaims, requireTaskToken } from "../../src/jwt/middleware.js";
+import { createTaskTokenVerifier } from "../../src/jwt/verify.js";
+
+const KID = "test-kid";
+const AUDIENCE = "gcp-gemini" as const;
+
+let privateKeyPem: string;
+let publicJwk: JWK;
+let app: Hono;
+
+beforeAll(async () => {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  privateKeyPem = await exportPKCS8(privateKey);
+  publicJwk = await exportJWK(publicKey);
+  publicJwk.kid = KID;
+
+  const verifier = createTaskTokenVerifier({
+    getKey: createLocalJWKSet({ keys: [publicJwk] }),
+    expectedAudience: AUDIENCE,
+  });
+
+  app = new Hono();
+  app.post("/bid", requireTaskToken(verifier, "bid"), (c) => {
+    const claims = getTokenClaims(c);
+    return c.json({ ok: true, task_id: claims.task_id, phase: claims.phase });
+  });
+});
+
+async function bearerToken(opts: { phase?: string; audience?: string } = {}): Promise<string> {
+  const key = await importPKCS8(privateKeyPem, "RS256");
+  const iat = Math.floor(Date.now() / 1000);
+  return new SignJWT({ task_id: "task-mw-1", phase: opts.phase ?? "bid" })
+    .setProtectedHeader({ alg: "RS256", kid: KID, typ: "JWT" })
+    .setIssuer(COORDINATOR_ISSUER)
+    .setSubject(COORDINATOR_ISSUER)
+    .setAudience(opts.audience ?? AUDIENCE)
+    .setIssuedAt(iat)
+    .setExpirationTime(iat + TOKEN_TTL_SECONDS)
+    .sign(key);
+}
+
+describe("requireTaskToken middleware", () => {
+  it("calls the downstream handler with claims attached on success", async () => {
+    const token = await bearerToken();
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; task_id: string; phase: string };
+    expect(body).toEqual({ ok: true, task_id: "task-mw-1", phase: "bid" });
+  });
+
+  it("returns 401 when no Authorization header is present", async () => {
+    const res = await app.request("/bid", { method: "POST" });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("unauthorized");
+    expect(body.error.message).toMatch(/missing bearer/i);
+  });
+
+  it("returns 401 when the Authorization header isn't a bearer", async () => {
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { authorization: "Basic Zm9vOmJhcg==" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the token's phase doesn't match the route's expected phase", async () => {
+    const token = await bearerToken({ phase: "award" });
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/expected phase bid/i);
+  });
+
+  it("returns 401 when the audience doesn't match", async () => {
+    const token = await bearerToken({ audience: "aws-nova" });
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/agent/test/jwt/verify.test.ts
+++ b/agent/test/jwt/verify.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  SignJWT,
+  createLocalJWKSet,
+  exportJWK,
+  exportPKCS8,
+  generateKeyPair,
+  importPKCS8,
+  type JWK,
+} from "jose";
+import { COORDINATOR_ISSUER, TOKEN_TTL_SECONDS } from "@agent-tasker/protocol";
+import {
+  TokenVerificationError,
+  createTaskTokenVerifier,
+  type TaskTokenVerifier,
+} from "../../src/jwt/verify.js";
+
+const KID = "test-coordinator-1";
+const AUDIENCE = "gcp-gemini" as const;
+
+let privateKeyPem: string;
+let publicJwk: JWK;
+let verifier: TaskTokenVerifier;
+
+beforeAll(async () => {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  privateKeyPem = await exportPKCS8(privateKey);
+  publicJwk = await exportJWK(publicKey);
+  publicJwk.kid = KID;
+  verifier = createTaskTokenVerifier({
+    getKey: createLocalJWKSet({ keys: [publicJwk] }),
+    expectedAudience: AUDIENCE,
+  });
+});
+
+afterAll(() => {
+  // No resources to release; left for symmetry as more setup creeps in.
+});
+
+interface SignOptions {
+  audience?: string;
+  iss?: string;
+  sub?: string;
+  taskId?: string;
+  phase?: string;
+  ttlSeconds?: number;
+  now?: Date;
+  // Override the kid header (default: KID).
+  kid?: string;
+}
+
+async function mintToken(opts: SignOptions = {}): Promise<string> {
+  const key = await importPKCS8(privateKeyPem, "RS256");
+  const iat = Math.floor((opts.now ?? new Date()).getTime() / 1000);
+  const ttl = opts.ttlSeconds ?? TOKEN_TTL_SECONDS;
+  return new SignJWT({
+    task_id: opts.taskId ?? "task-1",
+    phase: opts.phase ?? "bid",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: opts.kid ?? KID, typ: "JWT" })
+    .setIssuer(opts.iss ?? COORDINATOR_ISSUER)
+    .setSubject(opts.sub ?? COORDINATOR_ISSUER)
+    .setAudience(opts.audience ?? AUDIENCE)
+    .setIssuedAt(iat)
+    .setExpirationTime(iat + ttl)
+    .sign(key);
+}
+
+describe("createTaskTokenVerifier", () => {
+  it("returns parsed claims for a well-formed token signed by the trusted key", async () => {
+    const token = await mintToken();
+    const claims = await verifier.verify(token, "bid");
+    expect(claims.task_id).toBe("task-1");
+    expect(claims.phase).toBe("bid");
+    expect(claims.aud).toBe(AUDIENCE);
+    expect(claims.iss).toBe(COORDINATOR_ISSUER);
+    expect(claims.sub).toBe(COORDINATOR_ISSUER);
+  });
+
+  it("rejects when the expected phase doesn't match the claim", async () => {
+    const token = await mintToken({ phase: "bid" });
+    await expect(verifier.verify(token, "award")).rejects.toThrow(TokenVerificationError);
+    await expect(verifier.verify(token, "award")).rejects.toThrow(/expected phase award/i);
+  });
+
+  it("rejects on wrong audience", async () => {
+    const token = await mintToken({ audience: "aws-nova" });
+    await expect(verifier.verify(token, "bid")).rejects.toThrow(TokenVerificationError);
+  });
+
+  it("rejects on wrong issuer", async () => {
+    const token = await mintToken({ iss: "evil-coordinator" });
+    await expect(verifier.verify(token, "bid")).rejects.toThrow(TokenVerificationError);
+  });
+
+  it("rejects expired tokens", async () => {
+    const past = new Date(Date.now() - 120_000);
+    const token = await mintToken({ now: past });
+    await expect(verifier.verify(token, "bid")).rejects.toThrow(TokenVerificationError);
+  });
+
+  it("rejects tokens signed by an untrusted key (wrong kid → JWKS miss)", async () => {
+    // Generate a *different* keypair; sign with that key but claim the trusted kid.
+    const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+    const otherPem = await exportPKCS8(privateKey);
+    const otherKey = await importPKCS8(otherPem, "RS256");
+    const iat = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ task_id: "task-bad", phase: "bid" })
+      .setProtectedHeader({ alg: "RS256", kid: "untrusted-kid", typ: "JWT" })
+      .setIssuer(COORDINATOR_ISSUER)
+      .setSubject(COORDINATOR_ISSUER)
+      .setAudience(AUDIENCE)
+      .setIssuedAt(iat)
+      .setExpirationTime(iat + TOKEN_TTL_SECONDS)
+      .sign(otherKey);
+    await expect(verifier.verify(token, "bid")).rejects.toThrow(TokenVerificationError);
+  });
+
+  it("rejects tokens whose claims fail Zod schema parsing", async () => {
+    // phase is required + must be one of the JwtPhase enum values.
+    const token = await mintToken({ phase: "not-a-real-phase" });
+    await expect(verifier.verify(token, "bid")).rejects.toThrow(TokenVerificationError);
+  });
+});

--- a/agent/tsconfig.build.json
+++ b/agent/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,15 @@ importers:
       '@agent-tasker/protocol':
         specifier: workspace:*
         version: link:../protocol
+      hono:
+        specifier: ^4.12.21
+        version: 4.12.21
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   agent/aws-nova:
     dependencies:


### PR DESCRIPTION
## Summary
Every agent's edge runs the same verification logic, so the lib lives in `/agent` and gets pulled in by all four per-agent packages. Production uses `jose.createRemoteJWKSet` against the coordinator's JWKS URL (published by #26); tests inject `createLocalJWKSet` against an in-memory keypair so no fake JWKS HTTP server is needed.

### Layout (`agent/src/jwt/`)
- **`verify.ts`** — `createTaskTokenVerifier({ getKey, expectedAudience, clockTolerance? })`. Returns a verifier whose `verify(token, expectedPhase)` checks:
  - signature against the JWKS
  - `iss = coordinator`, `aud = this agent`
  - `exp`/`iat` with clock skew (default 5s)
  - Zod-parse of `TaskTokenClaimsSchema`
  - **token's `phase` claim matches the route's expected phase** — so a `bid` token can't be replayed against `/execute`
  - Failures funnel through `TokenVerificationError` so callers branch once, not on jose's error subclasses

- **`middleware.ts`** — `requireTaskToken(verifier, expectedPhase)` Hono middleware factory. 401 + structured error envelope on missing/bad bearer; on success, attaches verified claims to `c` via `TOKEN_CLAIMS_CONTEXT_KEY`. Handlers read via the typed `getTokenClaims(c)` helper.

### Tests (12 cases, all passing)
- `verify.test.ts` (7): happy path, wrong phase, wrong aud, wrong iss, expired, **untrusted kid (JWKS miss)**, malformed claims
- `middleware.test.ts` (5): happy path, no header, non-bearer scheme, wrong phase, wrong aud

### Repo plumbing
- Agent package gains `jose`, `hono`, `zod` deps (zod pinned to `^3.x` to match `/protocol`)
- Adopts the coordinator's tsconfig split: `tsconfig.json` (src+test, `noEmit`) for typecheck/IDE; `tsconfig.build.json` for `tsc -p` builds
- `pnpm test` (vitest run) added

Closes #62

## Test plan
- [x] 12 tests pass; build, typecheck, lint, format all clean
- [ ] CI green
- [ ] Used end-to-end by the GCP/Gemini bid handler (#63) — that PR wires the middleware against a real Cloud Run service

🤖 Generated with [Claude Code](https://claude.com/claude-code)