### PR TITLE
Add cold-start fallback for tied bids

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -38,7 +38,6 @@ import type { AuctionRunner } from "./runner.js";
 //
 // What's still out of scope (separate issues):
 // - Adaptive bid timeout (#52)
-// - MAPE-based tie-breaking (#50, #51)
 // - Re-auction on /execute failure (#53)
 // - Score-weighted auction layer (#81)
 
@@ -57,6 +56,7 @@ export interface HttpAuctionRunnerOptions {
   tokenSigner: TaskTokenSigner;
   pricingSnapshot: PricingEntry[];
   accuracyByAgent?: AgentAccuracyLookup;
+  tieBreakRandom?: RandomSource;
   bidTimeoutMs?: number;
   executeTimeoutMs?: number;
   // Override for tests; defaults to the global `fetch` available in Node 22+.
@@ -129,7 +129,11 @@ export class HttpAuctionRunner implements AuctionRunner {
       return;
     }
 
-    const award = selectVickreyAward(eligibleBids, this.opts.accuracyByAgent);
+    const award = selectVickreyAward(
+      eligibleBids,
+      this.opts.accuracyByAgent,
+      this.opts.tieBreakRandom,
+    );
 
     await this.opts.store.awardTask({
       taskId,
@@ -258,9 +262,13 @@ export interface VickreyAward {
 export interface AgentAccuracy {
   // Mean absolute percentage error, lower is better.
   mape: number;
+  settledTaskCount: number;
 }
 
 export type AgentAccuracyLookup = Partial<Record<AgentId, AgentAccuracy>>;
+export type RandomSource = () => number;
+
+export const MIN_SETTLED_TASKS_FOR_MAPE_TIE_BREAK = 10;
 
 export function filterBidsByMinTier(bids: readonly Bid[], minTier: Tier | undefined): Bid[] {
   return bids.filter((bid) => meetsMinTier(bid.tier, minTier));
@@ -269,16 +277,20 @@ export function filterBidsByMinTier(bids: readonly Bid[], minTier: Tier | undefi
 export function selectVickreyAward(
   bids: readonly Bid[],
   accuracyByAgent: AgentAccuracyLookup = {},
+  random: RandomSource = Math.random,
 ): VickreyAward {
   if (bids.length === 0) {
     throw new Error("cannot select a Vickrey award without at least one bid");
   }
 
-  const ranked = [...bids].sort(
-    (a, b) => a.bid_usd - b.bid_usd || compareHistoricalMape(a, b, accuracyByAgent),
-  );
-  const winner = ranked[0]!;
-  const priceBid = ranked[1] ?? winner;
+  const rankedByBid = [...bids].sort((a, b) => a.bid_usd - b.bid_usd);
+  const lowestBidUsd = rankedByBid[0]!.bid_usd;
+  const tiedLowestBids = rankedByBid.filter((bid) => bid.bid_usd === lowestBidUsd);
+  const winner =
+    tiedLowestBids.length === 1
+      ? tiedLowestBids[0]!
+      : pickTieWinner(tiedLowestBids, accuracyByAgent, random);
+  const priceBid = rankedByBid.filter((bid) => bid !== winner)[0] ?? winner;
 
   return {
     winner,
@@ -287,12 +299,30 @@ export function selectVickreyAward(
   };
 }
 
-function compareHistoricalMape(a: Bid, b: Bid, accuracyByAgent: AgentAccuracyLookup): number {
-  const aMape = accuracyByAgent[a.agent_id]?.mape;
-  const bMape = accuracyByAgent[b.agent_id]?.mape;
+function pickTieWinner(
+  tiedBids: readonly Bid[],
+  accuracyByAgent: AgentAccuracyLookup,
+  random: RandomSource,
+): Bid {
+  const coldStartBids = tiedBids.filter(
+    (bid) => !hasEnoughSettledTasks(accuracyByAgent[bid.agent_id]),
+  );
+  if (coldStartBids.length > 0) {
+    return pickRandom(coldStartBids, random);
+  }
 
-  if (aMape === undefined && bMape === undefined) return 0;
-  if (aMape === undefined) return 1;
-  if (bMape === undefined) return -1;
-  return aMape - bMape;
+  return [...tiedBids].sort(
+    (a, b) => accuracyByAgent[a.agent_id]!.mape - accuracyByAgent[b.agent_id]!.mape,
+  )[0]!;
+}
+
+function hasEnoughSettledTasks(accuracy: AgentAccuracy | undefined): boolean {
+  return (
+    accuracy !== undefined && accuracy.settledTaskCount >= MIN_SETTLED_TASKS_FOR_MAPE_TIE_BREAK
+  );
+}
+
+function pickRandom<T>(items: readonly T[], random: RandomSource): T {
+  const index = Math.min(Math.floor(random() * items.length), items.length - 1);
+  return items[index]!;
 }

--- a/coordinator/test/auction/vickrey-award.test.ts
+++ b/coordinator/test/auction/vickrey-award.test.ts
@@ -74,8 +74,8 @@ describe("selectVickreyAward", () => {
     const award = selectVickreyAward(
       [bidFor("gcp-gemini", 0.02), bidFor("aws-nova", 0.02), bidFor("azure-gpt", 0.04)],
       {
-        "gcp-gemini": { mape: 0.18 },
-        "aws-nova": { mape: 0.08 },
+        "gcp-gemini": { mape: 0.18, settledTaskCount: 10 },
+        "aws-nova": { mape: 0.08, settledTaskCount: 10 },
       },
     );
 
@@ -86,12 +86,42 @@ describe("selectVickreyAward", () => {
 
   it("uses historical MAPE only after bid_usd ties", () => {
     const award = selectVickreyAward([bidFor("gcp-gemini", 0.01), bidFor("aws-nova", 0.02)], {
-      "gcp-gemini": { mape: 0.5 },
-      "aws-nova": { mape: 0.01 },
+      "gcp-gemini": { mape: 0.5, settledTaskCount: 10 },
+      "aws-nova": { mape: 0.01, settledTaskCount: 10 },
     });
 
     expect(award.winner.agent_id).toBe("gcp-gemini");
     expect(award.winningBidUsd).toBe(0.01);
+    expect(award.auctionPriceUsd).toBe(0.02);
+  });
+
+  it("falls back to random selection among tied cold-start agents", () => {
+    const award = selectVickreyAward(
+      [bidFor("gcp-gemini", 0.02), bidFor("aws-nova", 0.02), bidFor("azure-gpt", 0.04)],
+      {
+        "gcp-gemini": { mape: 0.18, settledTaskCount: 9 },
+        "aws-nova": { mape: 0.08, settledTaskCount: 9 },
+      },
+      () => 0.75,
+    );
+
+    expect(award.winner.agent_id).toBe("aws-nova");
+    expect(award.winningBidUsd).toBe(0.02);
+    expect(award.auctionPriceUsd).toBe(0.02);
+  });
+
+  it("prefers tied cold-start agents over mature MAPE candidates", () => {
+    const award = selectVickreyAward(
+      [bidFor("gcp-gemini", 0.02), bidFor("aws-nova", 0.02), bidFor("azure-gpt", 0.04)],
+      {
+        "gcp-gemini": { mape: 0.18, settledTaskCount: 9 },
+        "aws-nova": { mape: 0.08, settledTaskCount: 10 },
+      },
+      () => 0,
+    );
+
+    expect(award.winner.agent_id).toBe("gcp-gemini");
+    expect(award.winningBidUsd).toBe(0.02);
     expect(award.auctionPriceUsd).toBe(0.02);
   });
 

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -72,6 +72,7 @@ async function startAuction(opts: {
   taskId: TaskId;
   endpoints: AgentEndpoint[];
   accuracyByAgent?: AgentAccuracyLookup;
+  tieBreakRandom?: () => number;
   bidTimeoutMs?: number;
   spec?: TaskSpec;
 }): Promise<HttpAuctionRunner> {
@@ -85,6 +86,7 @@ async function startAuction(opts: {
     tokenSigner: stubSigner,
     pricingSnapshot: PRICING_SNAPSHOT,
     ...(opts.accuracyByAgent !== undefined ? { accuracyByAgent: opts.accuracyByAgent } : {}),
+    ...(opts.tieBreakRandom !== undefined ? { tieBreakRandom: opts.tieBreakRandom } : {}),
     ...(opts.bidTimeoutMs !== undefined ? { bidTimeoutMs: opts.bidTimeoutMs } : {}),
   });
   runner.start(opts.taskId);
@@ -239,9 +241,47 @@ describe("HttpAuctionRunner", () => {
         { agentId: "aws-nova", baseUrl: nova.url },
       ],
       accuracyByAgent: {
-        "gcp-gemini": { mape: 0.2 },
-        "aws-nova": { mape: 0.05 },
+        "gcp-gemini": { mape: 0.2, settledTaskCount: 10 },
+        "aws-nova": { mape: 0.05, settledTaskCount: 10 },
       },
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
+    expect(task?.winner_agent_id).toBe("aws-nova");
+    expect(task?.winning_bid_usd).toBe(0.02);
+    expect(task?.auction_price_usd).toBe(0.02);
+  });
+
+  it("uses random cold-start fallback when tied agents have too few settled tasks", async () => {
+    const taskId = "task-tied-cold-start";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (req) => bidFor("aws-nova", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "aws-nova",
+        output: "nova did it",
+        actual_usage: { input_tokens: 3900, output_tokens: 900 },
+      }),
+    });
+    agents.push(gemini, nova);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+      ],
+      accuracyByAgent: {
+        "gcp-gemini": { mape: 0.2, settledTaskCount: 9 },
+        "aws-nova": { mape: 0.05, settledTaskCount: 9 },
+      },
+      tieBreakRandom: () => 0.75,
     });
 
     const task = await store.getTask(taskId);


### PR DESCRIPTION
## Summary
- require at least 10 settled tasks before historical MAPE can break tied bids
- add a random fallback path for tied cold-start agents, with injectable randomness for tests
- preserve Vickrey pricing while choosing the winner from the tied lowest-bid group
- add unit and HTTP runner coverage for mature MAPE tie-breaks and cold-start fallback

## Tests
- pnpm --filter @agent-tasker/coordinator exec vitest run test/auction/vickrey-award.test.ts test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm exec prettier --check coordinator/src/auction/http-runner.ts coordinator/test/auction/vickrey-award.test.ts coordinator/test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator test

Closes #51