### PR TITLE
Add Azure GPT JWT middleware

### DIFF
--- a/agent/azure-gpt/package.json
+++ b/agent/azure-gpt/package.json
@@ -6,12 +6,16 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
     "@agent-tasker/agent": "workspace:*",
-    "@agent-tasker/protocol": "workspace:*"
+    "@agent-tasker/protocol": "workspace:*",
+    "@hono/node-server": "^2.0.3",
+    "hono": "^4.12.21",
+    "jose": "^6.2.3"
   }
 }

--- a/agent/azure-gpt/src/app.ts
+++ b/agent/azure-gpt/src/app.ts
@@ -1,0 +1,73 @@
+import { Hono } from "hono";
+import { AnnounceRequestSchema, ExecuteRequestSchema } from "@agent-tasker/protocol";
+import { getTokenClaims, requireTaskToken, type TaskTokenVerifier } from "@agent-tasker/agent";
+import { AGENT_ID } from "./index.js";
+
+export interface CreateAppOptions {
+  verifier: TaskTokenVerifier;
+}
+
+export function createApp(opts: CreateAppOptions) {
+  const app = new Hono();
+
+  app.get("/health", (c) => c.json({ ok: true, agent_id: AGENT_ID }));
+
+  app.post("/bid", requireTaskToken(opts.verifier, "bid"), async (c) => {
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    const parsed = AnnounceRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: { code: "invalid_request", message: "bad announce body" } }, 400);
+    }
+
+    const claims = getTokenClaims(c);
+    if (claims.task_id !== parsed.data.task_id) {
+      return c.json(
+        { error: { code: "unauthorized", message: "token task_id does not match body" } },
+        401,
+      );
+    }
+
+    return c.json({
+      task_id: parsed.data.task_id,
+      agent_id: AGENT_ID,
+      status: "no_bid",
+      reason: "capability",
+    });
+  });
+
+  app.post("/execute", requireTaskToken(opts.verifier, "execute"), async (c) => {
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    const parsed = ExecuteRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: { code: "invalid_request", message: "bad execute body" } }, 400);
+    }
+
+    const claims = getTokenClaims(c);
+    if (claims.task_id !== parsed.data.task_id) {
+      return c.json(
+        { error: { code: "unauthorized", message: "token task_id does not match body" } },
+        401,
+      );
+    }
+
+    return c.json(
+      {
+        error: {
+          code: "not_implemented",
+          message: "azure-gpt execute handler is not implemented yet",
+        },
+      },
+      501,
+    );
+  });
+
+  app.onError((err, c) => {
+    console.error("azure-gpt unhandled error", err);
+    return c.json(
+      { error: { code: "internal_error", message: "agent failed to handle request" } },
+      500,
+    );
+  });
+
+  return app;
+}

--- a/agent/azure-gpt/src/server.ts
+++ b/agent/azure-gpt/src/server.ts
@@ -1,0 +1,24 @@
+import { serve } from "@hono/node-server";
+import { createRemoteJWKSet } from "jose";
+import { createTaskTokenVerifier } from "@agent-tasker/agent";
+import { AGENT_ID } from "./index.js";
+import { createApp } from "./app.js";
+
+const port = Number(process.env["PORT"] ?? 8080);
+const jwksUrl = process.env["JWKS_URL"];
+
+if (!jwksUrl) {
+  console.error("JWKS_URL env var is required");
+  process.exit(1);
+}
+
+const verifier = createTaskTokenVerifier({
+  getKey: createRemoteJWKSet(new URL(jwksUrl), { cacheMaxAge: 10 * 60_000 }),
+  expectedAudience: AGENT_ID,
+});
+
+const app = createApp({ verifier });
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`${AGENT_ID} agent listening on :${info.port}`);
+});

--- a/agent/azure-gpt/test/app.test.ts
+++ b/agent/azure-gpt/test/app.test.ts
@@ -1,0 +1,152 @@
+import { Hono } from "hono";
+import {
+  SignJWT,
+  createLocalJWKSet,
+  exportJWK,
+  exportPKCS8,
+  generateKeyPair,
+  importPKCS8,
+  type JWK,
+} from "jose";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTaskTokenVerifier } from "@agent-tasker/agent";
+import { COORDINATOR_ISSUER, TOKEN_TTL_SECONDS, type JwtPhase } from "@agent-tasker/protocol";
+import { createApp } from "../src/app.js";
+
+const KID = "test-kid";
+const AUDIENCE = "azure-gpt" as const;
+
+let privateKeyPem: string;
+let publicJwk: JWK;
+let app: Hono;
+
+async function token(opts: {
+  taskId?: string;
+  phase?: JwtPhase;
+  audience?: string;
+  now?: Date;
+}): Promise<string> {
+  const key = await importPKCS8(privateKeyPem, "RS256");
+  const iat = Math.floor((opts.now ?? new Date()).getTime() / 1000);
+  return new SignJWT({
+    task_id: opts.taskId ?? "task-1",
+    phase: opts.phase ?? "bid",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: KID, typ: "JWT" })
+    .setIssuer(COORDINATOR_ISSUER)
+    .setSubject(COORDINATOR_ISSUER)
+    .setAudience(opts.audience ?? AUDIENCE)
+    .setIssuedAt(iat)
+    .setExpirationTime(iat + TOKEN_TTL_SECONDS)
+    .sign(key);
+}
+
+beforeAll(async () => {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  privateKeyPem = await exportPKCS8(privateKey);
+  publicJwk = await exportJWK(publicKey);
+  publicJwk.kid = KID;
+});
+
+beforeEach(() => {
+  const verifier = createTaskTokenVerifier({
+    getKey: createLocalJWKSet({ keys: [publicJwk] }),
+    expectedAudience: AUDIENCE,
+  });
+  app = createApp({ verifier });
+});
+
+describe("GET /health", () => {
+  it("returns ok without auth", async () => {
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, agent_id: "azure-gpt" });
+  });
+});
+
+describe("POST /bid", () => {
+  it("declines with capability for a valid bid token until the bid handler lands", async () => {
+    const t = await token({ taskId: "task-bid-1", phase: "bid" });
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-bid-1", spec: { prompt: "summarize" } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      task_id: "task-bid-1",
+      agent_id: "azure-gpt",
+      status: "no_bid",
+      reason: "capability",
+    });
+  });
+
+  it("rejects missing bearer with 401", async () => {
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task_id: "task-1", spec: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects wrong phase with 401", async () => {
+    const t = await token({ phase: "execute" });
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-1", spec: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects mismatched task_id between JWT and body with 401", async () => {
+    const t = await token({ taskId: "task-token", phase: "bid" });
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-different", spec: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on malformed body", async () => {
+    const t = await token({ phase: "bid" });
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /execute", () => {
+  it("verifies a valid execute token before returning not implemented", async () => {
+    const t = await token({ taskId: "task-exec-1", phase: "execute" });
+    const res = await app.request("/execute", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-exec-1", spec: { prompt: "do the thing" } }),
+    });
+
+    expect(res.status).toBe(501);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "not_implemented",
+        message: "azure-gpt execute handler is not implemented yet",
+      },
+    });
+  });
+
+  it("rejects bid-phase token on /execute with 401", async () => {
+    const t = await token({ phase: "bid" });
+    const res = await app.request("/execute", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-1", spec: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/agent/azure-gpt/tsconfig.build.json
+++ b/agent/azure-gpt/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/agent/azure-gpt/tsconfig.json
+++ b/agent/azure-gpt/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,15 @@ importers:
       '@agent-tasker/protocol':
         specifier: workspace:*
         version: link:../../protocol
+      '@hono/node-server':
+        specifier: ^2.0.3
+        version: 2.0.3(hono@4.12.21)
+      hono:
+        specifier: ^4.12.21
+        version: 4.12.21
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
 
   agent/gcp-gemini:
     dependencies:


### PR DESCRIPTION
## Summary
- add an Azure/GPT Hono app with open /health and JWT-protected /bid and /execute endpoints
- wire the shared RS256 task-token verifier with Azure/GPT audience and JWKS server entrypoint
- add tests for bearer requirements, phase checks, task_id claim matching, malformed bodies, and placeholder authenticated behavior

Closes #57

## Tests
- pnpm --filter @agent-tasker/agent-azure-gpt test
- pnpm --filter @agent-tasker/agent-azure-gpt typecheck
- pnpm --filter @agent-tasker/agent-azure-gpt build
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test