### PR TITLE
Pricing-refresh handler: Firestore writes + last-known-good (#39)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,13 +9,13 @@ export default tseslint.config(
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,
-  // Cloud Function sources are CommonJS Node modules deployed straight to
-  // GCP — not part of the workspace TS build. Give them Node globals so
-  // `exports` / `console` / `Buffer` don't trip no-undef.
+  // Cloud Function sources are ESM Node modules deployed straight to GCP
+  // — not part of the workspace TS build. Give them Node globals so
+  // `process` / `console` / `Buffer` don't trip no-undef.
   {
     files: ["infra/**/functions/**/*.js"],
     languageOptions: {
-      sourceType: "commonjs",
+      sourceType: "module",
       globals: { ...globals.node },
     },
   },

--- a/infra/coordinator/functions/pricing-refresh/index.js
+++ b/infra/coordinator/functions/pricing-refresh/index.js
@@ -1,19 +1,128 @@
-// Placeholder daily pricing-refresh handler. Real implementation that pulls
-// from the Cloud Billing Catalog and writes Firestore /pricing snapshots
-// lands with #38; this stub only exists so #35's Terraform has something to
-// deploy and the Cloud Scheduler trigger can be smoke-tested end-to-end.
+// Daily pricing-refresh handler. Writes per-model price snapshots to
+// Firestore at `pricing/{model_id}/snapshots/{YYYY-MM-DD}` plus a
+// `pricing/{model_id}` "latest" doc the coordinator and bidders can read
+// without an extra collection-group query.
 //
-// HTTP-triggered gen-2 Cloud Function. Cloud Scheduler invokes it daily
-// with an OIDC token (verified by Cloud Run's IAM layer before reaching
-// this handler).
+// Scope today: writes FALLBACK_PRICING constants (CLAUDE.md "for SKUs not
+// exposed cleanly in [the Catalog API], fall back to maintained constants
+// in /protocol"). Real Cloud Billing Catalog integration lives behind the
+// TODO below and will overwrite the `source` field from "fallback" to
+// "catalog" as it lands per-model.
+//
+// Last-known-good behaviour (#39): per-day snapshots are append-only —
+// writes upsert `pricing/{model}/snapshots/{date}` so today's failure
+// doesn't disturb yesterday's snapshot. The `pricing/{model}` latest doc
+// is only updated for models that succeeded; failed models keep yesterday's
+// prices visible to bidders.
+//
+// HTTP-triggered gen-2 function. Cloud Scheduler invokes daily with OIDC
+// (verified by Cloud Run's IAM layer before reaching this handler).
 
-exports.refreshPricing = (req, res) => {
-  console.log(
-    JSON.stringify({
-      msg: "pricing-refresh stub invoked",
-      method: req.method,
-      ts: new Date().toISOString(),
-    }),
+import { Firestore } from "@google-cloud/firestore";
+
+// Hand-maintained copy of /protocol/src/pricing.ts FALLBACK_PRICING. The
+// Cloud Function deploys from infra/coordinator/functions/pricing-refresh/
+// with only the deps listed in its own package.json — no monorepo TS
+// imports. Keep this in sync; quarterly review (#41) is the safety net.
+// Units: USD per 1,000,000 tokens.
+const FALLBACK_PRICING = {
+  "amazon.nova-micro": { in: 0.035, out: 0.14 },
+  "amazon.nova-lite": { in: 0.06, out: 0.24 },
+  "amazon.nova-pro": { in: 0.8, out: 3.2 },
+  "gpt-5-mini": { in: 0.25, out: 2.0 },
+  "gpt-5": { in: 1.25, out: 10.0 },
+  "gemini-2-5-flash": { in: 0.3, out: 2.5 },
+  "gemini-2-5-pro": { in: 1.25, out: 10.0 },
+};
+
+function log(level, msg, extra) {
+  // Structured logs play well with Cloud Logging — every entry is one
+  // JSON object on stdout, severity included.
+  const entry = { severity: level, msg, ts: new Date().toISOString(), ...extra };
+  console.log(JSON.stringify(entry));
+}
+
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+async function writeOne(firestore, modelId, prices, date) {
+  const fetchedAt = new Date().toISOString();
+  const snapshot = {
+    model_id: modelId,
+    price_in_usd_per_mtoken: prices.in,
+    price_out_usd_per_mtoken: prices.out,
+    effective_date: date,
+    source: prices.source || "fallback",
+    fetched_at: fetchedAt,
+  };
+  const modelDoc = firestore.collection("pricing").doc(modelId);
+
+  // Snapshot doc: keyed by date so re-running the same day is idempotent
+  // and prior days are never overwritten — this is the "last-known-good"
+  // append-only journal that eval replay reads against.
+  await modelDoc.collection("snapshots").doc(date).set(snapshot);
+
+  // Latest-pointer doc: cheap single-doc read for the coordinator and
+  // bidders. Only the date marker + the two prices, kept as merge so
+  // sibling fields a future migration adds aren't clobbered.
+  await modelDoc.set(
+    {
+      model_id: modelId,
+      latest_snapshot_date: date,
+      latest_price_in_usd_per_mtoken: prices.in,
+      latest_price_out_usd_per_mtoken: prices.out,
+      updated_at: fetchedAt,
+    },
+    { merge: true },
   );
-  res.status(200).send("stub");
+}
+
+export const refreshPricing = async (req, res) => {
+  const projectId = process.env.GCP_PROJECT_ID;
+  if (!projectId) {
+    log("ERROR", "GCP_PROJECT_ID env var is required");
+    res.status(500).send("missing GCP_PROJECT_ID");
+    return;
+  }
+
+  // TODO: Pull live SKUs from the Cloud Billing Catalog (Vertex AI Gemini
+  // + GAEP) and merge over FALLBACK_PRICING per model. The Catalog client
+  // and roles/billing.viewer wiring land alongside. Until then every model
+  // writes with source: "fallback".
+
+  const date = todayUtc();
+  const firestore = new Firestore({ projectId });
+
+  const results = { written: [], failed: [] };
+  for (const [modelId, prices] of Object.entries(FALLBACK_PRICING)) {
+    try {
+      await writeOne(firestore, modelId, prices, date);
+      results.written.push(modelId);
+    } catch (err) {
+      // Per-model isolation: a single bad write doesn't abort the rest.
+      // The latest-doc for this model stays on yesterday's values.
+      results.failed.push({ model_id: modelId, error: err.message });
+      log("ERROR", "pricing-refresh: write failed", {
+        model_id: modelId,
+        error: err.message,
+      });
+    }
+  }
+
+  if (results.written.length === 0) {
+    log("ERROR", "pricing-refresh: nothing written", { date, results });
+    // Non-2xx lets Cloud Scheduler's retry config kick in.
+    res.status(500).json({ ok: false, date, results });
+    return;
+  }
+
+  log("INFO", "pricing-refresh: done", {
+    date,
+    written: results.written.length,
+    failed: results.failed.length,
+  });
+  // 200 even if some models failed — yesterday's prices are still good for
+  // those. A repeat at next-scheduled-run picks them up.
+  res.status(200).json({ ok: true, date, results });
 };

--- a/infra/coordinator/functions/pricing-refresh/package.json
+++ b/infra/coordinator/functions/pricing-refresh/package.json
@@ -2,10 +2,13 @@
   "name": "@agent-tasker/pricing-refresh",
   "version": "0.0.0",
   "private": true,
-  "description": "Daily pricing refresh Cloud Function — placeholder source until #38 lands the Cloud Billing Catalog parser.",
+  "type": "module",
+  "description": "Daily pricing-refresh Cloud Function. Writes per-model snapshots to Firestore /pricing.",
   "main": "index.js",
   "engines": {
     "node": "22"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@google-cloud/firestore": "^8.6.0"
+  }
 }


### PR DESCRIPTION
## Summary
Replaces the #35 stub with a real handler. Writes per-model snapshots to Firestore `/pricing` on every invocation; on failure, yesterday's prices stay visible to bidders.

### Behavior
- For each entry in `FALLBACK_PRICING`, upserts `pricing/{model_id}/snapshots/{YYYY-MM-DD}` with the price pair, `effective_date`, `source: "fallback"`, `fetched_at`. **Append-only by date** so re-running the same day is idempotent and prior days are untouched.
- Also upserts `pricing/{model_id}` latest-pointer doc (cheap single-doc read for the coordinator and bidders) — **only on per-model success**. A failed model's `latest_*` fields stay on yesterday's values.
- **Per-model isolation**: one failed write doesn't abort the rest. Each failure is logged with `severity=ERROR` and surfaced in the response body; HTTP 200 if at least one model wrote, 500 if all failed (lets Cloud Scheduler's retry config kick in).
- Structured JSON logs throughout — Cloud Logging treats each `console.log` as one entry with severity.
- **ESM module** (Node 22 / `"type":"module"`); ESLint scope updated from CommonJS to module for `infra/**/functions/**/*.js`.

### What this PR closes
- **#39 last-known-good fallback** — fully landed: append-only daily snapshots, per-model isolation, latest-doc only updates on success.
- **#38 Cloud Billing Catalog parser** — *partial*. The fallback path (CLAUDE.md's documented escape hatch for SKUs the Catalog doesn't expose cleanly) is now the active code path. The `TODO` in `index.js` marks where the live Catalog probe + per-model `source: "catalog"` mapping will land. **Leaving #38 open** so that work has a home.

### Deferred to that follow-up
- `@google-cloud/billing` dep
- `roles/billing.viewer` on the runtime SA
- SKU-name → `model_id` matching with conservative regex patterns
- Unit conversion (Catalog reports per-1k-chars; we need per-1M-tokens)

### Manual smoke after `terraform apply`
```sh
gcloud functions call agent-tasker-dev-pricing-refresh \
    --region=us-central1 --gen2
# Then in Firestore console verify:
#   /pricing/gemini-2-5-pro                       (latest doc)
#   /pricing/gemini-2-5-pro/snapshots/2026-MM-DD  (today's snapshot)
```

Closes #39

## Test plan
- [x] `pnpm lint` + `pnpm format` + `pnpm typecheck` clean (CF source picks up scoped Node globals)
- [ ] CI green
- [ ] After `terraform apply` in dev: `gcloud functions call` returns `{ok:true, written:[...]}`, Firestore docs appear, second run same day is a no-op for snapshot doc and an idempotent overwrite for the latest doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)