### PR TITLE
Add Azure GPT container app stack

### DIFF
--- a/infra/agent-azure-gpt/.terraform.lock.hcl
+++ b/infra/agent-azure-gpt/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.74.0"
+  constraints = "~> 4.72"
+  hashes = [
+    "h1:zTMbAZqXUEqhQNkj8Q1n3zvfqur4cXSY9HSrRbEGz08=",
+    "zh:004decccb53c332710894b890f3a5fd724aeeb440c32a8d337d6a2fe9f4427cc",
+    "zh:10ee232dfa76c987cbd226f81f825bbbe36786a8097fcb811ff655f2b471959c",
+    "zh:43ffac27efbbcc741ec6e0e96e0def151ddb04d7ce7fd0b67032dc4cdaa20e90",
+    "zh:459438a78b6cb43ba09e2c11832c6234848a08ab264dc2efe809db8b073057d6",
+    "zh:4f156cb69b8ed3d43b52fd90106d06609736019bc79faf6c1695aa942bbdade4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:921285f6e9beb02a7482bb8036e6b032255bc0c4aa61a11def63870c1ee10672",
+    "zh:994cf51bdc8aefa7e8a93474a322c9231df3512e85bc603c9295343ebc31228c",
+    "zh:9c6136ed2ae6cbbbfc57e74cdd7b83af9faea5ca3c7e3fa82877aca0b215fd27",
+    "zh:a0349f105af1882bf9d795a6fdac2fbe71f2e588ca6f4587b87de7b5423a0be8",
+    "zh:c7a91501928e23d5d8f088909aaa633a13d5f032fbc2043c6618305beb090058",
+    "zh:f11cb049e16a459f799c4f394ac20f8e9b3d0ef210cf56cb0850e0beffeaf4e1",
+  ]
+}

--- a/infra/agent-azure-gpt/backend.hcl.example
+++ b/infra/agent-azure-gpt/backend.hcl.example
@@ -1,0 +1,10 @@
+# Copy to backend.hcl per environment and pass to:
+#   terraform init -backend-config=backend.hcl
+#
+# Uses the Azure Storage account/container created by infra/azure-bootstrap.
+
+resource_group_name  = "agent-tasker-dev-azure"
+storage_account_name = "agenttaskerdevtfstate"
+container_name       = "tfstate"
+key                  = "agent-azure-gpt/dev.tfstate"
+use_azuread_auth     = true

--- a/infra/agent-azure-gpt/container_app.tf
+++ b/infra/agent-azure-gpt/container_app.tf
@@ -1,0 +1,81 @@
+resource "azurerm_log_analytics_workspace" "agent" {
+  name                = "${local.name_prefix}-azure-gpt-logs"
+  location            = data.azurerm_resource_group.agent.location
+  resource_group_name = data.azurerm_resource_group.agent.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  tags                = local.common_tags
+}
+
+resource "azurerm_container_app_environment" "agent" {
+  name                       = "${local.name_prefix}-azure-gpt-env"
+  location                   = data.azurerm_resource_group.agent.location
+  resource_group_name        = data.azurerm_resource_group.agent.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.agent.id
+  tags                       = local.common_tags
+}
+
+resource "azurerm_container_app" "agent" {
+  name                         = "${local.name_prefix}-azure-gpt"
+  container_app_environment_id = azurerm_container_app_environment.agent.id
+  resource_group_name          = data.azurerm_resource_group.agent.name
+  revision_mode                = "Single"
+  tags                         = local.common_tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = var.agent_port
+    transport        = "auto"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    min_replicas = var.agent_min_replicas
+    max_replicas = var.agent_max_replicas
+
+    container {
+      name   = "azure-gpt"
+      image  = var.agent_image
+      cpu    = var.agent_cpu
+      memory = var.agent_memory
+
+      env {
+        name  = "AGENT_ID"
+        value = "azure-gpt"
+      }
+
+      env {
+        name  = "JWKS_URL"
+        value = var.jwks_url
+      }
+
+      env {
+        name  = "AZURE_OPENAI_ENDPOINT"
+        value = var.azure_openai_endpoint
+      }
+
+      env {
+        name  = "AZURE_OPENAI_DEPLOYMENT"
+        value = var.azure_openai_deployment
+      }
+
+      env {
+        name  = "AZURE_OPENAI_API_KEY_SECRET_NAME"
+        value = var.azure_openai_api_key_secret_name
+      }
+
+      env {
+        name  = "KEY_VAULT_URI"
+        value = azurerm_key_vault.agent.vault_uri
+      }
+    }
+  }
+}

--- a/infra/agent-azure-gpt/key_vault.tf
+++ b/infra/agent-azure-gpt/key_vault.tf
@@ -1,0 +1,45 @@
+resource "azurerm_key_vault" "agent" {
+  name                       = local.key_vault_name
+  location                   = data.azurerm_resource_group.agent.location
+  resource_group_name        = data.azurerm_resource_group.agent.name
+  tenant_id                  = var.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+  tags                       = local.common_tags
+}
+
+resource "azurerm_key_vault_access_policy" "deployer" {
+  key_vault_id = azurerm_key_vault.agent.id
+  tenant_id    = var.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  secret_permissions = [
+    "Delete",
+    "Get",
+    "List",
+    "Set",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "agent" {
+  key_vault_id = azurerm_key_vault.agent.id
+  tenant_id    = var.tenant_id
+  object_id    = azurerm_container_app.agent.identity[0].principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}
+
+resource "azurerm_key_vault_secret" "azure_openai_api_key" {
+  count        = var.azure_openai_api_key == null ? 0 : 1
+  name         = var.azure_openai_api_key_secret_name
+  value        = var.azure_openai_api_key
+  key_vault_id = azurerm_key_vault.agent.id
+
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+  ]
+}

--- a/infra/agent-azure-gpt/main.tf
+++ b/infra/agent-azure-gpt/main.tf
@@ -1,0 +1,30 @@
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azurerm_resource_group" "agent" {
+  name = var.resource_group_name
+}
+
+locals {
+  name_prefix = "${var.project}-${var.env}"
+
+  common_tags = merge(
+    {
+      project = var.project
+      env     = var.env
+      module  = "agent-azure-gpt"
+    },
+    var.tags,
+  )
+
+  key_vault_name = coalesce(
+    var.key_vault_name,
+    substr(replace("${var.project}${var.env}azgptkv", "-", ""), 0, 24),
+  )
+}

--- a/infra/agent-azure-gpt/outputs.tf
+++ b/infra/agent-azure-gpt/outputs.tf
@@ -1,0 +1,24 @@
+output "agent_url" {
+  description = "Public HTTPS URL for the Azure/GPT Container App. Coordinator per-agent endpoint config points at this."
+  value       = "https://${azurerm_container_app.agent.latest_revision_fqdn}"
+}
+
+output "agent_principal_id" {
+  description = "Managed identity principal ID for the Azure/GPT Container App."
+  value       = azurerm_container_app.agent.identity[0].principal_id
+}
+
+output "key_vault_uri" {
+  description = "Key Vault URI that stores the Azure OpenAI credential."
+  value       = azurerm_key_vault.agent.vault_uri
+}
+
+output "azure_openai_api_key_secret_name" {
+  description = "Key Vault secret name the Azure/GPT agent reads for the Azure OpenAI API key."
+  value       = var.azure_openai_api_key_secret_name
+}
+
+output "log_analytics_workspace_id" {
+  description = "Log Analytics workspace ID backing the Azure/GPT Container Apps environment."
+  value       = azurerm_log_analytics_workspace.agent.id
+}

--- a/infra/agent-azure-gpt/variables.tf
+++ b/infra/agent-azure-gpt/variables.tf
@@ -1,0 +1,111 @@
+variable "subscription_id" {
+  description = "Azure subscription ID hosting the Azure/GPT agent stack."
+  type        = string
+}
+
+variable "tenant_id" {
+  description = "Microsoft Entra tenant ID for the subscription and Key Vault access policies."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Bootstrap resource group name from infra/azure-bootstrap."
+  type        = string
+}
+
+variable "project" {
+  description = "Project name prefix used in resource naming and tags."
+  type        = string
+  default     = "agent-tasker"
+}
+
+variable "env" {
+  description = "Environment name (e.g. dev, staging, prod). Used in resource names."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,16}$", var.env))
+    error_message = "env must be 1-16 chars of [a-z0-9-]."
+  }
+}
+
+variable "tags" {
+  description = "Extra tags to merge onto every Azure resource that supports tags."
+  type        = map(string)
+  default     = {}
+}
+
+variable "agent_image" {
+  description = "Container image for the Azure/GPT agent. Defaults to Azure's hello-world image so Terraform can stand up the stack before the real image exists."
+  type        = string
+  default     = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+}
+
+variable "agent_min_replicas" {
+  description = "Minimum Container Apps replicas. Zero keeps the Azure/GPT agent cheap at idle."
+  type        = number
+  default     = 0
+}
+
+variable "agent_max_replicas" {
+  description = "Maximum Container Apps replicas. This is a cost backstop for bid/execute traffic."
+  type        = number
+  default     = 10
+}
+
+variable "agent_cpu" {
+  description = "CPU allocated to the Azure/GPT agent container."
+  type        = number
+  default     = 0.5
+}
+
+variable "agent_memory" {
+  description = "Memory allocated to the Azure/GPT agent container."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "agent_port" {
+  description = "Container port that serves /bid, /execute, and /health."
+  type        = number
+  default     = 8080
+}
+
+variable "jwks_url" {
+  description = "Coordinator JWKS URL the Azure/GPT agent will use for RS256 token verification."
+  type        = string
+}
+
+variable "azure_openai_endpoint" {
+  description = "Azure OpenAI endpoint URL used by the Azure/GPT agent."
+  type        = string
+}
+
+variable "azure_openai_deployment" {
+  description = "Azure OpenAI deployment name pinned for the Azure/GPT execution model."
+  type        = string
+}
+
+variable "azure_openai_api_key_secret_name" {
+  description = "Key Vault secret name that stores the Azure OpenAI API key."
+  type        = string
+  default     = "azure-openai-api-key"
+}
+
+variable "key_vault_name" {
+  description = "Optional globally unique Key Vault name. Must be 3-24 alphanumeric/hyphen chars, start with a letter, and end with a letter or number."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.key_vault_name == null || can(regex("^[A-Za-z][A-Za-z0-9-]{1,22}[A-Za-z0-9]$", var.key_vault_name))
+    error_message = "key_vault_name must be 3-24 chars, start with a letter, and end with a letter or number."
+  }
+}
+
+variable "azure_openai_api_key" {
+  description = "Optional Azure OpenAI API key to write into Key Vault. Leave null when the secret is managed out-of-band."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/infra/agent-azure-gpt/versions.tf
+++ b/infra/agent-azure-gpt/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.72"
+    }
+  }
+
+  # Backend is left as a partial config so each environment supplies the
+  # Azure Storage account created by infra/azure-bootstrap:
+  #
+  #   terraform init -backend-config=backend.hcl
+  #
+  # See backend.hcl.example.
+  backend "azurerm" {}
+}


### PR DESCRIPTION
## Summary
- add an Azure/GPT Terraform root using Container Apps with public ingress for /bid, /execute, and /health
- provision Log Analytics, managed identity, Key Vault, and optional Azure OpenAI API key secret wiring
- add azurerm backend example and outputs for coordinator endpoint and downstream identity wiring

Closes #56

## Tests
- terraform -chdir=infra/agent-azure-gpt validate -no-color
- terraform fmt -check -recursive infra
- CI-style terraform init/validate loop across infra roots
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test