### PR TITLE
Add execution overrun cap

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -6,6 +6,7 @@ import {
   type BidResponse,
   type JwtPhase,
   type PricingEntry,
+  type Result,
   type TaskId,
   type TaskSpec,
   type Tier,
@@ -72,6 +73,7 @@ const DEFAULT_BID_TIMEOUT_MS = 5_000;
 const DEFAULT_BID_INITIAL_WAIT_MS = 2_000;
 const DEFAULT_BID_EXTENSION_MS = 1_000;
 const DEFAULT_EXECUTE_TIMEOUT_MS = 60_000;
+export const EXECUTION_OVERRUN_MULTIPLIER = 10;
 
 export class HttpAuctionRunner implements AuctionRunner {
   private readonly settlements = new Map<TaskId, Promise<void>>();
@@ -161,6 +163,7 @@ export class HttpAuctionRunner implements AuctionRunner {
 
       try {
         const result = await this.execute(taskId, award.winner.agent_id, spec);
+        enforceExecutionOverrunCap(award.winner, result);
         await this.opts.store.completeTask({ taskId, result });
         return;
       } catch (err) {
@@ -277,6 +280,27 @@ export class HttpAuctionRunner implements AuctionRunner {
     if (!res.ok) throw new Error(`execute returned ${res.status}`);
     const body = (await res.json()) as unknown;
     return ResultSchema.parse(body);
+  }
+}
+
+export function computeActualUsdFromBidPrices(bid: Bid, result: Result): number {
+  return (
+    (result.actual_usage.input_tokens / 1_000_000) * bid.price_in_usd_per_mtoken +
+    (result.actual_usage.output_tokens / 1_000_000) * bid.price_out_usd_per_mtoken
+  );
+}
+
+export function enforceExecutionOverrunCap(
+  winningBid: Bid,
+  result: Result,
+  multiplier = EXECUTION_OVERRUN_MULTIPLIER,
+): void {
+  const actualUsd = computeActualUsdFromBidPrices(winningBid, result);
+  const maxUsd = winningBid.bid_usd * multiplier;
+  if (actualUsd > maxUsd) {
+    throw new Error(
+      `execution overrun exceeded ${multiplier}x bid: actual_usd=${actualUsd}, max_usd=${maxUsd}`,
+    );
   }
 }
 

--- a/coordinator/test/auction/execution-overrun.test.ts
+++ b/coordinator/test/auction/execution-overrun.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { AgentId, Bid, Result } from "@agent-tasker/protocol";
+import {
+  EXECUTION_OVERRUN_MULTIPLIER,
+  computeActualUsdFromBidPrices,
+  enforceExecutionOverrunCap,
+} from "../../src/auction/http-runner.js";
+
+function bidFor(agentId: AgentId, bidUsd: number): Bid {
+  return {
+    task_id: "task-overrun",
+    agent_id: agentId,
+    tier: "frontier",
+    model_family: agentId.startsWith("gcp") ? "gemini" : agentId.startsWith("aws") ? "nova" : "gpt",
+    model_id: "stub-model",
+    est_input_tokens: 4000,
+    est_output_tokens: 1000,
+    price_in_usd_per_mtoken: 1,
+    price_out_usd_per_mtoken: 2,
+    bid_usd: bidUsd,
+    expires_at: "2026-05-21T01:00:00Z",
+    signature: "stub",
+  };
+}
+
+function resultWithUsage(inputTokens: number, outputTokens: number): Result {
+  return {
+    task_id: "task-overrun",
+    agent_id: "gcp-gemini",
+    output: "summary",
+    actual_usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+    },
+  };
+}
+
+describe("execution overrun cap", () => {
+  it("computes actual USD using the winner bid's prices", () => {
+    expect(
+      computeActualUsdFromBidPrices(bidFor("gcp-gemini", 0.02), resultWithUsage(1000, 2000)),
+    ).toBe(0.005);
+  });
+
+  it("allows actual cost at exactly 10x the winning bid", () => {
+    const bid = bidFor("gcp-gemini", 0.001);
+    const result = resultWithUsage(10_000, 0);
+
+    expect(() => enforceExecutionOverrunCap(bid, result)).not.toThrow();
+    expect(computeActualUsdFromBidPrices(bid, result)).toBe(
+      bid.bid_usd * EXECUTION_OVERRUN_MULTIPLIER,
+    );
+  });
+
+  it("throws when actual cost exceeds 10x the winning bid", () => {
+    const bid = bidFor("gcp-gemini", 0.001);
+    const result = resultWithUsage(10_001, 0);
+
+    expect(() => enforceExecutionOverrunCap(bid, result)).toThrow(/execution overrun exceeded 10x/);
+  });
+});

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -426,4 +426,53 @@ describe("HttpAuctionRunner", () => {
     expect(nova.executeCalls).toBe(1);
     expect(azure.executeCalls).toBe(0);
   });
+
+  it("treats execution overrun as failure and re-auctions", async () => {
+    const taskId = "task-overrun-reauction";
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.001, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "gcp-gemini",
+        output: "too expensive",
+        actual_usage: { input_tokens: 20_000_000, output_tokens: 0 },
+      }),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (req) => bidFor("aws-nova", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "aws-nova",
+        output: "nova stayed in budget",
+        actual_usage: { input_tokens: 4000, output_tokens: 1000 },
+      }),
+    });
+    const azure = await startFakeAgent({
+      agentId: "azure-gpt",
+      onBid: (req) => bidFor("azure-gpt", 0.03, req.task_id),
+    });
+    agents.push(gemini, nova, azure);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+        { agentId: "azure-gpt", baseUrl: azure.url },
+      ],
+    });
+
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
+    expect(task?.winner_agent_id).toBe("aws-nova");
+    expect(task?.winning_bid_usd).toBe(0.02);
+    expect(task?.auction_price_usd).toBe(0.03);
+    expect(task?.result?.output).toBe("nova stayed in budget");
+
+    expect(gemini.executeCalls).toBe(1);
+    expect(nova.executeCalls).toBe(1);
+    expect(azure.executeCalls).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- enforce a 10x winning-bid cost cap on execution results before settlement
- treat over-cap executions as failures so the existing re-auction path can exclude the runaway winner
- add unit and integration coverage for cap math and re-auction behavior

Closes #54

## Tests
- pnpm --filter @agent-tasker/coordinator exec vitest run test/auction/execution-overrun.test.ts test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm exec prettier --check coordinator/src/auction/http-runner.ts coordinator/test/auction/execution-overrun.test.ts coordinator/test/integration/http-runner.test.ts
- pnpm --filter @agent-tasker/coordinator test