### PR TITLE
Add adaptive bid timeout

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -57,6 +57,8 @@ export interface HttpAuctionRunnerOptions {
   pricingSnapshot: PricingEntry[];
   accuracyByAgent?: AgentAccuracyLookup;
   tieBreakRandom?: RandomSource;
+  bidInitialWaitMs?: number;
+  bidExtensionMs?: number;
   bidTimeoutMs?: number;
   executeTimeoutMs?: number;
   // Override for tests; defaults to the global `fetch` available in Node 22+.
@@ -68,6 +70,8 @@ export interface HttpAuctionRunnerOptions {
 }
 
 const DEFAULT_BID_TIMEOUT_MS = 5_000;
+const DEFAULT_BID_INITIAL_WAIT_MS = 2_000;
+const DEFAULT_BID_EXTENSION_MS = 1_000;
 const DEFAULT_EXECUTE_TIMEOUT_MS = 60_000;
 
 export class HttpAuctionRunner implements AuctionRunner {
@@ -155,38 +159,32 @@ export class HttpAuctionRunner implements AuctionRunner {
     }
   }
 
-  // Sends POST /bid to every configured agent in parallel and returns one
-  // BidResponse per agent. Agents that error / time out / return junk are
-  // translated to a synthetic `no_bid: internal_error` so the ledger has a
-  // record per agent.
+  // Sends POST /bid to every configured agent in parallel and waits with the
+  // adaptive window from AGENTS.md: 2s initial wait, +1s while responses keep
+  // landing, capped at 5s total wall clock. Agents still pending at the cap
+  // are translated to synthetic `no_bid: internal_error` so the ledger has a
+  // record per configured participant.
   private async gatherBids(taskId: TaskId, spec: TaskSpec): Promise<BidResponse[]> {
-    const timeoutMs = this.opts.bidTimeoutMs ?? DEFAULT_BID_TIMEOUT_MS;
     const fetchImpl = this.opts.fetch ?? fetch;
     const body = JSON.stringify({ task_id: taskId, spec });
-    return Promise.all(
-      this.opts.agents.map(async (agent): Promise<BidResponse> => {
+    const pending = this.opts.agents.map((agent) => {
+      const controller = new AbortController();
+      const promise = (async (): Promise<BidResponse> => {
         try {
           const token = await this.opts.tokenSigner.sign({
             agentId: agent.agentId,
             taskId,
             phase: "bid",
           });
-          const controller = new AbortController();
-          const timer = setTimeout(() => controller.abort(), timeoutMs);
-          let res: Response;
-          try {
-            res = await fetchImpl(`${agent.baseUrl}/bid`, {
-              method: "POST",
-              headers: {
-                "content-type": "application/json",
-                authorization: `Bearer ${token}`,
-              },
-              body,
-              signal: controller.signal,
-            });
-          } finally {
-            clearTimeout(timer);
-          }
+          const res = await fetchImpl(`${agent.baseUrl}/bid`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              authorization: `Bearer ${token}`,
+            },
+            body,
+            signal: controller.signal,
+          });
           if (!res.ok) {
             return syntheticNoBid(taskId, agent.agentId, `agent returned ${res.status}`);
           }
@@ -205,8 +203,25 @@ export class HttpAuctionRunner implements AuctionRunner {
           const reason = err instanceof Error && err.name === "AbortError" ? "timeout" : "error";
           return syntheticNoBid(taskId, agent.agentId, reason);
         }
-      }),
-    );
+      })();
+      return {
+        agentId: agent.agentId,
+        abort: () => controller.abort(),
+        promise,
+      };
+    });
+
+    try {
+      return await collectBidResponsesAdaptive({
+        taskId,
+        pending,
+        totalTimeoutMs: this.opts.bidTimeoutMs ?? DEFAULT_BID_TIMEOUT_MS,
+        initialWaitMs: this.opts.bidInitialWaitMs ?? DEFAULT_BID_INITIAL_WAIT_MS,
+        extensionMs: this.opts.bidExtensionMs ?? DEFAULT_BID_EXTENSION_MS,
+      });
+    } finally {
+      for (const entry of pending) entry.abort();
+    }
   }
 
   private async execute(taskId: TaskId, agentId: AgentId, spec: TaskSpec) {
@@ -237,6 +252,85 @@ export class HttpAuctionRunner implements AuctionRunner {
     const body = (await res.json()) as unknown;
     return ResultSchema.parse(body);
   }
+}
+
+export interface PendingBidResponse {
+  agentId: AgentId;
+  promise: Promise<BidResponse>;
+  abort?: () => void;
+}
+
+export interface AdaptiveBidCollectionInput {
+  taskId: TaskId;
+  pending: PendingBidResponse[];
+  totalTimeoutMs: number;
+  initialWaitMs: number;
+  extensionMs: number;
+  wait?: (ms: number) => Promise<void>;
+}
+
+export async function collectBidResponsesAdaptive({
+  taskId,
+  pending,
+  totalTimeoutMs,
+  initialWaitMs,
+  extensionMs,
+  wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}: AdaptiveBidCollectionInput): Promise<BidResponse[]> {
+  const responses = new Map<AgentId, BidResponse>();
+  const unresolved = new Set(pending.map((entry) => entry.agentId));
+  const allSettled = Promise.allSettled(pending.map((entry) => entry.promise));
+
+  for (const entry of pending) {
+    entry.promise.then(
+      (response) => {
+        if (!unresolved.has(entry.agentId)) return;
+        unresolved.delete(entry.agentId);
+        responses.set(entry.agentId, response);
+      },
+      () => {
+        if (!unresolved.has(entry.agentId)) return;
+        unresolved.delete(entry.agentId);
+        responses.set(entry.agentId, syntheticNoBid(taskId, entry.agentId, "bid promise rejected"));
+      },
+    );
+  }
+
+  const start = Date.now();
+  let windowMs = Math.min(initialWaitMs, totalTimeoutMs);
+
+  while (unresolved.size > 0 && Date.now() - start < totalTimeoutMs && windowMs > 0) {
+    const responseCountBeforeWindow = responses.size;
+    await Promise.race([wait(windowMs), allSettled]);
+    await Promise.resolve();
+
+    const landedThisWindow = responses.size > responseCountBeforeWindow;
+    if (!shouldExtendBidWindow(responses, landedThisWindow, unresolved.size)) break;
+
+    const elapsed = Date.now() - start;
+    windowMs = Math.min(extensionMs, totalTimeoutMs - elapsed);
+  }
+
+  for (const entry of pending) {
+    if (!responses.has(entry.agentId)) {
+      unresolved.delete(entry.agentId);
+      entry.abort?.();
+      responses.set(entry.agentId, syntheticNoBid(taskId, entry.agentId, "adaptive timeout"));
+    }
+  }
+
+  return pending.map((entry) => responses.get(entry.agentId)!);
+}
+
+function shouldExtendBidWindow(
+  responses: ReadonlyMap<AgentId, BidResponse>,
+  landedThisWindow: boolean,
+  unresolvedCount: number,
+): boolean {
+  const realBidCount = Array.from(responses.values()).filter(
+    (response) => !isNoBid(response),
+  ).length;
+  return unresolvedCount > 0 && realBidCount >= 2 && landedThisWindow;
 }
 
 function syntheticNoBid(taskId: TaskId, agentId: AgentId, reason: string): BidResponse {

--- a/coordinator/test/auction/adaptive-bid-timeout.test.ts
+++ b/coordinator/test/auction/adaptive-bid-timeout.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { AgentId, Bid, BidResponse } from "@agent-tasker/protocol";
+import { collectBidResponsesAdaptive } from "../../src/auction/http-runner.js";
+
+function bidFor(agentId: AgentId, bidUsd: number): Bid {
+  return {
+    task_id: "task-adaptive",
+    agent_id: agentId,
+    tier: "frontier",
+    model_family: agentId.startsWith("gcp") ? "gemini" : agentId.startsWith("aws") ? "nova" : "gpt",
+    model_id: "stub-model",
+    est_input_tokens: 4000,
+    est_output_tokens: 1000,
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10.0,
+    bid_usd: bidUsd,
+    expires_at: "2026-05-21T01:00:00Z",
+    signature: "stub",
+  };
+}
+
+function delayedResponse(ms: number, response: BidResponse): Promise<BidResponse> {
+  return new Promise((resolve) => setTimeout(() => resolve(response), ms));
+}
+
+describe("collectBidResponsesAdaptive", () => {
+  it("extends the bid window when at least two real bids land in the initial window", async () => {
+    const responses = await collectBidResponsesAdaptive({
+      taskId: "task-adaptive",
+      totalTimeoutMs: 90,
+      initialWaitMs: 20,
+      extensionMs: 50,
+      pending: [
+        { agentId: "gcp-gemini", promise: delayedResponse(1, bidFor("gcp-gemini", 0.03)) },
+        { agentId: "aws-nova", promise: delayedResponse(5, bidFor("aws-nova", 0.04)) },
+        { agentId: "azure-gpt", promise: delayedResponse(35, bidFor("azure-gpt", 0.02)) },
+      ],
+    });
+
+    expect(responses.map((response) => response.agent_id)).toEqual([
+      "gcp-gemini",
+      "aws-nova",
+      "azure-gpt",
+    ]);
+    expect(responses.every((response) => !("status" in response))).toBe(true);
+  });
+
+  it("does not extend when fewer than two real bids have landed", async () => {
+    const responses = await collectBidResponsesAdaptive({
+      taskId: "task-adaptive",
+      totalTimeoutMs: 90,
+      initialWaitMs: 10,
+      extensionMs: 50,
+      pending: [
+        { agentId: "gcp-gemini", promise: delayedResponse(1, bidFor("gcp-gemini", 0.03)) },
+        { agentId: "aws-nova", promise: delayedResponse(35, bidFor("aws-nova", 0.02)) },
+      ],
+    });
+
+    expect(responses[0]).toMatchObject({ agent_id: "gcp-gemini", bid_usd: 0.03 });
+    expect(responses[1]).toMatchObject({
+      agent_id: "aws-nova",
+      status: "no_bid",
+      reason: "internal_error",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace fixed per-agent bid wait with adaptive bid collection
- use 2s initial wait, 1s extension windows, and 5s total cap by default
- extend only when at least two real bids have landed and the previous window had a response
- record pending agents as synthetic no_bid: internal_error at the cap
- add focused adaptive timeout tests

## Tests
- pnpm --filter @agent-tasker/coordinator exec vitest run test/auction/adaptive-bid-timeout.test.ts test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm exec prettier --check coordinator/src/auction/http-runner.ts coordinator/test/auction/adaptive-bid-timeout.test.ts coordinator/test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator test

Closes #52