### PR TITLE
GCP/Gemini execute handler: direct Gemini 2.5 Pro call (#64)

### DIFF
--- a/agent/gcp-gemini/src/execute/handler.ts
+++ b/agent/gcp-gemini/src/execute/handler.ts
@@ -1,0 +1,33 @@
+import type { ExecuteRequest, Result } from "@agent-tasker/protocol";
+import { AGENT_ID } from "../bid/handler.js";
+import type { GenerativeTextClient } from "./runner.js";
+
+export interface ExecuteHandlerDeps {
+  client: GenerativeTextClient;
+}
+
+// Direct single-call execution against Gemini 2.5 Pro. Unlike the bid
+// handler, execute does NOT have a graceful fallback — if the model call
+// fails, the error bubbles to the Hono handler which surfaces a 500;
+// the coordinator's HttpAuctionRunner then records failTask with a
+// reason mentioning this agent (covered by the runner's existing tests).
+//
+// `actual_usage` comes from Vertex's usageMetadata, so accuracy of MAPE
+// rollups depends on Google reporting honest counts. For the orchestrator
+// agent (#94) this gets more complicated — token counts have to be summed
+// across all GAEP steps.
+export async function handleExecute(
+  req: ExecuteRequest,
+  deps: ExecuteHandlerDeps,
+): Promise<Result> {
+  const { output, input_tokens, output_tokens } = await deps.client.generate(req.spec.prompt);
+  return {
+    task_id: req.task_id,
+    agent_id: AGENT_ID,
+    output,
+    actual_usage: {
+      input_tokens,
+      output_tokens,
+    },
+  };
+}

--- a/agent/gcp-gemini/src/execute/index.ts
+++ b/agent/gcp-gemini/src/execute/index.ts
@@ -1,0 +1,2 @@
+export * from "./runner.js";
+export * from "./handler.js";

--- a/agent/gcp-gemini/src/execute/runner.ts
+++ b/agent/gcp-gemini/src/execute/runner.ts
@@ -1,0 +1,49 @@
+import { VertexAI, type GenerativeModel } from "@google-cloud/vertexai";
+
+// Minimal surface the handler needs from the underlying model client.
+// Production wires this against @google-cloud/vertexai; tests inject a
+// stub that returns canned output + usage so they don't need network.
+export interface GenerativeTextClient {
+  generate(prompt: string): Promise<{
+    output: string;
+    input_tokens: number;
+    output_tokens: number;
+  }>;
+}
+
+export interface VertexTextClientOptions {
+  project: string;
+  location: string;
+  model: string; // e.g. "gemini-2.5-pro"
+}
+
+// Production wiring: direct single-call to Gemini 2.5 Pro. No tool use,
+// no multi-step orchestration — that's the orchestrator agent's
+// (#90-#95) job. CLAUDE.md → Per-cloud agent implementation pins this
+// agent to the direct SDK only.
+export function createVertexTextClient(opts: VertexTextClientOptions): GenerativeTextClient {
+  const vertex = new VertexAI({ project: opts.project, location: opts.location });
+  const model: GenerativeModel = vertex.getGenerativeModel({ model: opts.model });
+
+  return {
+    async generate(prompt: string) {
+      const result = await model.generateContent({
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+      });
+      const candidate = result.response.candidates?.[0];
+      const text = candidate?.content?.parts?.[0]?.text;
+      if (text === undefined) {
+        throw new Error("Vertex AI Gemini 2.5 Pro returned no text");
+      }
+      const usage = result.response.usageMetadata;
+      if (!usage) {
+        throw new Error("Vertex AI response missing usageMetadata");
+      }
+      return {
+        output: text,
+        input_tokens: usage.promptTokenCount ?? 0,
+        output_tokens: usage.candidatesTokenCount ?? 0,
+      };
+    },
+  };
+}

--- a/agent/gcp-gemini/src/index.ts
+++ b/agent/gcp-gemini/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./bid/index.js";
+export * from "./execute/index.js";

--- a/agent/gcp-gemini/test/execute/handler.test.ts
+++ b/agent/gcp-gemini/test/execute/handler.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { ExecuteRequest } from "@agent-tasker/protocol";
+import { handleExecute } from "../../src/execute/handler.js";
+import type { GenerativeTextClient } from "../../src/execute/runner.js";
+
+const REQ: ExecuteRequest = {
+  task_id: "task-exec-1",
+  spec: { prompt: "summarize the transcript" },
+};
+
+function stubClient(
+  output: string,
+  input_tokens: number,
+  output_tokens: number,
+): GenerativeTextClient {
+  return {
+    async generate() {
+      return { output, input_tokens, output_tokens };
+    },
+  };
+}
+
+function recordingClient(): { client: GenerativeTextClient; promptSeen: string[] } {
+  const seen: string[] = [];
+  return {
+    promptSeen: seen,
+    client: {
+      async generate(prompt) {
+        seen.push(prompt);
+        return { output: "ok", input_tokens: 10, output_tokens: 5 };
+      },
+    },
+  };
+}
+
+describe("handleExecute", () => {
+  it("returns a Result envelope with output + actual usage", async () => {
+    const res = await handleExecute(REQ, {
+      client: stubClient("the summary text", 4100, 950),
+    });
+
+    expect(res.task_id).toBe("task-exec-1");
+    expect(res.agent_id).toBe("gcp-gemini");
+    expect(res.output).toBe("the summary text");
+    expect(res.actual_usage).toEqual({ input_tokens: 4100, output_tokens: 950 });
+  });
+
+  it("forwards the spec prompt verbatim to the client", async () => {
+    const { client, promptSeen } = recordingClient();
+    await handleExecute(REQ, { client });
+    expect(promptSeen).toEqual(["summarize the transcript"]);
+  });
+
+  it("propagates client errors (the coordinator decides whether to re-auction)", async () => {
+    const client: GenerativeTextClient = {
+      async generate() {
+        throw new Error("model overloaded");
+      },
+    };
+    await expect(handleExecute(REQ, { client })).rejects.toThrow(/model overloaded/);
+  });
+});


### PR DESCRIPTION
## Summary
Symmetric to the bid handler (#63): a thin `GenerativeTextClient` seam over `@google-cloud/vertexai`, plus a `handleExecute(req, deps)` function that wraps a single-call generation in the protocol's `Result` envelope.

### Layout (`agent/gcp-gemini/`)
- **`src/execute/runner.ts`** — `GenerativeTextClient` interface; `generate(prompt)` returns `{ output, input_tokens, output_tokens }` from Vertex's `usageMetadata`. `createVertexTextClient` wires the SDK against a configurable project/location/model (production pins `gemini-2.5-pro` per CLAUDE.md).
- **`src/execute/handler.ts`** — `handleExecute(req, deps)` → `Result`. Reads `req.spec.prompt`, delegates to the client, attaches `AGENT_ID` + `actual_usage`. **Failures propagate** — unlike bid, there is no graceful `no_bid` fallback; the coordinator's `HttpAuctionRunner` already handles execute failures by recording `failTask`.

Per CLAUDE.md → Per-cloud agent implementation: this agent is deliberately direct-SDK only. Tool use / multi-step orchestration is the GAEP-backed orchestrator agent's job (#90–#95).

### Tests (3 cases, vitest)
- happy path: `Result` envelope shape, output + `actual_usage`
- forwards `spec.prompt` verbatim to the client
- client errors propagate (so the coordinator can fail the task)

`agent-gcp-gemini` total: **7 tests across 2 files**, all green.

Closes #64

## Test plan
- [x] 3 new tests + all existing tests pass
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm build` all clean
- [ ] CI green
- [ ] Manual smoke test against real Vertex AI deferred to e2e PR (#98)

🤖 Generated with [Claude Code](https://claude.com/claude-code)