### PR TITLE
Terraform: pricing-refresh Cloud Function + Scheduler (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ override.tf.json
 *_override.tf.json
 .terraformrc
 terraform.rc
+
+# function-source archives produced by hashicorp/archive_file at plan time
+infra/**/functions/**/.dist/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
@@ -8,5 +9,15 @@ export default tseslint.config(
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,
+  // Cloud Function sources are CommonJS Node modules deployed straight to
+  // GCP — not part of the workspace TS build. Give them Node globals so
+  // `exports` / `console` / `Buffer` don't trip no-undef.
+  {
+    files: ["infra/**/functions/**/*.js"],
+    languageOptions: {
+      sourceType: "commonjs",
+      globals: { ...globals.node },
+    },
+  },
   prettier,
 );

--- a/infra/coordinator/.terraform.lock.hcl
+++ b/infra/coordinator/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.6"
+  hashes = [
+    "h1:oRWx6ZDIdlNBF90L8TzV9X7pQ+P403hoCDiBfmUfhC0=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "6.50.0"
   constraints = "~> 6.10"

--- a/infra/coordinator/functions/pricing-refresh/index.js
+++ b/infra/coordinator/functions/pricing-refresh/index.js
@@ -1,0 +1,19 @@
+// Placeholder daily pricing-refresh handler. Real implementation that pulls
+// from the Cloud Billing Catalog and writes Firestore /pricing snapshots
+// lands with #38; this stub only exists so #35's Terraform has something to
+// deploy and the Cloud Scheduler trigger can be smoke-tested end-to-end.
+//
+// HTTP-triggered gen-2 Cloud Function. Cloud Scheduler invokes it daily
+// with an OIDC token (verified by Cloud Run's IAM layer before reaching
+// this handler).
+
+exports.refreshPricing = (req, res) => {
+  console.log(
+    JSON.stringify({
+      msg: "pricing-refresh stub invoked",
+      method: req.method,
+      ts: new Date().toISOString(),
+    }),
+  );
+  res.status(200).send("stub");
+};

--- a/infra/coordinator/functions/pricing-refresh/package.json
+++ b/infra/coordinator/functions/pricing-refresh/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@agent-tasker/pricing-refresh",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Daily pricing refresh Cloud Function — placeholder source until #38 lands the Cloud Billing Catalog parser.",
+  "main": "index.js",
+  "engines": {
+    "node": "22"
+  },
+  "dependencies": {}
+}

--- a/infra/coordinator/outputs.tf
+++ b/infra/coordinator/outputs.tf
@@ -32,3 +32,13 @@ output "coordinator_image_repo" {
   description = "Artifact Registry path agent CI/CD pushes coordinator images to. Format: LOCATION-docker.pkg.dev/PROJECT/REPO."
   value       = "${google_artifact_registry_repository.coordinator.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.coordinator.repository_id}"
 }
+
+output "pricing_refresh_function_url" {
+  description = "HTTPS URL of the pricing-refresh Cloud Function. Useful for ad-hoc invocation via `gcloud functions call` or for issuing OIDC-signed curls when debugging."
+  value       = google_cloudfunctions2_function.pricing_refresh.service_config[0].uri
+}
+
+output "pricing_refresh_runtime_service_account_email" {
+  description = "Pricing-refresh function runtime SA. #38 adds roles/billing.viewer to this principal so the Cloud Billing Catalog parser can fetch SKUs."
+  value       = google_service_account.pricing_refresh_runtime.email
+}

--- a/infra/coordinator/pricing_refresh.tf
+++ b/infra/coordinator/pricing_refresh.tf
@@ -1,0 +1,173 @@
+# Daily pricing-refresh Cloud Function + Cloud Scheduler trigger.
+#
+# Source today is a placeholder (functions/pricing-refresh/index.js) that
+# logs and returns "stub". Real handler lands with #38 — Cloud Billing
+# Catalog parsing + Firestore /pricing writes. The Terraform shape is
+# unchanged when the source is swapped: only the archive_file picks up
+# new bytes and triggers a redeploy via the hashed object name.
+#
+# Flow:
+#   Cloud Scheduler --(OIDC)--> CF2 HTTP URL --> refreshPricing()
+#   refreshPricing() reads Cloud Billing Catalog, writes Firestore docs.
+#
+# Both runtime and scheduler get dedicated SAs (separate from the
+# coordinator runtime SA). The runtime SA writes Firestore; the
+# scheduler SA holds the invoker permission on the function. Neither
+# can do the other's job.
+
+# Source bucket for function zips. Lifecycle keeps only the most recent
+# 10 archived versions — function deploys are infrequent (~weekly when
+# Tier 5 lands) but a stale zip is cheap to keep around for one-step
+# rollback.
+resource "google_storage_bucket" "functions_source" {
+  project = var.project_id
+
+  name     = "${local.name_prefix}-functions-source-${var.project_id}"
+  location = var.region
+
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    condition {
+      num_newer_versions = 10
+      with_state         = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  force_destroy = !var.pricing_refresh_delete_protection
+}
+
+# Zip the placeholder source. output_md5 is part of the bucket object
+# name so any change to the source forces a new upload + function redeploy.
+data "archive_file" "pricing_refresh_source" {
+  type        = "zip"
+  source_dir  = "${path.module}/functions/pricing-refresh"
+  output_path = "${path.module}/functions/.dist/pricing-refresh.zip"
+}
+
+resource "google_storage_bucket_object" "pricing_refresh_source" {
+  name   = "pricing-refresh-${data.archive_file.pricing_refresh_source.output_md5}.zip"
+  bucket = google_storage_bucket.functions_source.name
+  source = data.archive_file.pricing_refresh_source.output_path
+}
+
+# Runtime SA — Firestore writer (for the /pricing collection) plus log
+# writer. #38 will add roles/billing.viewer for Cloud Billing Catalog
+# reads; left out today so the placeholder's least-privilege deploy is
+# the actual minimum.
+resource "google_service_account" "pricing_refresh_runtime" {
+  project      = var.project_id
+  account_id   = "${local.name_prefix}-pricing-refresh"
+  display_name = "Pricing-refresh function runtime SA"
+  description  = "Identity for the daily pricing-refresh Cloud Function — writes Firestore /pricing"
+}
+
+resource "google_project_iam_member" "pricing_refresh_firestore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.pricing_refresh_runtime.email}"
+}
+
+resource "google_project_iam_member" "pricing_refresh_logs" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.pricing_refresh_runtime.email}"
+}
+
+# Scheduler SA — holds run.invoker on the function and nothing else.
+# Kept separate from the runtime SA so a compromised scheduler config
+# can't write Firestore.
+resource "google_service_account" "pricing_refresh_scheduler" {
+  project      = var.project_id
+  account_id   = "${local.name_prefix}-pricing-sched"
+  display_name = "Pricing-refresh scheduler SA"
+  description  = "Identity Cloud Scheduler assumes when invoking the pricing-refresh function"
+}
+
+resource "google_cloudfunctions2_function" "pricing_refresh" {
+  project  = var.project_id
+  location = var.region
+  name     = "${local.name_prefix}-pricing-refresh"
+
+  build_config {
+    runtime     = "nodejs22"
+    entry_point = "refreshPricing"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions_source.name
+        object = google_storage_bucket_object.pricing_refresh_source.name
+      }
+    }
+  }
+
+  service_config {
+    service_account_email = google_service_account.pricing_refresh_runtime.email
+
+    available_memory   = "256Mi"
+    timeout_seconds    = 540 # 9 min — vendor APIs can be slow during burst
+    max_instance_count = 1   # one daily run; no concurrency benefit
+    min_instance_count = 0   # scale to zero between runs
+
+    # Function URL is reachable only by callers that hold run.invoker IAM,
+    # so even with all-traffic ingress, only the scheduler SA can invoke.
+    # Keep ingress all so we can curl-invoke for ad-hoc smoke testing
+    # using gcloud-minted OIDC tokens. Tighten to internal-only if a
+    # follow-up requires it.
+    ingress_settings = "ALLOW_ALL"
+
+    environment_variables = {
+      GCP_PROJECT_ID = var.project_id
+    }
+  }
+
+  depends_on = [
+    google_project_iam_member.pricing_refresh_firestore,
+    google_project_iam_member.pricing_refresh_logs,
+  ]
+}
+
+# Scheduler SA gets invoker on the underlying Cloud Run service that
+# backs the gen-2 function. (gen-2 functions ARE Cloud Run services
+# under the hood; the cloudfunctions.invoker role is gen-1 only.)
+resource "google_cloud_run_v2_service_iam_member" "pricing_refresh_scheduler_invoker" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloudfunctions2_function.pricing_refresh.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.pricing_refresh_scheduler.email}"
+}
+
+resource "google_cloud_scheduler_job" "pricing_refresh" {
+  project = var.project_id
+  region  = var.region
+  name    = "${local.name_prefix}-pricing-refresh"
+
+  schedule  = var.pricing_refresh_schedule
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = google_cloudfunctions2_function.pricing_refresh.service_config[0].uri
+    http_method = "POST"
+
+    oidc_token {
+      service_account_email = google_service_account.pricing_refresh_scheduler.email
+      # audience must match the function URL for Cloud Run to accept it.
+      audience = google_cloudfunctions2_function.pricing_refresh.service_config[0].uri
+    }
+  }
+
+  retry_config {
+    retry_count          = 1
+    max_retry_duration   = "600s"
+    min_backoff_duration = "60s"
+    max_backoff_duration = "300s"
+    max_doublings        = 2
+  }
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -84,3 +84,15 @@ variable "coordinator_delete_protection" {
   type        = bool
   default     = false
 }
+
+variable "pricing_refresh_schedule" {
+  description = "Cron expression (Etc/UTC) for the daily pricing-refresh job. Default 04:00 UTC — overnight in the Americas, mid-morning in EU, low coordinator traffic everywhere."
+  type        = string
+  default     = "0 4 * * *"
+}
+
+variable "pricing_refresh_delete_protection" {
+  description = "Whether `terraform destroy` is allowed to delete the function-source bucket. False in dev (rapid iteration); true in prod (rollback-from-archived-version is the recovery path)."
+  type        = bool
+  default     = false
+}

--- a/infra/coordinator/versions.tf
+++ b/infra/coordinator/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "~> 6.10"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.6"
+    }
   }
 
   # Backend is left as a partial config so each environment supplies its own

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^22.18.10",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.6.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
     "prettier": "^3.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.4.0)
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -852,6 +855,10 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+    engines: {node: '>=18'}
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
@@ -2224,6 +2231,8 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  globals@17.6.0: {}
 
   google-auth-library@10.6.2:
     dependencies:


### PR DESCRIPTION
## Summary
Infra-only PR. Provisions the daily-trigger plumbing so #38's real Cloud Billing Catalog parser can be a thin source-code swap behind an already-deployed function.

### What lands
- **`functions/pricing-refresh/{index.js,package.json}`** — placeholder Node 22 HTTP handler that logs and returns "stub". Real handler replaces this in #38; the `archive_file` hash drives a redeploy when source changes.
- **`google_storage_bucket "functions_source"`** — versioned source bucket (10-version lifecycle cap), shared across future functions in this module
- **`google_cloudfunctions2_function "pricing_refresh"`** — gen-2, Node 22, `refreshPricing` entrypoint, 256Mi / 540s / max=1 instance, scaled-to-zero between runs. Dedicated runtime SA with only `datastore.user` + `logging.logWriter` (`billing.viewer` added in #38)
- **`google_service_account "pricing_refresh_scheduler"`** — separate identity Cloud Scheduler assumes. Holds `run.invoker` on the function and nothing else, so a compromised scheduler config can't write Firestore
- **`google_cloud_scheduler_job "pricing_refresh"`** — daily 04:00 UTC cron (var-driven), HTTP POST to function URL with OIDC token, one retry with backoff

### Knobs
- `versions.tf` adds `hashicorp/archive ~> 2.6` for the `archive_file` data source
- Variables: `pricing_refresh_schedule`, `pricing_refresh_delete_protection`
- Outputs: `pricing_refresh_function_url`, `pricing_refresh_runtime_service_account_email`
- `.gitignore` excludes archive artifacts (`infra/**/functions/**/.dist/`)
- `eslint.config.mjs` scoped Node globals (`globals` devDep) for `infra/**/functions/**/*.js` so CF sources lint under the same config without `exports`/`console` tripping no-undef

Closes #35

## Test plan
- [x] `terraform validate` + `terraform fmt -check` pass for `infra/coordinator`
- [x] `pnpm lint` + `pnpm format` + `pnpm typecheck` all clean
- [ ] CI green
- [ ] After `terraform apply` in dev: `gcloud scheduler jobs list` shows the job, `gcloud functions describe agent-tasker-dev-pricing-refresh` shows ACTIVE, manual `gcloud functions call` returns "stub"

🤖 Generated with [Claude Code](https://claude.com/claude-code)