### PR TITLE
Add Azure GPT bid handler

### DIFF
--- a/agent/azure-gpt/src/app.ts
+++ b/agent/azure-gpt/src/app.ts
@@ -1,10 +1,15 @@
 import { Hono } from "hono";
+import type { PricingEntry } from "@agent-tasker/protocol";
 import { AnnounceRequestSchema, ExecuteRequestSchema } from "@agent-tasker/protocol";
 import { getTokenClaims, requireTaskToken, type TaskTokenVerifier } from "@agent-tasker/agent";
+import { handleBid } from "./bid/handler.js";
+import type { BidEstimator } from "./bid/estimator.js";
 import { AGENT_ID } from "./index.js";
 
 export interface CreateAppOptions {
   verifier: TaskTokenVerifier;
+  estimator: BidEstimator;
+  pricing: PricingEntry;
 }
 
 export function createApp(opts: CreateAppOptions) {
@@ -27,12 +32,11 @@ export function createApp(opts: CreateAppOptions) {
       );
     }
 
-    return c.json({
-      task_id: parsed.data.task_id,
-      agent_id: AGENT_ID,
-      status: "no_bid",
-      reason: "capability",
+    const result = await handleBid(parsed.data, {
+      estimator: opts.estimator,
+      pricing: opts.pricing,
     });
+    return c.json(result);
   });
 
   app.post("/execute", requireTaskToken(opts.verifier, "execute"), async (c) => {

--- a/agent/azure-gpt/src/bid/estimator.ts
+++ b/agent/azure-gpt/src/bid/estimator.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import type { TaskSpec } from "@agent-tasker/protocol";
+
+export interface BidEstimator {
+  estimate(spec: TaskSpec): Promise<{ input_tokens: number; output_tokens: number }>;
+}
+
+export interface GenerativeJsonClient {
+  generateJson(prompt: string): Promise<unknown>;
+}
+
+const EstimateResultSchema = z.object({
+  est_input_tokens: z.number().int().nonnegative(),
+  est_output_tokens: z.number().int().nonnegative(),
+});
+
+function buildPrompt(spec: TaskSpec): string {
+  return `You estimate token cost for another model (GPT-5) to complete a task.
+
+Task prompt:
+---
+${spec.prompt}
+---
+${spec.min_tier ? `Minimum tier requested by client: ${spec.min_tier}\n` : ""}${
+    spec.attachments?.length
+      ? `Attachments: ${spec.attachments.length} (referenced by content hash; agent must fetch if it bids)\n`
+      : ""
+  }
+Return JSON with conservative integer estimates:
+- est_input_tokens: tokens the prompt + system context + any tool calls would consume on input
+- est_output_tokens: tokens the model's response would generate`;
+}
+
+export class AzureOpenAiBidEstimator implements BidEstimator {
+  constructor(private readonly client: GenerativeJsonClient) {}
+
+  async estimate(spec: TaskSpec): Promise<{ input_tokens: number; output_tokens: number }> {
+    const raw = await this.client.generateJson(buildPrompt(spec));
+    const parsed = EstimateResultSchema.parse(raw);
+    return {
+      input_tokens: parsed.est_input_tokens,
+      output_tokens: parsed.est_output_tokens,
+    };
+  }
+}
+
+export interface AzureOpenAiJsonClientOptions {
+  endpoint: string;
+  deployment: string;
+  apiKey: string;
+  apiVersion: string;
+}
+
+export function createAzureOpenAiJsonClient(
+  opts: AzureOpenAiJsonClientOptions,
+): GenerativeJsonClient {
+  const endpoint = opts.endpoint.replace(/\/$/, "");
+  const url = new URL(
+    `${endpoint}/openai/deployments/${encodeURIComponent(opts.deployment)}/chat/completions`,
+  );
+  url.searchParams.set("api-version", opts.apiVersion);
+
+  return {
+    async generateJson(prompt: string): Promise<unknown> {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "api-key": opts.apiKey,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: [
+            {
+              role: "system",
+              content: "Return only JSON matching the requested shape.",
+            },
+            { role: "user", content: prompt },
+          ],
+          response_format: { type: "json_object" },
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Azure OpenAI bid estimate failed with HTTP ${response.status}`);
+      }
+
+      const body = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string | null } }>;
+      };
+      const content = body.choices?.[0]?.message?.content;
+      if (!content) throw new Error("Azure OpenAI returned no estimate content");
+      return JSON.parse(content);
+    },
+  };
+}

--- a/agent/azure-gpt/src/bid/handler.ts
+++ b/agent/azure-gpt/src/bid/handler.ts
@@ -1,0 +1,59 @@
+import {
+  computeBidUsd,
+  type AnnounceRequest,
+  type Bid,
+  type BidResponse,
+  type PricingEntry,
+} from "@agent-tasker/protocol";
+import { AGENT_ID } from "../index.js";
+import type { BidEstimator } from "./estimator.js";
+
+export const EXECUTION_MODEL_ID = "gpt-5";
+export const EXECUTION_MODEL_FAMILY = "gpt" as const;
+export const EXECUTION_TIER = "frontier" as const;
+
+const BID_TTL_MS = 60_000;
+
+export interface BidHandlerDeps {
+  estimator: BidEstimator;
+  pricing: PricingEntry;
+  now?: () => Date;
+  sign?: (taskId: string) => string;
+}
+
+export async function handleBid(req: AnnounceRequest, deps: BidHandlerDeps): Promise<BidResponse> {
+  const now = deps.now?.() ?? new Date();
+  try {
+    const { input_tokens, output_tokens } = await deps.estimator.estimate(req.spec);
+    const bidUsd = computeBidUsd({
+      est_input_tokens: input_tokens,
+      est_output_tokens: output_tokens,
+      price_in_usd_per_mtoken: deps.pricing.price_in_usd_per_mtoken,
+      price_out_usd_per_mtoken: deps.pricing.price_out_usd_per_mtoken,
+    });
+
+    const bid: Bid = {
+      task_id: req.task_id,
+      agent_id: AGENT_ID,
+      tier: EXECUTION_TIER,
+      model_family: EXECUTION_MODEL_FAMILY,
+      model_id: EXECUTION_MODEL_ID,
+      est_input_tokens: input_tokens,
+      est_output_tokens: output_tokens,
+      price_in_usd_per_mtoken: deps.pricing.price_in_usd_per_mtoken,
+      price_out_usd_per_mtoken: deps.pricing.price_out_usd_per_mtoken,
+      bid_usd: bidUsd,
+      expires_at: new Date(now.getTime() + BID_TTL_MS).toISOString(),
+      signature: deps.sign?.(req.task_id) ?? "stub-signature",
+    };
+    return bid;
+  } catch (err) {
+    void err;
+    return {
+      task_id: req.task_id,
+      agent_id: AGENT_ID,
+      status: "no_bid",
+      reason: "internal_error",
+    };
+  }
+}

--- a/agent/azure-gpt/src/bid/index.ts
+++ b/agent/azure-gpt/src/bid/index.ts
@@ -1,0 +1,2 @@
+export * from "./estimator.js";
+export * from "./handler.js";

--- a/agent/azure-gpt/src/server.ts
+++ b/agent/azure-gpt/src/server.ts
@@ -1,14 +1,20 @@
 import { serve } from "@hono/node-server";
 import { createRemoteJWKSet } from "jose";
 import { createTaskTokenVerifier } from "@agent-tasker/agent";
+import { FALLBACK_PRICING } from "@agent-tasker/protocol";
 import { AGENT_ID } from "./index.js";
 import { createApp } from "./app.js";
+import { AzureOpenAiBidEstimator, createAzureOpenAiJsonClient } from "./bid/estimator.js";
 
 const port = Number(process.env["PORT"] ?? 8080);
 const jwksUrl = process.env["JWKS_URL"];
+const azureOpenAiEndpoint = process.env["AZURE_OPENAI_ENDPOINT"];
+const azureOpenAiApiKey = process.env["AZURE_OPENAI_API_KEY"];
+const bidDeployment = process.env["AZURE_OPENAI_BID_DEPLOYMENT"] ?? "gpt-5-mini";
+const apiVersion = process.env["AZURE_OPENAI_API_VERSION"] ?? "2025-04-01-preview";
 
-if (!jwksUrl) {
-  console.error("JWKS_URL env var is required");
+if (!jwksUrl || !azureOpenAiEndpoint || !azureOpenAiApiKey) {
+  console.error("JWKS_URL, AZURE_OPENAI_ENDPOINT, and AZURE_OPENAI_API_KEY env vars are required");
   process.exit(1);
 }
 
@@ -17,7 +23,22 @@ const verifier = createTaskTokenVerifier({
   expectedAudience: AGENT_ID,
 });
 
-const app = createApp({ verifier });
+const pricing = FALLBACK_PRICING["gpt-5"];
+if (!pricing) {
+  console.error("missing FALLBACK_PRICING entry for gpt-5");
+  process.exit(1);
+}
+
+const estimator = new AzureOpenAiBidEstimator(
+  createAzureOpenAiJsonClient({
+    endpoint: azureOpenAiEndpoint,
+    deployment: bidDeployment,
+    apiKey: azureOpenAiApiKey,
+    apiVersion,
+  }),
+);
+
+const app = createApp({ verifier, estimator, pricing });
 
 serve({ fetch: app.fetch, port }, (info) => {
   console.log(`${AGENT_ID} agent listening on :${info.port}`);

--- a/agent/azure-gpt/test/app.test.ts
+++ b/agent/azure-gpt/test/app.test.ts
@@ -10,8 +10,14 @@ import {
 } from "jose";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createTaskTokenVerifier } from "@agent-tasker/agent";
-import { COORDINATOR_ISSUER, TOKEN_TTL_SECONDS, type JwtPhase } from "@agent-tasker/protocol";
+import {
+  COORDINATOR_ISSUER,
+  FALLBACK_PRICING,
+  TOKEN_TTL_SECONDS,
+  type JwtPhase,
+} from "@agent-tasker/protocol";
 import { createApp } from "../src/app.js";
+import type { BidEstimator } from "../src/bid/estimator.js";
 
 const KID = "test-kid";
 const AUDIENCE = "azure-gpt" as const;
@@ -19,6 +25,14 @@ const AUDIENCE = "azure-gpt" as const;
 let privateKeyPem: string;
 let publicJwk: JWK;
 let app: Hono;
+
+const stubEstimator: BidEstimator = {
+  async estimate() {
+    return { input_tokens: 4000, output_tokens: 1000 };
+  },
+};
+
+const PRICING = FALLBACK_PRICING["gpt-5"]!;
 
 async function token(opts: {
   taskId?: string;
@@ -53,7 +67,7 @@ beforeEach(() => {
     getKey: createLocalJWKSet({ keys: [publicJwk] }),
     expectedAudience: AUDIENCE,
   });
-  app = createApp({ verifier });
+  app = createApp({ verifier, estimator: stubEstimator, pricing: PRICING });
 });
 
 describe("GET /health", () => {
@@ -65,7 +79,7 @@ describe("GET /health", () => {
 });
 
 describe("POST /bid", () => {
-  it("declines with capability for a valid bid token until the bid handler lands", async () => {
+  it("returns a Bid for a valid request", async () => {
     const t = await token({ taskId: "task-bid-1", phase: "bid" });
     const res = await app.request("/bid", {
       method: "POST",
@@ -74,12 +88,18 @@ describe("POST /bid", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
-      task_id: "task-bid-1",
-      agent_id: "azure-gpt",
-      status: "no_bid",
-      reason: "capability",
-    });
+    const body = (await res.json()) as {
+      agent_id: string;
+      bid_usd: number;
+      tier: string;
+      model_family: string;
+      model_id: string;
+    };
+    expect(body.agent_id).toBe("azure-gpt");
+    expect(body.tier).toBe("frontier");
+    expect(body.model_family).toBe("gpt");
+    expect(body.model_id).toBe("gpt-5");
+    expect(body.bid_usd).toBeGreaterThan(0);
   });
 
   it("rejects missing bearer with 401", async () => {

--- a/agent/azure-gpt/test/bid/estimator.test.ts
+++ b/agent/azure-gpt/test/bid/estimator.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { AzureOpenAiBidEstimator, createAzureOpenAiJsonClient } from "../../src/bid/estimator.js";
+
+describe("AzureOpenAiBidEstimator", () => {
+  it("parses structured token estimates from the JSON client", async () => {
+    const estimator = new AzureOpenAiBidEstimator({
+      async generateJson(prompt) {
+        expect(prompt).toContain("GPT-5");
+        expect(prompt).toContain("summarize");
+        return { est_input_tokens: 123, est_output_tokens: 45 };
+      },
+    });
+
+    await expect(estimator.estimate({ prompt: "summarize" })).resolves.toEqual({
+      input_tokens: 123,
+      output_tokens: 45,
+    });
+  });
+});
+
+describe("createAzureOpenAiJsonClient", () => {
+  it("calls Azure OpenAI chat completions and parses message JSON", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"est_input_tokens":200,"est_output_tokens":80}' } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createAzureOpenAiJsonClient({
+      endpoint: "https://example.openai.azure.com/",
+      deployment: "gpt-5-mini",
+      apiKey: "test-key",
+      apiVersion: "2025-04-01-preview",
+    });
+
+    await expect(client.generateJson("estimate this")).resolves.toEqual({
+      est_input_tokens: 200,
+      est_output_tokens: 80,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL(
+        "https://example.openai.azure.com/openai/deployments/gpt-5-mini/chat/completions?api-version=2025-04-01-preview",
+      ),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "api-key": "test-key" }),
+      }),
+    );
+
+    fetchMock.mockRestore();
+  });
+
+  it("throws on non-2xx responses", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 429 }));
+    const client = createAzureOpenAiJsonClient({
+      endpoint: "https://example.openai.azure.com",
+      deployment: "gpt-5-mini",
+      apiKey: "test-key",
+      apiVersion: "2025-04-01-preview",
+    });
+
+    await expect(client.generateJson("estimate this")).rejects.toThrow(
+      /Azure OpenAI bid estimate failed with HTTP 429/,
+    );
+
+    fetchMock.mockRestore();
+  });
+});

--- a/agent/azure-gpt/test/bid/handler.test.ts
+++ b/agent/azure-gpt/test/bid/handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { AnnounceRequest, PricingEntry } from "@agent-tasker/protocol";
+import { handleBid } from "../../src/bid/handler.js";
+import type { BidEstimator } from "../../src/bid/estimator.js";
+
+const SPEC: AnnounceRequest["spec"] = { prompt: "summarize the transcript" };
+
+const PRICING: PricingEntry = {
+  model_id: "gpt-5",
+  price_in_usd_per_mtoken: 1.25,
+  price_out_usd_per_mtoken: 10.0,
+  effective_date: "2026-05-15",
+};
+
+function stubEstimator(input_tokens: number, output_tokens: number): BidEstimator {
+  return {
+    async estimate() {
+      return { input_tokens, output_tokens };
+    },
+  };
+}
+
+function throwingEstimator(message: string): BidEstimator {
+  return {
+    async estimate() {
+      throw new Error(message);
+    },
+  };
+}
+
+describe("handleBid", () => {
+  it("returns an Azure/GPT bid with computed USD when estimation succeeds", async () => {
+    const fixed = new Date("2026-05-21T12:00:00Z");
+    const res = await handleBid(
+      { task_id: "task-1", spec: SPEC },
+      {
+        estimator: stubEstimator(4000, 1000),
+        pricing: PRICING,
+        now: () => fixed,
+      },
+    );
+
+    if ("status" in res) throw new Error(`expected bid, got no_bid: ${res.reason}`);
+
+    expect(res.task_id).toBe("task-1");
+    expect(res.agent_id).toBe("azure-gpt");
+    expect(res.tier).toBe("frontier");
+    expect(res.model_family).toBe("gpt");
+    expect(res.model_id).toBe("gpt-5");
+    expect(res.est_input_tokens).toBe(4000);
+    expect(res.est_output_tokens).toBe(1000);
+    expect(res.price_in_usd_per_mtoken).toBe(1.25);
+    expect(res.price_out_usd_per_mtoken).toBe(10.0);
+    expect(res.bid_usd).toBeCloseTo(0.015, 10);
+    expect(res.expires_at).toBe("2026-05-21T12:01:00.000Z");
+    expect(res.signature).toBe("stub-signature");
+  });
+
+  it("uses a custom signer when provided", async () => {
+    const res = await handleBid(
+      { task_id: "task-sign", spec: SPEC },
+      {
+        estimator: stubEstimator(100, 50),
+        pricing: PRICING,
+        sign: (id) => `signed:${id}`,
+      },
+    );
+    if ("status" in res) throw new Error("expected bid");
+    expect(res.signature).toBe("signed:task-sign");
+  });
+
+  it("declines with internal_error when the estimator throws", async () => {
+    const res = await handleBid(
+      { task_id: "task-fail", spec: SPEC },
+      {
+        estimator: throwingEstimator("Azure OpenAI unavailable"),
+        pricing: PRICING,
+      },
+    );
+    if (!("status" in res)) throw new Error("expected no_bid");
+    expect(res.status).toBe("no_bid");
+    expect(res.reason).toBe("internal_error");
+    expect(res.agent_id).toBe("azure-gpt");
+    expect(res.task_id).toBe("task-fail");
+  });
+});

--- a/infra/agent-azure-gpt/container_app.tf
+++ b/infra/agent-azure-gpt/container_app.tf
@@ -26,6 +26,11 @@ resource "azurerm_container_app" "agent" {
     type = "SystemAssigned"
   }
 
+  secret {
+    name  = var.azure_openai_api_key_secret_name
+    value = coalesce(var.azure_openai_api_key, "replace-me")
+  }
+
   ingress {
     external_enabled = true
     target_port      = var.agent_port
@@ -68,8 +73,23 @@ resource "azurerm_container_app" "agent" {
       }
 
       env {
+        name  = "AZURE_OPENAI_BID_DEPLOYMENT"
+        value = var.azure_openai_bid_deployment
+      }
+
+      env {
+        name  = "AZURE_OPENAI_API_VERSION"
+        value = var.azure_openai_api_version
+      }
+
+      env {
         name  = "AZURE_OPENAI_API_KEY_SECRET_NAME"
         value = var.azure_openai_api_key_secret_name
+      }
+
+      env {
+        name        = "AZURE_OPENAI_API_KEY"
+        secret_name = var.azure_openai_api_key_secret_name
       }
 
       env {

--- a/infra/agent-azure-gpt/variables.tf
+++ b/infra/agent-azure-gpt/variables.tf
@@ -86,6 +86,18 @@ variable "azure_openai_deployment" {
   type        = string
 }
 
+variable "azure_openai_bid_deployment" {
+  description = "Azure OpenAI deployment name for the small-model bid estimator."
+  type        = string
+  default     = "gpt-5-mini"
+}
+
+variable "azure_openai_api_version" {
+  description = "Azure OpenAI data-plane API version used by the Azure/GPT agent."
+  type        = string
+  default     = "2025-04-01-preview"
+}
+
 variable "azure_openai_api_key_secret_name" {
   description = "Key Vault secret name that stores the Azure OpenAI API key."
   type        = string


### PR DESCRIPTION
## Summary
- add Azure/GPT bid estimator and handler producing GPT-5 frontier bid envelopes
- wire /bid through the estimator while preserving shared JWT/task_id checks
- add Azure OpenAI chat-completions JSON client tests and handler/app tests
- expose bid deployment/API version/API-key secret wiring in the Azure Container Apps Terraform root

Closes #58

## Tests
- pnpm --filter @agent-tasker/agent-azure-gpt test
- pnpm --filter @agent-tasker/agent-azure-gpt typecheck
- pnpm --filter @agent-tasker/agent-azure-gpt build
- terraform -chdir=infra/agent-azure-gpt validate -no-color
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test
- terraform fmt -check -recursive infra