### PR TITLE
Re-auction after execute failure

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -33,12 +33,11 @@ import type { AuctionRunner } from "./runner.js";
 //   auction price falls back to that bidder's own bid.
 // - Awards, marks executing, POSTs to {winner.baseUrl}/execute, records
 //   the result, completes.
-// - Any unrecoverable failure → store.failTask. Re-auction on /execute
-//   failure is #53.
+// - Re-auctions on /execute failure by excluding the failed winner and
+//   selecting from remaining eligible bids while at least two agents remain.
 //
 // What's still out of scope (separate issues):
 // - Adaptive bid timeout (#52)
-// - Re-auction on /execute failure (#53)
 // - Score-weighted auction layer (#81)
 
 export interface AgentEndpoint {
@@ -133,30 +132,57 @@ export class HttpAuctionRunner implements AuctionRunner {
       return;
     }
 
-    const award = selectVickreyAward(
-      eligibleBids,
-      this.opts.accuracyByAgent,
-      this.opts.tieBreakRandom,
-    );
+    await this.awardAndExecuteWithReauction(taskId, task.spec, eligibleBids);
+  }
 
-    await this.opts.store.awardTask({
-      taskId,
-      winnerAgentId: award.winner.agent_id,
-      auctionPriceUsd: award.auctionPriceUsd,
-      winningBidUsd: award.winningBidUsd,
-    });
+  private async awardAndExecuteWithReauction(
+    taskId: TaskId,
+    spec: TaskSpec,
+    eligibleBids: readonly Bid[],
+  ): Promise<void> {
+    const remainingBids = [...eligibleBids];
+    const failures: string[] = [];
 
-    await this.opts.store.markExecuting(taskId);
+    while (remainingBids.length > 0) {
+      const award = selectVickreyAward(
+        remainingBids,
+        this.opts.accuracyByAgent,
+        this.opts.tieBreakRandom,
+      );
 
-    try {
-      const result = await this.execute(taskId, award.winner.agent_id, task.spec);
-      await this.opts.store.completeTask({ taskId, result });
-    } catch (err) {
-      await this.opts.store.failTask({
+      await this.opts.store.awardTask({
         taskId,
-        reason: `winner ${award.winner.agent_id} failed /execute: ${(err as Error).message}`,
+        winnerAgentId: award.winner.agent_id,
+        auctionPriceUsd: award.auctionPriceUsd,
+        winningBidUsd: award.winningBidUsd,
       });
+
+      await this.opts.store.markExecuting(taskId);
+
+      try {
+        const result = await this.execute(taskId, award.winner.agent_id, spec);
+        await this.opts.store.completeTask({ taskId, result });
+        return;
+      } catch (err) {
+        failures.push(`winner ${award.winner.agent_id} failed /execute: ${(err as Error).message}`);
+        const failedIndex = remainingBids.findIndex(
+          (bid) => bid.agent_id === award.winner.agent_id,
+        );
+        if (failedIndex >= 0) remainingBids.splice(failedIndex, 1);
+        if (remainingBids.length <= 1) {
+          await this.opts.store.failTask({
+            taskId,
+            reason: `re-auction exhausted after execute failure: ${failures.join("; ")}`,
+          });
+          return;
+        }
+      }
     }
+
+    await this.opts.store.failTask({
+      taskId,
+      reason: `re-auction exhausted without an executable winner: ${failures.join("; ")}`,
+    });
   }
 
   // Sends POST /bid to every configured agent in parallel and waits with the

--- a/coordinator/src/auction/state-machine.ts
+++ b/coordinator/src/auction/state-machine.ts
@@ -1,13 +1,12 @@
 import type { TaskStatus } from "@agent-tasker/protocol";
 
 // Auction lifecycle per CLAUDE.md → Bidding protocol. Terminal states have no
-// outgoing transitions; re-auction on /execute failure (#53) is modeled as a
-// *new* task lifecycle that links back to the original via a parent reference,
-// not as a transition out of `failed`.
+// outgoing transitions. Re-auction on /execute failure re-awards the same task
+// attempt from `executing` back to `awarded`, excluding the failed winner.
 export const VALID_TRANSITIONS: Record<TaskStatus, readonly TaskStatus[]> = {
   bidding: ["awarded", "failed"],
   awarded: ["executing", "failed"],
-  executing: ["completed", "failed"],
+  executing: ["awarded", "completed", "failed"],
   completed: [],
   failed: [],
 };

--- a/coordinator/src/ledger/store.ts
+++ b/coordinator/src/ledger/store.ts
@@ -38,9 +38,9 @@ export interface LedgerStore {
 
   listBids(taskId: TaskId): Promise<BidRecord[]>;
 
-  // Transitions bidding → awarded. Idempotent only if the *same* winner +
-  // pricing is reasserted; throws InvalidTransitionError if status has
-  // already moved past `awarded` (i.e. someone else has already executed).
+  // Transitions bidding → awarded. Re-auction may also transition
+  // executing → awarded with a different winner after excluding a failed
+  // executor. Idempotent only if the *same* winner + pricing is reasserted.
   awardTask(input: AwardTaskInput): Promise<TaskRecord>;
 
   // Transitions awarded → executing. Idempotent if already executing.

--- a/coordinator/test/auction/state-machine.test.ts
+++ b/coordinator/test/auction/state-machine.test.ts
@@ -28,6 +28,10 @@ describe("VALID_TRANSITIONS", () => {
     expect(canTransition("executing", "completed")).toBe(true);
   });
 
+  it("allows re-auction from executing back to awarded", () => {
+    expect(canTransition("executing", "awarded")).toBe(true);
+  });
+
   it("rejects skipping states", () => {
     expect(canTransition("bidding", "executing")).toBe(false);
     expect(canTransition("bidding", "completed")).toBe(false);

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -380,4 +380,50 @@ describe("HttpAuctionRunner", () => {
     expect(task?.failure_reason).toMatch(/gcp-gemini/);
     expect(task?.failure_reason).toMatch(/500|execute/i);
   });
+
+  it("re-auctions after execute failure and settles with the next winner", async () => {
+    const taskId = "task-reauction";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.01, req.task_id),
+      onExecute: () => {
+        throw new Error("model overloaded");
+      },
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (req) => bidFor("aws-nova", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "aws-nova",
+        output: "nova recovered it",
+        actual_usage: { input_tokens: 4000, output_tokens: 1000 },
+      }),
+    });
+    const azure = await startFakeAgent({
+      agentId: "azure-gpt",
+      onBid: (req) => bidFor("azure-gpt", 0.03, req.task_id),
+    });
+    agents.push(gemini, nova, azure);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+        { agentId: "azure-gpt", baseUrl: azure.url },
+      ],
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
+    expect(task?.winner_agent_id).toBe("aws-nova");
+    expect(task?.winning_bid_usd).toBe(0.02);
+    expect(task?.auction_price_usd).toBe(0.03);
+    expect(task?.result?.output).toBe("nova recovered it");
+
+    expect(gemini.executeCalls).toBe(1);
+    expect(nova.executeCalls).toBe(1);
+    expect(azure.executeCalls).toBe(0);
+  });
 });

--- a/coordinator/test/ledger/in-memory-store.test.ts
+++ b/coordinator/test/ledger/in-memory-store.test.ts
@@ -239,6 +239,28 @@ describe("awardTask", () => {
       }),
     ).rejects.toThrow(InvalidTransitionError);
   });
+
+  it("allows re-awarding a different winner after execution starts", async () => {
+    await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.05,
+      winningBidUsd: 0.02,
+    });
+    await store.markExecuting(TASK_ID);
+
+    const record = await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "aws-nova",
+      auctionPriceUsd: 0.04,
+      winningBidUsd: 0.03,
+    });
+
+    expect(record.status).toBe("awarded");
+    expect(record.winner_agent_id).toBe("aws-nova");
+    expect(record.auction_price_usd).toBe(0.04);
+    expect(record.winning_bid_usd).toBe(0.03);
+  });
 });
 
 describe("markExecuting / completeTask / failTask", () => {


### PR DESCRIPTION
## Summary
- re-auction after a winner fails /execute by excluding the failed winner
- re-award the same task from executing back to awarded while at least two candidates remain
- fail once re-auction is exhausted with one or fewer remaining candidates
- add state-machine, ledger, and HTTP runner coverage for re-award behavior

## Tests
- pnpm --filter @agent-tasker/coordinator exec vitest run test/auction/state-machine.test.ts test/ledger/in-memory-store.test.ts test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm exec prettier --check coordinator/src/auction/http-runner.ts coordinator/src/auction/state-machine.ts coordinator/src/ledger/store.ts coordinator/test/auction/state-machine.test.ts coordinator/test/ledger/in-memory-store.test.ts coordinator/test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator test

Closes #53