### PR TITLE
Apply min_tier filter before scoring

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -8,7 +8,9 @@ import {
   type PricingEntry,
   type TaskId,
   type TaskSpec,
+  type Tier,
   isNoBid,
+  meetsMinTier,
 } from "@agent-tasker/protocol";
 import type { LedgerStore } from "../ledger/store.js";
 import type { AuctionRunner } from "./runner.js";
@@ -25,6 +27,7 @@ import type { AuctionRunner } from "./runner.js";
 //   #52). Slow agents are treated as `no_bid: internal_error`.
 // - Records every bid/no_bid via store.recordBidResponse with the supplied
 //   pricing snapshot.
+// - Applies the task's optional `min_tier` filter before winner selection.
 // - Picks the winner with lowest `bid_usd`; records the auction price as
 //   the second-lowest bid (Vickrey / second-price). With one bidder, the
 //   auction price falls back to that bidder's own bid.
@@ -116,7 +119,16 @@ export class HttpAuctionRunner implements AuctionRunner {
       return;
     }
 
-    const award = selectVickreyAward(realBids);
+    const eligibleBids = filterBidsByMinTier(realBids, task.spec.min_tier);
+    if (eligibleBids.length === 0) {
+      await this.opts.store.failTask({
+        taskId,
+        reason: `no bids met min_tier ${task.spec.min_tier ?? "none"}`,
+      });
+      return;
+    }
+
+    const award = selectVickreyAward(eligibleBids);
 
     await this.opts.store.awardTask({
       taskId,
@@ -240,6 +252,10 @@ export interface VickreyAward {
   winner: Bid;
   winningBidUsd: number;
   auctionPriceUsd: number;
+}
+
+export function filterBidsByMinTier(bids: readonly Bid[], minTier: Tier | undefined): Bid[] {
+  return bids.filter((bid) => meetsMinTier(bid.tier, minTier));
 }
 
 export function selectVickreyAward(bids: readonly Bid[]): VickreyAward {

--- a/coordinator/test/auction/vickrey-award.test.ts
+++ b/coordinator/test/auction/vickrey-award.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { AgentId, Bid } from "@agent-tasker/protocol";
-import { selectVickreyAward } from "../../src/auction/http-runner.js";
+import type { AgentId, Bid, Tier } from "@agent-tasker/protocol";
+import { filterBidsByMinTier, selectVickreyAward } from "../../src/auction/http-runner.js";
 
-function bidFor(agentId: AgentId, bidUsd: number): Bid {
+function bidFor(agentId: AgentId, bidUsd: number, tier: Tier = "frontier"): Bid {
   return {
     task_id: "task-vickrey",
     agent_id: agentId,
-    tier: "frontier",
+    tier,
     model_family: agentId.startsWith("gcp") ? "gemini" : agentId.startsWith("aws") ? "nova" : "gpt",
     model_id: "stub-model",
     est_input_tokens: 4000,
@@ -18,6 +18,36 @@ function bidFor(agentId: AgentId, bidUsd: number): Bid {
     signature: "stub",
   };
 }
+
+describe("filterBidsByMinTier", () => {
+  it("keeps every bid when no minimum tier is requested", () => {
+    const bids = [
+      bidFor("gcp-gemini", 0.01, "small"),
+      bidFor("aws-nova", 0.02, "medium"),
+      bidFor("azure-gpt", 0.03, "frontier"),
+    ];
+
+    expect(filterBidsByMinTier(bids, undefined).map((bid) => bid.agent_id)).toEqual([
+      "gcp-gemini",
+      "aws-nova",
+      "azure-gpt",
+    ]);
+  });
+
+  it("excludes bids below the requested minimum tier before scoring", () => {
+    const bids = [
+      bidFor("gcp-gemini", 0.01, "small"),
+      bidFor("aws-nova", 0.02, "medium"),
+      bidFor("azure-gpt", 0.03, "frontier"),
+    ];
+
+    expect(filterBidsByMinTier(bids, "medium").map((bid) => bid.agent_id)).toEqual([
+      "aws-nova",
+      "azure-gpt",
+    ]);
+    expect(filterBidsByMinTier(bids, "frontier").map((bid) => bid.agent_id)).toEqual(["azure-gpt"]);
+  });
+});
 
 describe("selectVickreyAward", () => {
   it("selects the lowest bid and prices at the second-lowest bid", () => {

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -6,6 +6,8 @@ import type {
   JwtPhase,
   PricingEntry,
   TaskId,
+  TaskSpec,
+  Tier,
 } from "@agent-tasker/protocol";
 import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
 import {
@@ -35,11 +37,11 @@ const stubSigner: TaskTokenSigner = {
   },
 };
 
-function bidFor(agentId: AgentId, bidUsd: number, taskId: string): Bid {
+function bidFor(agentId: AgentId, bidUsd: number, taskId: string, tier: Tier = "frontier"): Bid {
   return {
     task_id: taskId,
     agent_id: agentId,
-    tier: "frontier",
+    tier,
     model_family: agentId.startsWith("gcp") ? "gemini" : agentId.startsWith("aws") ? "nova" : "gpt",
     model_id: "stub-model",
     est_input_tokens: 4000,
@@ -69,10 +71,11 @@ async function startAuction(opts: {
   taskId: TaskId;
   endpoints: AgentEndpoint[];
   bidTimeoutMs?: number;
+  spec?: TaskSpec;
 }): Promise<HttpAuctionRunner> {
   await store.createTask({
     taskId: opts.taskId,
-    spec: { prompt: "summarize the transcript" },
+    spec: opts.spec ?? { prompt: "summarize the transcript" },
   });
   const runner = new HttpAuctionRunner({
     store,
@@ -164,6 +167,43 @@ describe("HttpAuctionRunner", () => {
     const bids = await store.listBids(taskId);
     const novaRecord = bids.find((b) => b.agent_id === "aws-nova");
     expect(novaRecord?.response).toMatchObject({ status: "no_bid", reason: "capability" });
+  });
+
+  it("applies min_tier before winner selection", async () => {
+    const taskId = "task-min-tier-frontier";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.01, req.task_id, "small"),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (req) => bidFor("aws-nova", 0.04, req.task_id, "frontier"),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "aws-nova",
+        output: "nova did it",
+        actual_usage: { input_tokens: 3900, output_tokens: 900 },
+      }),
+    });
+    agents.push(gemini, nova);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+      ],
+      spec: { prompt: "summarize the transcript", min_tier: "frontier" },
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
+    expect(task?.winner_agent_id).toBe("aws-nova");
+    expect(task?.winning_bid_usd).toBe(0.04);
+    expect(task?.auction_price_usd).toBe(0.04);
+
+    const bids = await store.listBids(taskId);
+    expect(bids.map((bid) => bid.agent_id).sort()).toEqual(["aws-nova", "gcp-gemini"]);
   });
 
   it("all agents decline → task fails with reason listing decline codes", async () => {


### PR DESCRIPTION
## Summary
- filter real bids against task.spec.min_tier before Vickrey winner selection
- fail the task when bids arrive but none meet the requested minimum tier
- add focused unit coverage for tier filtering
- add HTTP runner coverage proving a cheaper low-tier bid is excluded before scoring

## Tests
- pnpm --filter @agent-tasker/coordinator exec vitest run test/auction/vickrey-award.test.ts test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm exec prettier --check coordinator/src/auction/http-runner.ts coordinator/test/auction/vickrey-award.test.ts coordinator/test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator test

Closes #48