### PR TITLE
GCP/Gemini bid handler with Vertex AI Gemini Flash estimator (#63)

### DIFF
--- a/agent/gcp-gemini/package.json
+++ b/agent/gcp-gemini/package.json
@@ -6,12 +6,15 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
     "@agent-tasker/agent": "workspace:*",
-    "@agent-tasker/protocol": "workspace:*"
+    "@agent-tasker/protocol": "workspace:*",
+    "@google-cloud/vertexai": "^1.12.0",
+    "zod": "^3.25.76"
   }
 }

--- a/agent/gcp-gemini/src/bid/estimator.ts
+++ b/agent/gcp-gemini/src/bid/estimator.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import { VertexAI, type GenerativeModel } from "@google-cloud/vertexai";
+import type { TaskSpec } from "@agent-tasker/protocol";
+
+// Estimator interface decouples the bid handler from any single LLM SDK.
+// VertexBidEstimator is the production wiring; tests inject a fake that
+// returns canned token counts so they don't need network or credentials.
+export interface BidEstimator {
+  estimate(spec: TaskSpec): Promise<{ input_tokens: number; output_tokens: number }>;
+}
+
+// Minimal surface VertexBidEstimator needs from a generative model client.
+// One method: send a prompt, get back parsed JSON. Tests stub this
+// directly without touching @google-cloud/vertexai.
+export interface GenerativeJsonClient {
+  generateJson(prompt: string): Promise<unknown>;
+}
+
+const EstimateResultSchema = z.object({
+  est_input_tokens: z.number().int().nonnegative(),
+  est_output_tokens: z.number().int().nonnegative(),
+});
+
+// JSON schema fed to Gemini's `responseSchema` so it returns structured
+// output rather than free-form prose we'd then have to parse.
+const ESTIMATE_RESPONSE_SCHEMA = {
+  type: "object",
+  properties: {
+    est_input_tokens: { type: "integer", minimum: 0 },
+    est_output_tokens: { type: "integer", minimum: 0 },
+  },
+  required: ["est_input_tokens", "est_output_tokens"],
+} as const;
+
+function buildPrompt(spec: TaskSpec): string {
+  // Keep the prompt tight — bid-phase tokens count against the per-task
+  // cost floor and Gemini Flash is the cheapest in the family. CLAUDE.md
+  // pegs the whole bid round at ~$0.0004 total across all four agents.
+  return `You estimate token cost for another model (Gemini 2.5 Pro) to complete a task.
+
+Task prompt:
+---
+${spec.prompt}
+---
+${spec.min_tier ? `Minimum tier requested by client: ${spec.min_tier}\n` : ""}${
+    spec.attachments?.length
+      ? `Attachments: ${spec.attachments.length} (referenced by content hash; agent must fetch if it bids)\n`
+      : ""
+  }
+Return JSON with conservative integer estimates:
+- est_input_tokens: tokens the prompt + system context + any tool calls would consume on input
+- est_output_tokens: tokens the model's response would generate`;
+}
+
+export class VertexBidEstimator implements BidEstimator {
+  constructor(private readonly client: GenerativeJsonClient) {}
+
+  async estimate(spec: TaskSpec): Promise<{ input_tokens: number; output_tokens: number }> {
+    const raw = await this.client.generateJson(buildPrompt(spec));
+    const parsed = EstimateResultSchema.parse(raw);
+    return {
+      input_tokens: parsed.est_input_tokens,
+      output_tokens: parsed.est_output_tokens,
+    };
+  }
+}
+
+// Production wiring: returns a GenerativeJsonClient backed by Vertex AI
+// Gemini Flash. The handler PR keeps this thin so the bulk of the bid
+// logic stays under unit test.
+export interface VertexJsonClientOptions {
+  project: string;
+  location: string;
+  model: string; // e.g. "gemini-2.5-flash"
+}
+
+export function createVertexJsonClient(opts: VertexJsonClientOptions): GenerativeJsonClient {
+  const vertex = new VertexAI({ project: opts.project, location: opts.location });
+  const model: GenerativeModel = vertex.getGenerativeModel({ model: opts.model });
+
+  return {
+    async generateJson(prompt: string): Promise<unknown> {
+      const result = await model.generateContent({
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+        generationConfig: {
+          responseMimeType: "application/json",
+          // @ts-expect-error responseSchema typing in the Vertex SDK is
+          // loose; we pass our concrete object literal directly.
+          responseSchema: ESTIMATE_RESPONSE_SCHEMA,
+        },
+      });
+      const candidate = result.response.candidates?.[0];
+      const text = candidate?.content?.parts?.[0]?.text;
+      if (!text) throw new Error("Vertex AI Gemini Flash returned no text");
+      return JSON.parse(text);
+    },
+  };
+}

--- a/agent/gcp-gemini/src/bid/handler.ts
+++ b/agent/gcp-gemini/src/bid/handler.ts
@@ -1,0 +1,83 @@
+import {
+  computeBidUsd,
+  type AnnounceRequest,
+  type Bid,
+  type BidResponse,
+  type PricingEntry,
+} from "@agent-tasker/protocol";
+import type { BidEstimator } from "./estimator.js";
+
+// Identity of this agent. Locked at the package level — the deployment shape
+// (per-project SA, per-service IAM Condition) enforces that this agent only
+// ever serves as "gcp-gemini"; the constant just keeps the bid envelope
+// honest.
+export const AGENT_ID = "gcp-gemini" as const;
+
+// Per CLAUDE.md → Per-cloud agent implementation: GCP/Gemini executes via
+// Gemini 2.5 Pro direct (no orchestration). Pinned per deployment, not in
+// code, but exposed here as the bid envelope's `model_id` for audit.
+export const EXECUTION_MODEL_ID = "gemini-2-5-pro";
+export const EXECUTION_MODEL_FAMILY = "gemini" as const;
+export const EXECUTION_TIER = "frontier" as const;
+
+// Validity window placed on each bid. CLAUDE.md → bidding protocol caps the
+// adaptive round at 5s; 60s gives the coordinator plenty of award headroom
+// without making stale bids honor-bound.
+const BID_TTL_MS = 60_000;
+
+export interface BidHandlerDeps {
+  estimator: BidEstimator;
+  // Pricing for the execution model. Today comes from FALLBACK_PRICING in
+  // /protocol; Firestore-sourced pricing arrives with #35–#41.
+  pricing: PricingEntry;
+  // Test seam — defaults to Date.now / crypto-random signature.
+  now?: () => Date;
+  sign?: (taskId: string) => string;
+}
+
+// Pure-of-side-effects-other-than-the-estimator handler. Hono wiring lives
+// in src/app.ts (forthcoming with the Cloud Run PR #61).
+export async function handleBid(req: AnnounceRequest, deps: BidHandlerDeps): Promise<BidResponse> {
+  const now = deps.now?.() ?? new Date();
+  try {
+    const { input_tokens, output_tokens } = await deps.estimator.estimate(req.spec);
+    const bidUsd = computeBidUsd({
+      est_input_tokens: input_tokens,
+      est_output_tokens: output_tokens,
+      price_in_usd_per_mtoken: deps.pricing.price_in_usd_per_mtoken,
+      price_out_usd_per_mtoken: deps.pricing.price_out_usd_per_mtoken,
+    });
+
+    const bid: Bid = {
+      task_id: req.task_id,
+      agent_id: AGENT_ID,
+      tier: EXECUTION_TIER,
+      model_family: EXECUTION_MODEL_FAMILY,
+      model_id: EXECUTION_MODEL_ID,
+      est_input_tokens: input_tokens,
+      est_output_tokens: output_tokens,
+      price_in_usd_per_mtoken: deps.pricing.price_in_usd_per_mtoken,
+      price_out_usd_per_mtoken: deps.pricing.price_out_usd_per_mtoken,
+      bid_usd: bidUsd,
+      expires_at: new Date(now.getTime() + BID_TTL_MS).toISOString(),
+      // Bid signing is a future PR — agents will run their own keypair and
+      // the coordinator will verify against an agent-side JWKS. For now,
+      // a stub keeps the schema satisfied and the coordinator is configured
+      // not to verify bid signatures.
+      signature: deps.sign?.(req.task_id) ?? "stub-signature",
+    };
+    return bid;
+  } catch (err) {
+    // Estimator failure is treated as a decline, not a hard error, so the
+    // round still settles. The reason code is the protocol's
+    // `internal_error`; richer diagnostic detail goes to logs (TODO with
+    // #73 structured logging).
+    void err;
+    return {
+      task_id: req.task_id,
+      agent_id: AGENT_ID,
+      status: "no_bid",
+      reason: "internal_error",
+    };
+  }
+}

--- a/agent/gcp-gemini/src/bid/index.ts
+++ b/agent/gcp-gemini/src/bid/index.ts
@@ -1,0 +1,2 @@
+export * from "./estimator.js";
+export * from "./handler.js";

--- a/agent/gcp-gemini/src/index.ts
+++ b/agent/gcp-gemini/src/index.ts
@@ -1,1 +1,1 @@
-export const AGENT_ID = "gcp-gemini";
+export * from "./bid/index.js";

--- a/agent/gcp-gemini/test/bid/handler.test.ts
+++ b/agent/gcp-gemini/test/bid/handler.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { AnnounceRequest, PricingEntry } from "@agent-tasker/protocol";
+import { handleBid } from "../../src/bid/handler.js";
+import type { BidEstimator } from "../../src/bid/estimator.js";
+
+const SPEC: AnnounceRequest["spec"] = { prompt: "summarize the transcript" };
+
+const PRICING: PricingEntry = {
+  model_id: "gemini-2-5-pro",
+  price_in_usd_per_mtoken: 1.25,
+  price_out_usd_per_mtoken: 10.0,
+  effective_date: "2026-05-15",
+};
+
+function stubEstimator(input_tokens: number, output_tokens: number): BidEstimator {
+  return {
+    async estimate() {
+      return { input_tokens, output_tokens };
+    },
+  };
+}
+
+function throwingEstimator(message: string): BidEstimator {
+  return {
+    async estimate() {
+      throw new Error(message);
+    },
+  };
+}
+
+describe("handleBid", () => {
+  it("returns a Bid with the right shape and computed USD when estimation succeeds", async () => {
+    const fixed = new Date("2026-05-21T12:00:00Z");
+    const res = await handleBid(
+      { task_id: "task-1", spec: SPEC },
+      {
+        estimator: stubEstimator(4000, 1000),
+        pricing: PRICING,
+        now: () => fixed,
+      },
+    );
+
+    if ("status" in res) throw new Error(`expected bid, got no_bid: ${res.reason}`);
+
+    expect(res.task_id).toBe("task-1");
+    expect(res.agent_id).toBe("gcp-gemini");
+    expect(res.tier).toBe("frontier");
+    expect(res.model_family).toBe("gemini");
+    expect(res.model_id).toBe("gemini-2-5-pro");
+    expect(res.est_input_tokens).toBe(4000);
+    expect(res.est_output_tokens).toBe(1000);
+    expect(res.price_in_usd_per_mtoken).toBe(1.25);
+    expect(res.price_out_usd_per_mtoken).toBe(10.0);
+    // 4000 / 1e6 * 1.25 + 1000 / 1e6 * 10 = 0.005 + 0.01 = 0.015
+    expect(res.bid_usd).toBeCloseTo(0.015, 10);
+    // expires_at = now + 60s
+    expect(res.expires_at).toBe("2026-05-21T12:01:00.000Z");
+    expect(res.signature).toBe("stub-signature");
+  });
+
+  it("uses a custom signer when provided", async () => {
+    const res = await handleBid(
+      { task_id: "task-sign", spec: SPEC },
+      {
+        estimator: stubEstimator(100, 50),
+        pricing: PRICING,
+        sign: (id) => `signed:${id}`,
+      },
+    );
+    if ("status" in res) throw new Error("expected bid");
+    expect(res.signature).toBe("signed:task-sign");
+  });
+
+  it("declines with internal_error when the estimator throws", async () => {
+    const res = await handleBid(
+      { task_id: "task-fail", spec: SPEC },
+      {
+        estimator: throwingEstimator("Vertex unavailable"),
+        pricing: PRICING,
+      },
+    );
+    if (!("status" in res)) throw new Error("expected no_bid");
+    expect(res.status).toBe("no_bid");
+    expect(res.reason).toBe("internal_error");
+    expect(res.agent_id).toBe("gcp-gemini");
+    expect(res.task_id).toBe("task-fail");
+  });
+
+  it("propagates minimum-tier spec field into the estimator without changing the bid envelope's tier", async () => {
+    // gcp-gemini always declares frontier (per CLAUDE.md tier mapping).
+    // The estimator may use min_tier to refine its estimate, but the bid's
+    // tier field is fixed.
+    let seenSpec: AnnounceRequest["spec"] | undefined;
+    const estimator: BidEstimator = {
+      async estimate(spec) {
+        seenSpec = spec;
+        return { input_tokens: 200, output_tokens: 50 };
+      },
+    };
+    const res = await handleBid(
+      { task_id: "t", spec: { prompt: "p", min_tier: "small" } },
+      { estimator, pricing: PRICING },
+    );
+    if ("status" in res) throw new Error("expected bid");
+    expect(seenSpec?.min_tier).toBe("small");
+    expect(res.tier).toBe("frontier");
+  });
+});

--- a/agent/gcp-gemini/tsconfig.build.json
+++ b/agent/gcp-gemini/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/agent/gcp-gemini/tsconfig.json
+++ b/agent/gcp-gemini/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -7,6 +7,7 @@ import {
   type JwtPhase,
   type PricingEntry,
   type TaskId,
+  type TaskSpec,
   isNoBid,
 } from "@agent-tasker/protocol";
 import type { LedgerStore } from "../ledger/store.js";
@@ -94,7 +95,7 @@ export class HttpAuctionRunner implements AuctionRunner {
       return;
     }
 
-    const responses = await this.gatherBids(taskId);
+    const responses = await this.gatherBids(taskId, task.spec);
     for (const response of responses) {
       await this.opts.store.recordBidResponse({
         taskId,
@@ -129,7 +130,7 @@ export class HttpAuctionRunner implements AuctionRunner {
     await this.opts.store.markExecuting(taskId);
 
     try {
-      const result = await this.execute(taskId, winner.agent_id);
+      const result = await this.execute(taskId, winner.agent_id, task.spec);
       await this.opts.store.completeTask({ taskId, result });
     } catch (err) {
       await this.opts.store.failTask({
@@ -143,9 +144,10 @@ export class HttpAuctionRunner implements AuctionRunner {
   // BidResponse per agent. Agents that error / time out / return junk are
   // translated to a synthetic `no_bid: internal_error` so the ledger has a
   // record per agent.
-  private async gatherBids(taskId: TaskId): Promise<BidResponse[]> {
+  private async gatherBids(taskId: TaskId, spec: TaskSpec): Promise<BidResponse[]> {
     const timeoutMs = this.opts.bidTimeoutMs ?? DEFAULT_BID_TIMEOUT_MS;
     const fetchImpl = this.opts.fetch ?? fetch;
+    const body = JSON.stringify({ task_id: taskId, spec });
     return Promise.all(
       this.opts.agents.map(async (agent): Promise<BidResponse> => {
         try {
@@ -164,7 +166,7 @@ export class HttpAuctionRunner implements AuctionRunner {
                 "content-type": "application/json",
                 authorization: `Bearer ${token}`,
               },
-              body: JSON.stringify({ task_id: taskId }),
+              body,
               signal: controller.signal,
             });
           } finally {
@@ -173,8 +175,8 @@ export class HttpAuctionRunner implements AuctionRunner {
           if (!res.ok) {
             return syntheticNoBid(taskId, agent.agentId, `agent returned ${res.status}`);
           }
-          const body = (await res.json()) as unknown;
-          const parsed = BidResponseSchema.safeParse(body);
+          const responseBody = (await res.json()) as unknown;
+          const parsed = BidResponseSchema.safeParse(responseBody);
           if (!parsed.success) {
             return syntheticNoBid(taskId, agent.agentId, "malformed bid response");
           }
@@ -192,7 +194,7 @@ export class HttpAuctionRunner implements AuctionRunner {
     );
   }
 
-  private async execute(taskId: TaskId, agentId: AgentId) {
+  private async execute(taskId: TaskId, agentId: AgentId, spec: TaskSpec) {
     const agent = this.opts.agents.find((a) => a.agentId === agentId);
     if (!agent) {
       throw new Error(`winner ${agentId} not in agent registry`);
@@ -210,7 +212,7 @@ export class HttpAuctionRunner implements AuctionRunner {
           "content-type": "application/json",
           authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ task_id: taskId }),
+        body: JSON.stringify({ task_id: taskId, spec }),
         signal: controller.signal,
       });
     } finally {

--- a/coordinator/test/integration/fake-agent.test.ts
+++ b/coordinator/test/integration/fake-agent.test.ts
@@ -7,6 +7,14 @@ afterEach(async () => {
   if (agent) await agent.stop();
 });
 
+// All POSTs include a minimal valid spec — that's the new contract since
+// the runner forwards the announce body so agents can estimate without
+// round-tripping back to the coordinator.
+const ANNOUNCE_BODY = JSON.stringify({
+  task_id: "t-1",
+  spec: { prompt: "summarize the transcript" },
+});
+
 describe("FakeAgent", () => {
   beforeEach(async () => {
     agent = await startFakeAgent({ agentId: "gcp-gemini" });
@@ -22,7 +30,7 @@ describe("FakeAgent", () => {
     const res = await fetch(`${agent.url}/bid`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ task_id: "t-1" }),
+      body: ANNOUNCE_BODY,
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
@@ -38,7 +46,7 @@ describe("FakeAgent", () => {
     const res = await fetch(`${agent.url}/execute`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ task_id: "t-1" }),
+      body: ANNOUNCE_BODY,
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
@@ -48,24 +56,33 @@ describe("FakeAgent", () => {
     });
     expect(agent.executeCalls).toBe(1);
   });
+
+  it("rejects requests missing the spec field with 400", async () => {
+    const res = await fetch(`${agent.url}/bid`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task_id: "t-no-spec" }),
+    });
+    expect(res.status).toBe(400);
+  });
 });
 
 describe("FakeAgent with overrides", () => {
-  it("custom onBid returns a real bid", async () => {
+  it("custom onBid receives the parsed spec and returns a real bid", async () => {
     agent = await startFakeAgent({
       agentId: "aws-nova",
-      onBid: (taskId) => ({
-        task_id: taskId,
+      onBid: (req) => ({
+        task_id: req.task_id,
         agent_id: "aws-nova",
         tier: "frontier",
         model_family: "nova",
         model_id: "amazon.nova-pro",
-        est_input_tokens: 1000,
+        est_input_tokens: req.spec.prompt.length, // proves spec is parsed
         est_output_tokens: 500,
         price_in_usd_per_mtoken: 0.8,
         price_out_usd_per_mtoken: 3.2,
         bid_usd: 0.0024,
-        expires_at: "2026-05-20T13:00:00Z",
+        expires_at: "2026-05-21T01:00:00Z",
         signature: "stub",
       }),
     });
@@ -73,12 +90,16 @@ describe("FakeAgent with overrides", () => {
     const res = await fetch(`${agent.url}/bid`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ task_id: "t-2" }),
+      body: JSON.stringify({
+        task_id: "t-2",
+        spec: { prompt: "hi" },
+      }),
     });
     expect(await res.json()).toMatchObject({
       agent_id: "aws-nova",
       tier: "frontier",
       bid_usd: 0.0024,
+      est_input_tokens: 2,
     });
   });
 });

--- a/coordinator/test/integration/fake-agent.ts
+++ b/coordinator/test/integration/fake-agent.ts
@@ -1,28 +1,33 @@
 import { serve, type ServerType } from "@hono/node-server";
 import type { AddressInfo } from "node:net";
 import { Hono } from "hono";
-import type { AgentId, BidResponse, Result } from "@agent-tasker/protocol";
+import {
+  AnnounceRequestSchema,
+  ExecuteRequestSchema,
+  type AgentId,
+  type AnnounceRequest,
+  type BidResponse,
+  type ExecuteRequest,
+  type Result,
+} from "@agent-tasker/protocol";
 
-// Stand-in agent server. The real AuctionRunner (#47 + #52 + #53) will
-// POST to /bid and /execute on each agent's base URL; this harness lets
-// us stand up a configurable fake on an ephemeral port and assert on what
-// the runner did. Today it has no consumer in coordinator/ but the unit
-// tests in fake-agent.test.ts pin its behavior so the harness is ready
-// to drop in when the real runner lands.
+// Stand-in agent server. The real `HttpAuctionRunner` POSTs to /bid and
+// /execute on each agent's base URL with `{ task_id, spec }` bodies; this
+// harness lets tests stand up a configurable fake on an ephemeral port
+// and assert on what the runner did.
 
 export interface FakeAgentOptions {
   agentId: AgentId;
-  // Bid handler. Called with the announced taskId. Default: declines.
-  onBid?: (taskId: string) => BidResponse;
-  // Execute handler. Called with the awarded taskId. Default: returns a
-  // canned successful result.
-  onExecute?: (taskId: string) => Result;
+  // Bid handler. Receives the validated announce request. Default: declines.
+  onBid?: (req: AnnounceRequest) => BidResponse | Promise<BidResponse>;
+  // Execute handler. Receives the validated execute request. Default:
+  // returns a canned successful result.
+  onExecute?: (req: ExecuteRequest) => Result | Promise<Result>;
 }
 
 export interface FakeAgent {
   readonly agentId: AgentId;
   readonly url: string;
-  // Number of /bid and /execute calls observed. Reset per instance.
   bidCalls: number;
   executeCalls: number;
   stop(): Promise<void>;
@@ -34,8 +39,8 @@ export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent>
 
   const onBid =
     opts.onBid ??
-    ((taskId: string): BidResponse => ({
-      task_id: taskId,
+    ((req: AnnounceRequest): BidResponse => ({
+      task_id: req.task_id,
       agent_id: agentId,
       status: "no_bid",
       reason: "capability",
@@ -43,8 +48,8 @@ export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent>
 
   const onExecute =
     opts.onExecute ??
-    ((taskId: string): Result => ({
-      task_id: taskId,
+    ((req: ExecuteRequest): Result => ({
+      task_id: req.task_id,
       agent_id: agentId,
       output: `stub output from ${agentId}`,
       actual_usage: { input_tokens: 100, output_tokens: 50 },
@@ -55,16 +60,18 @@ export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent>
 
   app.post("/bid", async (c) => {
     state.bidCalls += 1;
-    const body = (await c.req.json()) as { task_id?: string };
-    if (!body.task_id) return c.json({ error: "task_id required" }, 400);
-    return c.json(onBid(body.task_id));
+    const body = (await c.req.json()) as unknown;
+    const parsed = AnnounceRequestSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid request" }, 400);
+    return c.json(await onBid(parsed.data));
   });
 
   app.post("/execute", async (c) => {
     state.executeCalls += 1;
-    const body = (await c.req.json()) as { task_id?: string };
-    if (!body.task_id) return c.json({ error: "task_id required" }, 400);
-    return c.json(onExecute(body.task_id));
+    const body = (await c.req.json()) as unknown;
+    const parsed = ExecuteRequestSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid request" }, 400);
+    return c.json(await onExecute(parsed.data));
   });
 
   const server: ServerType = await new Promise((resolve) => {

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -91,9 +91,9 @@ describe("HttpAuctionRunner", () => {
     const taskId = "task-happy-1";
     const gemini = await startFakeAgent({
       agentId: "gcp-gemini",
-      onBid: (id) => bidFor("gcp-gemini", 0.02, id),
-      onExecute: (id) => ({
-        task_id: id,
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
         agent_id: "gcp-gemini",
         output: "gemini did it",
         actual_usage: { input_tokens: 4100, output_tokens: 950 },
@@ -101,7 +101,7 @@ describe("HttpAuctionRunner", () => {
     });
     const nova = await startFakeAgent({
       agentId: "aws-nova",
-      onBid: (id) => bidFor("aws-nova", 0.04, id),
+      onBid: (req) => bidFor("aws-nova", 0.04, req.task_id),
     });
     agents.push(gemini, nova);
 
@@ -138,7 +138,7 @@ describe("HttpAuctionRunner", () => {
     const taskId = "task-single";
     const gemini = await startFakeAgent({
       agentId: "gcp-gemini",
-      onBid: (id) => bidFor("gcp-gemini", 0.02, id),
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
     });
     const nova = await startFakeAgent({
       agentId: "aws-nova",
@@ -170,8 +170,8 @@ describe("HttpAuctionRunner", () => {
     const taskId = "task-all-decline";
     const gemini = await startFakeAgent({
       agentId: "gcp-gemini",
-      onBid: (id): BidResponse => ({
-        task_id: id,
+      onBid: (req): BidResponse => ({
+        task_id: req.task_id,
         agent_id: "gcp-gemini",
         status: "no_bid",
         reason: "context_overflow",
@@ -179,8 +179,8 @@ describe("HttpAuctionRunner", () => {
     });
     const nova = await startFakeAgent({
       agentId: "aws-nova",
-      onBid: (id): BidResponse => ({
-        task_id: id,
+      onBid: (req): BidResponse => ({
+        task_id: req.task_id,
         agent_id: "aws-nova",
         status: "no_bid",
         reason: "policy",
@@ -206,7 +206,7 @@ describe("HttpAuctionRunner", () => {
     const taskId = "task-unreachable";
     const gemini = await startFakeAgent({
       agentId: "gcp-gemini",
-      onBid: (id) => bidFor("gcp-gemini", 0.02, id),
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
     });
     agents.push(gemini);
 
@@ -233,7 +233,7 @@ describe("HttpAuctionRunner", () => {
     const taskId = "task-execute-fail";
     const gemini = await startFakeAgent({
       agentId: "gcp-gemini",
-      onBid: (id) => bidFor("gcp-gemini", 0.02, id),
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
       onExecute: () => {
         throw new Error("model overloaded");
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
       '@agent-tasker/protocol':
         specifier: workspace:*
         version: link:../../protocol
+      '@google-cloud/vertexai':
+        specifier: ^1.12.0
+        version: 1.12.0
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   agent/gcp-orchestrator:
     dependencies:
@@ -188,6 +194,19 @@ packages:
   '@google-cloud/firestore@8.6.0':
     resolution: {integrity: sha512-TdvZHfwQj5B5CSDEgDqyrhdVqtOSupmBXDQPasMAJiC64tjsGvyMooNiC43fdk1TsUHeklyoZ6/vQ1TjWKVMbg==}
     engines: {node: '>=18'}
+
+  '@google-cloud/vertexai@1.12.0':
+    resolution: {integrity: sha512-XMJIk7GIeavFLP5A3YEUlowKa5Y5PZRrnnuTJcqR0k+lFKkv7+IWpdRp+Xbqb8xNDrvQaE2hP2RYPUylyD5EdA==}
+    engines: {node: '>=18.0.0'}
+
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -432,6 +451,9 @@ packages:
 
   '@types/node@22.19.18':
     resolution: {integrity: sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@typescript-eslint/eslint-plugin@8.59.4':
     resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
@@ -785,9 +807,17 @@ packages:
   functional-red-black-tree@1.0.1:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
 
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
@@ -814,13 +844,25 @@ packages:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
   google-gax@5.0.6:
     resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
     engines: {node: '>=18'}
 
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   hono@4.12.21:
     resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
@@ -869,6 +911,10 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1039,6 +1085,15 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1068,6 +1123,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1134,6 +1193,10 @@ packages:
   retry-request@8.0.2:
     resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -1247,6 +1310,9 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -1288,6 +1354,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vite@8.0.13:
     resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
@@ -1377,6 +1448,12 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1409,6 +1486,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -1495,6 +1584,28 @@ snapshots:
       protobufjs: 7.6.0
     transitivePeerDependencies:
       - supports-color
+
+  '@google-cloud/vertexai@1.12.0':
+    dependencies:
+      '@google/genai': 1.52.0
+      google-auth-library: 9.15.1
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.6.0
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@grpc/grpc-js@1.14.3':
     dependencies:
@@ -1669,6 +1780,8 @@ snapshots:
   '@types/node@22.19.18':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/retry@0.12.0': {}
 
   '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)':
     dependencies:
@@ -2046,12 +2159,32 @@ snapshots:
 
   functional-red-black-tree@1.0.1: {}
 
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
     transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
       - supports-color
 
   gcp-metadata@8.1.2:
@@ -2090,6 +2223,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   google-gax@5.0.6:
     dependencies:
       '@grpc/grpc-js': 1.14.3
@@ -2106,7 +2251,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-logging-utils@0.0.2: {}
+
   google-logging-utils@1.1.3: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   hono@4.12.21: {}
 
@@ -2145,6 +2300,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -2294,6 +2451,10 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -2328,6 +2489,11 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -2396,6 +2562,8 @@ snapshots:
       teeny-request: 10.1.2
     transitivePeerDependencies:
       - supports-color
+
+  retry@0.13.1: {}
 
   rfdc@1.4.1: {}
 
@@ -2519,6 +2687,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tr46@0.0.3: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -2562,6 +2732,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@9.0.1: {}
+
   vite@8.0.13(@types/node@22.19.18)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -2604,6 +2776,13 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2640,6 +2819,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.20.1: {}
 
   y18n@5.0.8: {}
 

--- a/protocol/src/schemas.ts
+++ b/protocol/src/schemas.ts
@@ -118,3 +118,18 @@ export type TaskStatus = z.infer<typeof TaskStatusSchema>;
 export const JWT_PHASES = ["bid", "award", "execute", "reject"] as const;
 export const JwtPhaseSchema = z.enum(JWT_PHASES);
 export type JwtPhase = z.infer<typeof JwtPhaseSchema>;
+
+// Wire shapes the coordinator sends to each agent. JWT (auth, phase) goes
+// in the Authorization header; the body carries the task_id + spec so the
+// agent can bid/execute without round-tripping back to the coordinator.
+export const AnnounceRequestSchema = z.object({
+  task_id: TaskIdSchema,
+  spec: TaskSpecSchema,
+});
+export type AnnounceRequest = z.infer<typeof AnnounceRequestSchema>;
+
+export const ExecuteRequestSchema = z.object({
+  task_id: TaskIdSchema,
+  spec: TaskSpecSchema,
+});
+export type ExecuteRequest = z.infer<typeof ExecuteRequestSchema>;


### PR DESCRIPTION
## Summary
The bid handler is what `/bid` actually does once the JWT middleware (#62) has cleared the request. Estimator predicts token usage for the execution model (Gemini 2.5 Pro); handler converts those tokens plus the current pricing entry into a structured `Bid` envelope, or returns a `no_bid: internal_error` decline if the estimator throws.

### `agent/gcp-gemini` layout
- **`src/bid/estimator.ts`** — `BidEstimator` interface; production `VertexBidEstimator` talks to Gemini Flash via a thin `GenerativeJsonClient` seam so tests inject canned token counts without touching Vertex. `createVertexJsonClient(opts)` wires `@google-cloud/vertexai` and asks Gemini to return JSON via `responseSchema` (no free-form parsing).
- **`src/bid/handler.ts`** — `handleBid(req, deps)` → structured `Bid` via `computeBidUsd(tokens × prices)`. `tier` always `frontier` per CLAUDE.md (gcp-gemini's execution model is Gemini 2.5 Pro). Estimator failures map to `NoBid{internal_error}` so the bidding round still settles. Exports `AGENT_ID` / `EXECUTION_MODEL_ID` / `EXECUTION_MODEL_FAMILY` / `EXECUTION_TIER` for the Cloud Run wiring (#61) and e2e test (#98) to share.

### Tests (4 cases, vitest)
- happy path: bid envelope + computed USD + 60s TTL
- custom signature injection
- estimator throws → `no_bid{internal_error}`
- `spec.min_tier` flows to estimator but doesn't change the bid envelope's tier

### Protocol extensions
- `AnnounceRequestSchema { task_id, spec }` and `ExecuteRequestSchema { task_id, spec }` added to `/protocol/src/schemas.ts`. CLAUDE.md says the coordinator includes the spec in announce so agents don't round-trip — runner now does.

### Runner + harness updated
- `HttpAuctionRunner` sends `{ task_id, spec }` as the body of both `/bid` and `/execute`. Pricing snapshot stays runner-side (recorded per-bid in the ledger for replay).
- `FakeAgent` `/bid` + `/execute` now validate via the new schemas and pass the parsed request to `onBid`/`onExecute` (was a bare `task_id`). All existing call sites updated.

### Repo plumbing
- `agent/gcp-gemini` adopts the standard tsconfig split (build vs test+IDE) and gains `test`: vitest run
- Deps: `@google-cloud/vertexai`, `zod` (pinned to `^3` to match `/protocol`)

Closes #63

## Test plan
- [x] 4 new tests + all existing tests pass (52 in coordinator, 12 in agent, 4 in agent-gcp-gemini)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm build` all clean
- [ ] CI green
- [ ] Manual smoke test against real Vertex AI deferred to e2e PR (#98)

🤖 Generated with [Claude Code](https://claude.com/claude-code)