### PR TITLE
Break tied bids by historical MAPE

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -56,6 +56,7 @@ export interface HttpAuctionRunnerOptions {
   agents: AgentEndpoint[];
   tokenSigner: TaskTokenSigner;
   pricingSnapshot: PricingEntry[];
+  accuracyByAgent?: AgentAccuracyLookup;
   bidTimeoutMs?: number;
   executeTimeoutMs?: number;
   // Override for tests; defaults to the global `fetch` available in Node 22+.
@@ -128,7 +129,7 @@ export class HttpAuctionRunner implements AuctionRunner {
       return;
     }
 
-    const award = selectVickreyAward(eligibleBids);
+    const award = selectVickreyAward(eligibleBids, this.opts.accuracyByAgent);
 
     await this.opts.store.awardTask({
       taskId,
@@ -254,16 +255,28 @@ export interface VickreyAward {
   auctionPriceUsd: number;
 }
 
+export interface AgentAccuracy {
+  // Mean absolute percentage error, lower is better.
+  mape: number;
+}
+
+export type AgentAccuracyLookup = Partial<Record<AgentId, AgentAccuracy>>;
+
 export function filterBidsByMinTier(bids: readonly Bid[], minTier: Tier | undefined): Bid[] {
   return bids.filter((bid) => meetsMinTier(bid.tier, minTier));
 }
 
-export function selectVickreyAward(bids: readonly Bid[]): VickreyAward {
+export function selectVickreyAward(
+  bids: readonly Bid[],
+  accuracyByAgent: AgentAccuracyLookup = {},
+): VickreyAward {
   if (bids.length === 0) {
     throw new Error("cannot select a Vickrey award without at least one bid");
   }
 
-  const ranked = [...bids].sort((a, b) => a.bid_usd - b.bid_usd);
+  const ranked = [...bids].sort(
+    (a, b) => a.bid_usd - b.bid_usd || compareHistoricalMape(a, b, accuracyByAgent),
+  );
   const winner = ranked[0]!;
   const priceBid = ranked[1] ?? winner;
 
@@ -272,4 +285,14 @@ export function selectVickreyAward(bids: readonly Bid[]): VickreyAward {
     winningBidUsd: winner.bid_usd,
     auctionPriceUsd: priceBid.bid_usd,
   };
+}
+
+function compareHistoricalMape(a: Bid, b: Bid, accuracyByAgent: AgentAccuracyLookup): number {
+  const aMape = accuracyByAgent[a.agent_id]?.mape;
+  const bMape = accuracyByAgent[b.agent_id]?.mape;
+
+  if (aMape === undefined && bMape === undefined) return 0;
+  if (aMape === undefined) return 1;
+  if (bMape === undefined) return -1;
+  return aMape - bMape;
 }

--- a/coordinator/test/auction/vickrey-award.test.ts
+++ b/coordinator/test/auction/vickrey-award.test.ts
@@ -70,6 +70,31 @@ describe("selectVickreyAward", () => {
     expect(award.auctionPriceUsd).toBe(0.02);
   });
 
+  it("breaks tied bids by lowest historical MAPE", () => {
+    const award = selectVickreyAward(
+      [bidFor("gcp-gemini", 0.02), bidFor("aws-nova", 0.02), bidFor("azure-gpt", 0.04)],
+      {
+        "gcp-gemini": { mape: 0.18 },
+        "aws-nova": { mape: 0.08 },
+      },
+    );
+
+    expect(award.winner.agent_id).toBe("aws-nova");
+    expect(award.winningBidUsd).toBe(0.02);
+    expect(award.auctionPriceUsd).toBe(0.02);
+  });
+
+  it("uses historical MAPE only after bid_usd ties", () => {
+    const award = selectVickreyAward([bidFor("gcp-gemini", 0.01), bidFor("aws-nova", 0.02)], {
+      "gcp-gemini": { mape: 0.5 },
+      "aws-nova": { mape: 0.01 },
+    });
+
+    expect(award.winner.agent_id).toBe("gcp-gemini");
+    expect(award.winningBidUsd).toBe(0.01);
+    expect(award.auctionPriceUsd).toBe(0.02);
+  });
+
   it("does not mutate caller-owned bid ordering", () => {
     const bids = [
       bidFor("azure-gpt", 0.04),

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "@agent-tasker/protocol";
 import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
 import {
+  type AgentAccuracyLookup,
   HttpAuctionRunner,
   type AgentEndpoint,
   type TaskTokenSigner,
@@ -70,6 +71,7 @@ afterEach(async () => {
 async function startAuction(opts: {
   taskId: TaskId;
   endpoints: AgentEndpoint[];
+  accuracyByAgent?: AgentAccuracyLookup;
   bidTimeoutMs?: number;
   spec?: TaskSpec;
 }): Promise<HttpAuctionRunner> {
@@ -82,6 +84,7 @@ async function startAuction(opts: {
     agents: opts.endpoints,
     tokenSigner: stubSigner,
     pricingSnapshot: PRICING_SNAPSHOT,
+    ...(opts.accuracyByAgent !== undefined ? { accuracyByAgent: opts.accuracyByAgent } : {}),
     ...(opts.bidTimeoutMs !== undefined ? { bidTimeoutMs: opts.bidTimeoutMs } : {}),
   });
   runner.start(opts.taskId);
@@ -209,6 +212,43 @@ describe("HttpAuctionRunner", () => {
 
     const bids = await store.listBids(taskId);
     expect(bids.map((bid) => bid.agent_id).sort()).toEqual(["aws-nova", "gcp-gemini"]);
+  });
+
+  it("breaks tied lowest bids by historical MAPE", async () => {
+    const taskId = "task-tied-mape";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (req) => bidFor("aws-nova", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "aws-nova",
+        output: "nova did it",
+        actual_usage: { input_tokens: 3900, output_tokens: 900 },
+      }),
+    });
+    agents.push(gemini, nova);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+      ],
+      accuracyByAgent: {
+        "gcp-gemini": { mape: 0.2 },
+        "aws-nova": { mape: 0.05 },
+      },
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
+    expect(task?.winner_agent_id).toBe("aws-nova");
+    expect(task?.winning_bid_usd).toBe(0.02);
+    expect(task?.auction_price_usd).toBe(0.02);
   });
 
   it("all agents decline → task fails with reason listing decline codes", async () => {


### PR DESCRIPTION
## Summary
- add an injectable agent accuracy snapshot to the HTTP auction runner
- use lowest historical MAPE to break equal bid_usd ties in Vickrey selection
- keep price ordering based on bid_usd and preserve MAPE as a tie-break only
- add unit and HTTP runner coverage for MAPE tie-breaking

## Tests
- pnpm --filter @agent-tasker/coordinator exec vitest run test/auction/vickrey-award.test.ts test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm exec prettier --check coordinator/src/auction/http-runner.ts coordinator/test/auction/vickrey-award.test.ts coordinator/test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator test

Closes #50