### PR TITLE
Add Azure subscription bootstrap

### DIFF
--- a/infra/azure-bootstrap/.terraform.lock.hcl
+++ b/infra/azure-bootstrap/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "3.8.0"
+  constraints = "~> 3.8"
+  hashes = [
+    "h1:c2POQkoFPDVvySvxV17WxiVPA2gBFdrFza2o/nf752c=",
+    "zh:0d26cfbf9417acd1c2295ccd5b0052abeac85ad1c3f6422ff09bf6a1ce16f00d",
+    "zh:144d4ea92fed541a6376bc76ad65ba4738dfd7bcab4c9d6cc20d35001338d06d",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:2061d2cb64d8167d0af37e6610d0dc051977bd1ccc0e5cdd5ab02525ee239f96",
+    "zh:75562fdc3b313b7e538907199bfa588a1fcbc40113b0f3b7bfb496fbc358a32f",
+    "zh:78bef022ae9b1b0c636b7dd32bcda13fb273023f3a888cc005f3aa20e365b417",
+    "zh:ad8dbee59843154f8e93b24db9939a4257d13c7c86331eb93f1691294bc4e31f",
+    "zh:b3d83d7ac57073631704336a188cb746c473f728fc7ccb76abecb520e83fdf65",
+    "zh:c0bf9e0be73843de9089597be2720e4093b3ba320fbad99ab86da47681e77949",
+    "zh:c9a4c27d2b0800d3f4ece19d66c1fa574f7cd4ff66277af8f120d65e8f03f48e",
+    "zh:cd9ad8c848e17d9824045c33132cc0e87aa4d58cdb7bee6c0f6c3f9bc27892d5",
+    "zh:fbcafc21cdd19451274b905f9ee8a5b758ca63cc231e7544c815642e4a399c6d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.74.0"
+  constraints = "~> 4.72"
+  hashes = [
+    "h1:zTMbAZqXUEqhQNkj8Q1n3zvfqur4cXSY9HSrRbEGz08=",
+    "zh:004decccb53c332710894b890f3a5fd724aeeb440c32a8d337d6a2fe9f4427cc",
+    "zh:10ee232dfa76c987cbd226f81f825bbbe36786a8097fcb811ff655f2b471959c",
+    "zh:43ffac27efbbcc741ec6e0e96e0def151ddb04d7ce7fd0b67032dc4cdaa20e90",
+    "zh:459438a78b6cb43ba09e2c11832c6234848a08ab264dc2efe809db8b073057d6",
+    "zh:4f156cb69b8ed3d43b52fd90106d06609736019bc79faf6c1695aa942bbdade4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:921285f6e9beb02a7482bb8036e6b032255bc0c4aa61a11def63870c1ee10672",
+    "zh:994cf51bdc8aefa7e8a93474a322c9231df3512e85bc603c9295343ebc31228c",
+    "zh:9c6136ed2ae6cbbbfc57e74cdd7b83af9faea5ca3c7e3fa82877aca0b215fd27",
+    "zh:a0349f105af1882bf9d795a6fdac2fbe71f2e588ca6f4587b87de7b5423a0be8",
+    "zh:c7a91501928e23d5d8f088909aaa633a13d5f032fbc2043c6618305beb090058",
+    "zh:f11cb049e16a459f799c4f394ac20f8e9b3d0ef210cf56cb0850e0beffeaf4e1",
+  ]
+}

--- a/infra/azure-bootstrap/README.md
+++ b/infra/azure-bootstrap/README.md
@@ -1,0 +1,10 @@
+# Azure Bootstrap
+
+Bootstraps the Azure subscription pieces that later Azure/GPT infra roots depend on:
+
+- a resource group for the Phase 3 Azure/GPT agent
+- a Storage Account + Blob container for Terraform state
+- a GitHub Actions OIDC CI service principal scoped to the resource group and state storage
+- a separate Microsoft Entra app registration/service principal for the Azure/GPT agent
+
+This root intentionally has no remote backend block: it creates the storage account that later Azure roots should use as their `azurerm` backend.

--- a/infra/azure-bootstrap/bootstrap.tf
+++ b/infra/azure-bootstrap/bootstrap.tf
@@ -1,0 +1,37 @@
+resource "azurerm_resource_group" "bootstrap" {
+  name     = "${local.name_prefix}-azure"
+  location = var.location
+  tags     = local.common_tags
+}
+
+resource "azurerm_storage_account" "tfstate" {
+  name                     = local.storage_account_name
+  resource_group_name      = azurerm_resource_group.bootstrap.name
+  location                 = azurerm_resource_group.bootstrap.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  allow_nested_items_to_be_public = false
+  min_tls_version                 = "TLS1_2"
+  shared_access_key_enabled       = false
+
+  blob_properties {
+    versioning_enabled = true
+
+    delete_retention_policy {
+      days = 14
+    }
+
+    container_delete_retention_policy {
+      days = 14
+    }
+  }
+
+  tags = local.common_tags
+}
+
+resource "azurerm_storage_container" "tfstate" {
+  name                  = var.state_container_name
+  storage_account_id    = azurerm_storage_account.tfstate.id
+  container_access_type = "private"
+}

--- a/infra/azure-bootstrap/identity.tf
+++ b/infra/azure-bootstrap/identity.tf
@@ -1,0 +1,39 @@
+resource "azuread_application" "ci" {
+  display_name     = "${local.name_prefix}-azure-ci"
+  sign_in_audience = "AzureADMyOrg"
+}
+
+resource "azuread_service_principal" "ci" {
+  client_id                    = azuread_application.ci.client_id
+  app_role_assignment_required = false
+}
+
+resource "azuread_application_federated_identity_credential" "ci_main_branch" {
+  application_id = azuread_application.ci.id
+  display_name   = "github-${var.github_owner}-${var.github_repository}-${var.github_branch}"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:${var.github_owner}/${var.github_repository}:ref:refs/heads/${var.github_branch}"
+}
+
+resource "azurerm_role_assignment" "ci_rg_contributor" {
+  scope                = azurerm_resource_group.bootstrap.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.ci.object_id
+}
+
+resource "azurerm_role_assignment" "ci_state_blob_contributor" {
+  scope                = azurerm_storage_account.tfstate.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azuread_service_principal.ci.object_id
+}
+
+resource "azuread_application" "agent" {
+  display_name     = "${local.name_prefix}-azure-gpt-agent"
+  sign_in_audience = "AzureADMyOrg"
+}
+
+resource "azuread_service_principal" "agent" {
+  client_id                    = azuread_application.agent.client_id
+  app_role_assignment_required = false
+}

--- a/infra/azure-bootstrap/main.tf
+++ b/infra/azure-bootstrap/main.tf
@@ -1,0 +1,29 @@
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+
+  features {}
+}
+
+provider "azuread" {
+  tenant_id = var.tenant_id
+}
+
+locals {
+  name_prefix = "${var.project}-${var.env}"
+
+  common_tags = merge(
+    {
+      project = var.project
+      env     = var.env
+      module  = "azure-bootstrap"
+    },
+    var.tags,
+  )
+
+  storage_account_base = replace("${var.project}${var.env}tfstate", "-", "")
+  storage_account_name = coalesce(
+    var.storage_account_name,
+    substr("${local.storage_account_base}${var.storage_account_suffix}", 0, 24),
+  )
+}

--- a/infra/azure-bootstrap/outputs.tf
+++ b/infra/azure-bootstrap/outputs.tf
@@ -1,0 +1,39 @@
+output "resource_group_name" {
+  description = "Azure resource group that will host Azure/GPT agent resources."
+  value       = azurerm_resource_group.bootstrap.name
+}
+
+output "resource_group_id" {
+  description = "Azure resource group ID for downstream role assignments and scoped deploys."
+  value       = azurerm_resource_group.bootstrap.id
+}
+
+output "state_storage_account_name" {
+  description = "Storage account name for Azure Terraform state."
+  value       = azurerm_storage_account.tfstate.name
+}
+
+output "state_container_name" {
+  description = "Blob container name for Azure Terraform state."
+  value       = azurerm_storage_container.tfstate.name
+}
+
+output "ci_client_id" {
+  description = "Client ID for the GitHub Actions OIDC CI service principal."
+  value       = azuread_application.ci.client_id
+}
+
+output "ci_object_id" {
+  description = "Object ID for the GitHub Actions OIDC CI service principal."
+  value       = azuread_service_principal.ci.object_id
+}
+
+output "agent_client_id" {
+  description = "Client ID for the Azure/GPT agent app registration."
+  value       = azuread_application.agent.client_id
+}
+
+output "agent_service_principal_object_id" {
+  description = "Object ID for the Azure/GPT agent enterprise application."
+  value       = azuread_service_principal.agent.object_id
+}

--- a/infra/azure-bootstrap/variables.tf
+++ b/infra/azure-bootstrap/variables.tf
@@ -1,0 +1,88 @@
+variable "subscription_id" {
+  description = "Azure subscription ID that will host the Phase 3 Azure/GPT agent resources."
+  type        = string
+}
+
+variable "tenant_id" {
+  description = "Microsoft Entra tenant ID for the subscription and app registrations."
+  type        = string
+}
+
+variable "project" {
+  description = "Project name prefix used in resource naming and tags."
+  type        = string
+  default     = "agent-tasker"
+}
+
+variable "env" {
+  description = "Environment name (e.g. dev, staging, prod). Used in resource names."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,16}$", var.env))
+    error_message = "env must be 1-16 chars of [a-z0-9-]."
+  }
+}
+
+variable "location" {
+  description = "Azure region for the bootstrap resource group and Terraform state storage."
+  type        = string
+  default     = "eastus"
+}
+
+variable "tags" {
+  description = "Extra tags to merge onto every Azure resource that supports tags."
+  type        = map(string)
+  default     = {}
+}
+
+variable "storage_account_name" {
+  description = "Optional globally unique Azure Storage account name for Terraform state. Must be 3-24 lowercase letters/numbers. Defaults to a deterministic project/env name."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.storage_account_name == null || can(regex("^[a-z0-9]{3,24}$", var.storage_account_name))
+    error_message = "storage_account_name must be 3-24 chars of [a-z0-9]."
+  }
+}
+
+variable "storage_account_suffix" {
+  description = "Optional lowercase alphanumeric suffix to make the default state storage account name globally unique."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{0,8}$", var.storage_account_suffix))
+    error_message = "storage_account_suffix must be 0-8 chars of [a-z0-9]."
+  }
+}
+
+variable "state_container_name" {
+  description = "Blob container name for Terraform state."
+  type        = string
+  default     = "tfstate"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.state_container_name))
+    error_message = "state_container_name must be a valid Azure Blob container name."
+  }
+}
+
+variable "github_owner" {
+  description = "GitHub organization/user that owns the repository using the CI service principal."
+  type        = string
+  default     = "lopeztech"
+}
+
+variable "github_repository" {
+  description = "GitHub repository name using the CI service principal."
+  type        = string
+  default     = "agent-tasker"
+}
+
+variable "github_branch" {
+  description = "GitHub branch allowed to use the CI service principal via OIDC."
+  type        = string
+  default     = "main"
+}

--- a/infra/azure-bootstrap/versions.tf
+++ b/infra/azure-bootstrap/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.8"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.72"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone Azure bootstrap Terraform root for the Phase 3 Azure/GPT agent foundation
- create the bootstrap resource group, Terraform state storage account/container, CI OIDC service principal, and Azure/GPT agent app registration
- output downstream IDs needed by later Azure infra roots

Closes #55

## Tests
- terraform fmt -check -recursive infra
- terraform -chdir=infra/azure-bootstrap validate -no-color
- CI-style terraform init/validate loop across infra roots
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test (rerun outside sandbox because coordinator integration tests bind local ports)