### PR TITLE
Record no-bid metadata separately

### DIFF
--- a/coordinator/src/ledger/firestore-store.ts
+++ b/coordinator/src/ledger/firestore-store.ts
@@ -4,7 +4,7 @@ import {
   type DocumentReference,
   type Transaction,
 } from "@google-cloud/firestore";
-import type { TaskId, TaskStatus } from "@agent-tasker/protocol";
+import { isNoBid, type TaskId, type TaskStatus } from "@agent-tasker/protocol";
 import {
   InvalidTransitionError,
   TaskAlreadyExistsError,
@@ -71,6 +71,9 @@ export class FirestoreLedgerStore implements LedgerStore {
         agent_id: input.response.agent_id,
         timestamp: nowIso(input.now),
         phase: "bid",
+        response_kind: isNoBid(input.response) ? "no_bid" : "bid",
+        no_bid_reason: isNoBid(input.response) ? input.response.reason : undefined,
+        mape_eligible: !isNoBid(input.response),
         response: input.response,
         pricing_snapshot: input.pricingSnapshot,
       };

--- a/coordinator/src/ledger/in-memory-store.ts
+++ b/coordinator/src/ledger/in-memory-store.ts
@@ -1,4 +1,4 @@
-import type { TaskId } from "@agent-tasker/protocol";
+import { isNoBid, type TaskId } from "@agent-tasker/protocol";
 import {
   InvalidTransitionError,
   TaskAlreadyExistsError,
@@ -57,6 +57,9 @@ export class InMemoryLedgerStore implements LedgerStore {
       agent_id: input.response.agent_id,
       timestamp: nowIso(input.now),
       phase: "bid",
+      response_kind: isNoBid(input.response) ? "no_bid" : "bid",
+      no_bid_reason: isNoBid(input.response) ? input.response.reason : undefined,
+      mape_eligible: !isNoBid(input.response),
       response: input.response,
       pricing_snapshot: input.pricingSnapshot,
     };

--- a/coordinator/src/ledger/types.ts
+++ b/coordinator/src/ledger/types.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   AgentIdSchema,
   BidResponseSchema,
+  NoBidReasonSchema,
   PricingEntrySchema,
   ResultSchema,
   TaskIdSchema,
@@ -43,11 +44,17 @@ export type TaskRecord = z.infer<typeof TaskRecordSchema>;
 //
 // `pricing_snapshot` captures the prices the bidder used so MAPE replay
 // remains reproducible even after the pricing collection rolls forward.
+// `response_kind` / `no_bid_reason` / `mape_eligible` intentionally
+// denormalize the union response so decline-rate queries and future MAPE
+// rollups do not have to inspect nested response shapes.
 export const BidRecordSchema = z.object({
   task_id: TaskIdSchema,
   agent_id: AgentIdSchema,
   timestamp: Iso8601,
   phase: z.literal("bid"),
+  response_kind: z.enum(["bid", "no_bid"]),
+  no_bid_reason: NoBidReasonSchema.optional(),
+  mape_eligible: z.boolean(),
   response: BidResponseSchema,
   pricing_snapshot: z.array(PricingEntrySchema),
 });

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -166,6 +166,11 @@ describe("HttpAuctionRunner", () => {
     // Nova's decline was still recorded
     const bids = await store.listBids(taskId);
     const novaRecord = bids.find((b) => b.agent_id === "aws-nova");
+    expect(novaRecord).toMatchObject({
+      response_kind: "no_bid",
+      no_bid_reason: "capability",
+      mape_eligible: false,
+    });
     expect(novaRecord?.response).toMatchObject({ status: "no_bid", reason: "capability" });
   });
 
@@ -266,6 +271,11 @@ describe("HttpAuctionRunner", () => {
 
     const bids = await store.listBids(taskId);
     const novaRecord = bids.find((b) => b.agent_id === "aws-nova");
+    expect(novaRecord).toMatchObject({
+      response_kind: "no_bid",
+      no_bid_reason: "internal_error",
+      mape_eligible: false,
+    });
     expect(novaRecord?.response).toMatchObject({ status: "no_bid", reason: "internal_error" });
   });
 

--- a/coordinator/test/ledger/in-memory-store.test.ts
+++ b/coordinator/test/ledger/in-memory-store.test.ts
@@ -109,6 +109,9 @@ describe("recordBidResponse", () => {
     const bids = await store.listBids(TASK_ID);
     expect(bids).toHaveLength(1);
     expect(bids[0]?.phase).toBe("bid");
+    expect(bids[0]?.response_kind).toBe("bid");
+    expect(bids[0]?.mape_eligible).toBe(true);
+    expect(bids[0]?.no_bid_reason).toBeUndefined();
     expect(bids[0]?.response).toEqual(bid);
     expect(bids[0]?.pricing_snapshot).toEqual(PRICING);
   });
@@ -127,7 +130,16 @@ describe("recordBidResponse", () => {
     const bids = await store.listBids(TASK_ID);
     expect(bids).toHaveLength(2);
     const byAgent = Object.fromEntries(bids.map((b) => [b.agent_id, b]));
+    expect(byAgent["gcp-gemini"]).toMatchObject({
+      response_kind: "bid",
+      mape_eligible: true,
+    });
     expect(byAgent["gcp-gemini"]?.response).toMatchObject({ bid_usd: 0.02 });
+    expect(byAgent["aws-nova"]).toMatchObject({
+      response_kind: "no_bid",
+      no_bid_reason: "capability",
+      mape_eligible: false,
+    });
     expect(byAgent["aws-nova"]?.response).toMatchObject({
       status: "no_bid",
       reason: "capability",


### PR DESCRIPTION
## Summary
- add top-level bid response metadata to ledger records: response_kind, no_bid_reason, and mape_eligible
- populate the metadata in both in-memory and Firestore ledger stores
- assert no_bid records are queryable separately from MAPE-eligible real bids

## Tests
- pnpm --filter @agent-tasker/coordinator exec vitest run test/ledger/in-memory-store.test.ts test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm exec prettier --check coordinator/src/ledger/types.ts coordinator/src/ledger/in-memory-store.ts coordinator/src/ledger/firestore-store.ts coordinator/test/ledger/in-memory-store.test.ts coordinator/test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator test

Closes #49