### PR TITLE
Minimal HttpAuctionRunner: real bid→execute→settle round-trip

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -1,0 +1,251 @@
+import {
+  BidResponseSchema,
+  ResultSchema,
+  type AgentId,
+  type Bid,
+  type BidResponse,
+  type JwtPhase,
+  type PricingEntry,
+  type TaskId,
+  isNoBid,
+} from "@agent-tasker/protocol";
+import type { LedgerStore } from "../ledger/store.js";
+import type { AuctionRunner } from "./runner.js";
+
+// Minimal real AuctionRunner that drives `bidding → awarded → executing →
+// (completed | failed)` for one task via real HTTP fan-out to each agent.
+//
+// What it does today:
+// - Mints per-phase JWTs via the injected signer; sends them as Bearer
+//   on each agent request.
+// - Announces in parallel via POST {agent.baseUrl}/bid with the task spec
+//   and the bid token.
+// - Waits up to `bidTimeoutMs` for responses (fixed; adaptive timeout is
+//   #52). Slow agents are treated as `no_bid: internal_error`.
+// - Records every bid/no_bid via store.recordBidResponse with the supplied
+//   pricing snapshot.
+// - Picks the winner with lowest `bid_usd`. Full Vickrey (second-price)
+//   selection lands with #47; for now the auction_price IS the winning
+//   bid (degenerate Vickrey for two-or-fewer bidders).
+// - Awards, marks executing, POSTs to {winner.baseUrl}/execute, records
+//   the result, completes.
+// - Any unrecoverable failure → store.failTask. Re-auction on /execute
+//   failure is #53.
+//
+// What's still out of scope (separate issues):
+// - Adaptive bid timeout (#52)
+// - Real Vickrey second-price selection (#47)
+// - MAPE-based tie-breaking (#50, #51)
+// - Re-auction on /execute failure (#53)
+// - Score-weighted auction layer (#81)
+
+export interface AgentEndpoint {
+  agentId: AgentId;
+  baseUrl: string;
+}
+
+export interface TaskTokenSigner {
+  sign(args: { agentId: AgentId; taskId: TaskId; phase: JwtPhase }): Promise<string>;
+}
+
+export interface HttpAuctionRunnerOptions {
+  store: LedgerStore;
+  agents: AgentEndpoint[];
+  tokenSigner: TaskTokenSigner;
+  pricingSnapshot: PricingEntry[];
+  bidTimeoutMs?: number;
+  executeTimeoutMs?: number;
+  // Override for tests; defaults to the global `fetch` available in Node 22+.
+  fetch?: typeof fetch;
+  // Hook so callers can observe runs / surface errors. The runner itself
+  // never throws past `start()` — every failure path is reflected in the
+  // ledger.
+  onError?: (taskId: TaskId, err: unknown) => void;
+}
+
+const DEFAULT_BID_TIMEOUT_MS = 5_000;
+const DEFAULT_EXECUTE_TIMEOUT_MS = 60_000;
+
+export class HttpAuctionRunner implements AuctionRunner {
+  private readonly settlements = new Map<TaskId, Promise<void>>();
+
+  constructor(private readonly opts: HttpAuctionRunnerOptions) {}
+
+  start(taskId: TaskId): void {
+    const settlement = this.runAuction(taskId).catch((err: unknown) => {
+      this.opts.onError?.(taskId, err);
+    });
+    this.settlements.set(taskId, settlement);
+  }
+
+  // Test helper — awaits the in-flight (or completed) auction for a given
+  // task. Production callers don't need this; the result is observable
+  // via GET /tasks/:id.
+  settle(taskId: TaskId): Promise<void> {
+    return this.settlements.get(taskId) ?? Promise.resolve();
+  }
+
+  private async runAuction(taskId: TaskId): Promise<void> {
+    const task = await this.opts.store.getTask(taskId);
+    if (!task) {
+      // POST /tasks just created this — if it's not here something is very
+      // wrong upstream. Surface via onError; nothing else to write.
+      this.opts.onError?.(taskId, new Error(`task ${taskId} vanished before auction start`));
+      return;
+    }
+
+    const responses = await this.gatherBids(taskId);
+    for (const response of responses) {
+      await this.opts.store.recordBidResponse({
+        taskId,
+        response,
+        pricingSnapshot: this.opts.pricingSnapshot,
+      });
+    }
+
+    const realBids = responses.filter((r): r is Bid => !isNoBid(r));
+    if (realBids.length === 0) {
+      const reasons = responses
+        .filter(isNoBid)
+        .map((r) => r.reason)
+        .join(", ");
+      await this.opts.store.failTask({
+        taskId,
+        reason: `all agents declined: ${reasons || "none responded"}`,
+      });
+      return;
+    }
+
+    const winner = pickLowestBid(realBids);
+    const auctionPriceUsd = pickAuctionPrice(realBids, winner);
+
+    await this.opts.store.awardTask({
+      taskId,
+      winnerAgentId: winner.agent_id,
+      auctionPriceUsd,
+      winningBidUsd: winner.bid_usd,
+    });
+
+    await this.opts.store.markExecuting(taskId);
+
+    try {
+      const result = await this.execute(taskId, winner.agent_id);
+      await this.opts.store.completeTask({ taskId, result });
+    } catch (err) {
+      await this.opts.store.failTask({
+        taskId,
+        reason: `winner ${winner.agent_id} failed /execute: ${(err as Error).message}`,
+      });
+    }
+  }
+
+  // Sends POST /bid to every configured agent in parallel and returns one
+  // BidResponse per agent. Agents that error / time out / return junk are
+  // translated to a synthetic `no_bid: internal_error` so the ledger has a
+  // record per agent.
+  private async gatherBids(taskId: TaskId): Promise<BidResponse[]> {
+    const timeoutMs = this.opts.bidTimeoutMs ?? DEFAULT_BID_TIMEOUT_MS;
+    const fetchImpl = this.opts.fetch ?? fetch;
+    return Promise.all(
+      this.opts.agents.map(async (agent): Promise<BidResponse> => {
+        try {
+          const token = await this.opts.tokenSigner.sign({
+            agentId: agent.agentId,
+            taskId,
+            phase: "bid",
+          });
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), timeoutMs);
+          let res: Response;
+          try {
+            res = await fetchImpl(`${agent.baseUrl}/bid`, {
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${token}`,
+              },
+              body: JSON.stringify({ task_id: taskId }),
+              signal: controller.signal,
+            });
+          } finally {
+            clearTimeout(timer);
+          }
+          if (!res.ok) {
+            return syntheticNoBid(taskId, agent.agentId, `agent returned ${res.status}`);
+          }
+          const body = (await res.json()) as unknown;
+          const parsed = BidResponseSchema.safeParse(body);
+          if (!parsed.success) {
+            return syntheticNoBid(taskId, agent.agentId, "malformed bid response");
+          }
+          // Defend against an agent claiming to be someone else.
+          const responseAgentId = "agent_id" in parsed.data ? parsed.data.agent_id : undefined;
+          if (responseAgentId !== agent.agentId) {
+            return syntheticNoBid(taskId, agent.agentId, "bid agent_id mismatch");
+          }
+          return parsed.data;
+        } catch (err) {
+          const reason = err instanceof Error && err.name === "AbortError" ? "timeout" : "error";
+          return syntheticNoBid(taskId, agent.agentId, reason);
+        }
+      }),
+    );
+  }
+
+  private async execute(taskId: TaskId, agentId: AgentId) {
+    const agent = this.opts.agents.find((a) => a.agentId === agentId);
+    if (!agent) {
+      throw new Error(`winner ${agentId} not in agent registry`);
+    }
+    const token = await this.opts.tokenSigner.sign({ agentId, taskId, phase: "execute" });
+    const timeoutMs = this.opts.executeTimeoutMs ?? DEFAULT_EXECUTE_TIMEOUT_MS;
+    const fetchImpl = this.opts.fetch ?? fetch;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let res: Response;
+    try {
+      res = await fetchImpl(`${agent.baseUrl}/execute`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ task_id: taskId }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) throw new Error(`execute returned ${res.status}`);
+    const body = (await res.json()) as unknown;
+    return ResultSchema.parse(body);
+  }
+}
+
+function syntheticNoBid(taskId: TaskId, agentId: AgentId, reason: string): BidResponse {
+  // `reason` here is descriptive but must map to the protocol's enum —
+  // anything outside `context_overflow | policy | capability |
+  // internal_error` is bucketed under `internal_error`. The richer free-form
+  // reason lives in the audit log (TODO: structured logging in #73).
+  void reason;
+  return {
+    task_id: taskId,
+    agent_id: agentId,
+    status: "no_bid",
+    reason: "internal_error",
+  };
+}
+
+function pickLowestBid(bids: Bid[]): Bid {
+  // Defensive: bids is non-empty by caller contract.
+  return bids.reduce((min, b) => (b.bid_usd < min.bid_usd ? b : min));
+}
+
+function pickAuctionPrice(bids: Bid[], winner: Bid): number {
+  // Vickrey: price = second-lowest bid. With a single bidder, the winner's
+  // own bid is the price (degenerate Vickrey). Full implementation with
+  // tier filtering + tie-breaking comes via #47.
+  const others = bids.filter((b) => b !== winner).map((b) => b.bid_usd);
+  if (others.length === 0) return winner.bid_usd;
+  return Math.min(...others);
+}

--- a/coordinator/src/auction/index.ts
+++ b/coordinator/src/auction/index.ts
@@ -1,2 +1,3 @@
 export * from "./state-machine.js";
 export * from "./runner.js";
+export * from "./http-runner.js";

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  AgentId,
+  Bid,
+  BidResponse,
+  JwtPhase,
+  PricingEntry,
+  TaskId,
+} from "@agent-tasker/protocol";
+import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
+import {
+  HttpAuctionRunner,
+  type AgentEndpoint,
+  type TaskTokenSigner,
+} from "../../src/auction/http-runner.js";
+import { startFakeAgent, type FakeAgent } from "./fake-agent.js";
+
+const PRICING_SNAPSHOT: PricingEntry[] = [
+  {
+    model_id: "gemini-2-5-pro",
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10.0,
+    effective_date: "2026-05-15",
+  },
+];
+
+// Token signer that returns a deterministic stub string. The FakeAgent
+// doesn't verify JWTs (that path is covered by agent/test/jwt/middleware.test.ts);
+// this test just confirms the runner *sends* a Bearer for each request.
+const signedTokens: Array<{ agentId: AgentId; phase: JwtPhase }> = [];
+const stubSigner: TaskTokenSigner = {
+  async sign({ agentId, phase }) {
+    signedTokens.push({ agentId, phase });
+    return `stub-token.${agentId}.${phase}`;
+  },
+};
+
+function bidFor(agentId: AgentId, bidUsd: number, taskId: string): Bid {
+  return {
+    task_id: taskId,
+    agent_id: agentId,
+    tier: "frontier",
+    model_family: agentId.startsWith("gcp") ? "gemini" : agentId.startsWith("aws") ? "nova" : "gpt",
+    model_id: "stub-model",
+    est_input_tokens: 4000,
+    est_output_tokens: 1000,
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10.0,
+    bid_usd: bidUsd,
+    expires_at: "2026-05-21T01:00:00Z",
+    signature: "stub",
+  };
+}
+
+let store: InMemoryLedgerStore;
+let agents: FakeAgent[];
+
+beforeEach(() => {
+  signedTokens.length = 0;
+  store = new InMemoryLedgerStore();
+  agents = [];
+});
+
+afterEach(async () => {
+  await Promise.all(agents.map((a) => a.stop()));
+});
+
+async function startAuction(opts: {
+  taskId: TaskId;
+  endpoints: AgentEndpoint[];
+  bidTimeoutMs?: number;
+}): Promise<HttpAuctionRunner> {
+  await store.createTask({
+    taskId: opts.taskId,
+    spec: { prompt: "summarize the transcript" },
+  });
+  const runner = new HttpAuctionRunner({
+    store,
+    agents: opts.endpoints,
+    tokenSigner: stubSigner,
+    pricingSnapshot: PRICING_SNAPSHOT,
+    ...(opts.bidTimeoutMs !== undefined ? { bidTimeoutMs: opts.bidTimeoutMs } : {}),
+  });
+  runner.start(opts.taskId);
+  await runner.settle(opts.taskId);
+  return runner;
+}
+
+describe("HttpAuctionRunner", () => {
+  it("happy path: two bidders, lowest wins, Vickrey price = other bid", async () => {
+    const taskId = "task-happy-1";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (id) => bidFor("gcp-gemini", 0.02, id),
+      onExecute: (id) => ({
+        task_id: id,
+        agent_id: "gcp-gemini",
+        output: "gemini did it",
+        actual_usage: { input_tokens: 4100, output_tokens: 950 },
+      }),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (id) => bidFor("aws-nova", 0.04, id),
+    });
+    agents.push(gemini, nova);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+      ],
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
+    expect(task?.winner_agent_id).toBe("gcp-gemini");
+    expect(task?.winning_bid_usd).toBe(0.02);
+    // Second-lowest is 0.04, so auction_price = 0.04
+    expect(task?.auction_price_usd).toBe(0.04);
+    expect(task?.result?.output).toBe("gemini did it");
+
+    // Per-phase JWTs: 2× bid + 1× execute = 3 total
+    expect(signedTokens).toEqual([
+      { agentId: "gcp-gemini", phase: "bid" },
+      { agentId: "aws-nova", phase: "bid" },
+      { agentId: "gcp-gemini", phase: "execute" },
+    ]);
+
+    expect(gemini.bidCalls).toBe(1);
+    expect(gemini.executeCalls).toBe(1);
+    expect(nova.bidCalls).toBe(1);
+    expect(nova.executeCalls).toBe(0);
+  });
+
+  it("single bidder: degenerate Vickrey price equals the winner's own bid", async () => {
+    const taskId = "task-single";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (id) => bidFor("gcp-gemini", 0.02, id),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      // default handler declines
+    });
+    agents.push(gemini, nova);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+      ],
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
+    expect(task?.winner_agent_id).toBe("gcp-gemini");
+    expect(task?.winning_bid_usd).toBe(0.02);
+    expect(task?.auction_price_usd).toBe(0.02);
+
+    // Nova's decline was still recorded
+    const bids = await store.listBids(taskId);
+    const novaRecord = bids.find((b) => b.agent_id === "aws-nova");
+    expect(novaRecord?.response).toMatchObject({ status: "no_bid", reason: "capability" });
+  });
+
+  it("all agents decline → task fails with reason listing decline codes", async () => {
+    const taskId = "task-all-decline";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (id): BidResponse => ({
+        task_id: id,
+        agent_id: "gcp-gemini",
+        status: "no_bid",
+        reason: "context_overflow",
+      }),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (id): BidResponse => ({
+        task_id: id,
+        agent_id: "aws-nova",
+        status: "no_bid",
+        reason: "policy",
+      }),
+    });
+    agents.push(gemini, nova);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+      ],
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("failed");
+    expect(task?.failure_reason).toContain("context_overflow");
+    expect(task?.failure_reason).toContain("policy");
+  });
+
+  it("unreachable agent is treated as no_bid: internal_error", async () => {
+    const taskId = "task-unreachable";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (id) => bidFor("gcp-gemini", 0.02, id),
+    });
+    agents.push(gemini);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        // Port 1 should always refuse connections; runner should treat as decline
+        { agentId: "aws-nova", baseUrl: "http://127.0.0.1:1" },
+      ],
+      bidTimeoutMs: 1500,
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
+    expect(task?.winner_agent_id).toBe("gcp-gemini");
+
+    const bids = await store.listBids(taskId);
+    const novaRecord = bids.find((b) => b.agent_id === "aws-nova");
+    expect(novaRecord?.response).toMatchObject({ status: "no_bid", reason: "internal_error" });
+  });
+
+  it("execute failure → task fails with reason mentioning the winner", async () => {
+    const taskId = "task-execute-fail";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (id) => bidFor("gcp-gemini", 0.02, id),
+      onExecute: () => {
+        throw new Error("model overloaded");
+      },
+    });
+    agents.push(gemini);
+
+    await startAuction({
+      taskId,
+      endpoints: [{ agentId: "gcp-gemini", baseUrl: gemini.url }],
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("failed");
+    expect(task?.failure_reason).toMatch(/gcp-gemini/);
+    expect(task?.failure_reason).toMatch(/500|execute/i);
+  });
+});


### PR DESCRIPTION
## Summary
Implicit dependency of Tier 2's "first agent end-to-end" deliverable (#98) — without a real (non-stub) `AuctionRunner`, the e2e smoke test has nothing to drive. This PR adds the foundation; Tier 5 polish layers on top.

**What `HttpAuctionRunner` does:**
- Mints per-phase JWTs via an injected `TaskTokenSigner` and sends them as `Bearer` on each agent request (separate tokens per `/bid` and `/execute`, no reuse — matches CLAUDE.md)
- Parallel POST to `{agent.baseUrl}/bid` with a fixed bid timeout; slow / unreachable / malformed agents are translated to a synthetic `no_bid: internal_error` so the ledger has one entry per configured agent
- Records every bid/no_bid via `store.recordBidResponse` with the supplied pricing snapshot
- Picks lowest `bid_usd` as the winner; `auction_price` = second-lowest (degenerate Vickrey for single-bidder cases)
- Awards, marks executing, POSTs to `{winner.baseUrl}/execute`, parses `ResultSchema`, calls `store.completeTask`. Any failure → `store.failTask` with a descriptive reason

**Out of scope** (separate issues, listed in `http-runner.ts` header):
- #47 Vickrey selection (with `min_tier` filtering)
- #52 Adaptive bid timeout
- #50/#51 MAPE-based tie-breaking
- #53 Re-auction on execute failure
- #81 Score-weighted auction layer

### Tests (5 new integration cases in `test/integration/http-runner.test.ts`, all using the `FakeAgent` harness from #27)
- happy path: 2 bidders, lowest wins, Vickrey price = other bid
- single bidder: degenerate Vickrey (price = own bid); declining agent's `no_bid` is still recorded
- all decline: `failTask` with concatenated reason codes
- unreachable agent: synthetic `no_bid: internal_error`; other bidder still wins
- execute failure: `failTask` with reason mentioning the winner

Coordinator now has **51 tests** across 7 files; all green.

## Test plan
- [x] 5 new tests pass; build/typecheck/lint/format clean
- [ ] CI green
- [ ] After GCP/Gemini handlers (#63 + #64) land: this runner can be wired up against the real agent (with Vertex AI mocked) in the e2e test (#98)

🤖 Generated with [Claude Code](https://claude.com/claude-code)