### PR TITLE
Add Azure GPT execute handler

### DIFF
--- a/agent/azure-gpt/src/app.ts
+++ b/agent/azure-gpt/src/app.ts
@@ -4,12 +4,15 @@ import { AnnounceRequestSchema, ExecuteRequestSchema } from "@agent-tasker/proto
 import { getTokenClaims, requireTaskToken, type TaskTokenVerifier } from "@agent-tasker/agent";
 import { handleBid } from "./bid/handler.js";
 import type { BidEstimator } from "./bid/estimator.js";
+import { handleExecute } from "./execute/handler.js";
+import type { GenerativeTextClient } from "./execute/runner.js";
 import { AGENT_ID } from "./index.js";
 
 export interface CreateAppOptions {
   verifier: TaskTokenVerifier;
   estimator: BidEstimator;
   pricing: PricingEntry;
+  client: GenerativeTextClient;
 }
 
 export function createApp(opts: CreateAppOptions) {
@@ -54,15 +57,8 @@ export function createApp(opts: CreateAppOptions) {
       );
     }
 
-    return c.json(
-      {
-        error: {
-          code: "not_implemented",
-          message: "azure-gpt execute handler is not implemented yet",
-        },
-      },
-      501,
-    );
+    const result = await handleExecute(parsed.data, { client: opts.client });
+    return c.json(result);
   });
 
   app.onError((err, c) => {

--- a/agent/azure-gpt/src/execute/handler.ts
+++ b/agent/azure-gpt/src/execute/handler.ts
@@ -1,0 +1,23 @@
+import type { ExecuteRequest, Result } from "@agent-tasker/protocol";
+import { AGENT_ID } from "../index.js";
+import type { GenerativeTextClient } from "./runner.js";
+
+export interface ExecuteHandlerDeps {
+  client: GenerativeTextClient;
+}
+
+export async function handleExecute(
+  req: ExecuteRequest,
+  deps: ExecuteHandlerDeps,
+): Promise<Result> {
+  const { output, input_tokens, output_tokens } = await deps.client.generate(req.spec.prompt);
+  return {
+    task_id: req.task_id,
+    agent_id: AGENT_ID,
+    output,
+    actual_usage: {
+      input_tokens,
+      output_tokens,
+    },
+  };
+}

--- a/agent/azure-gpt/src/execute/index.ts
+++ b/agent/azure-gpt/src/execute/index.ts
@@ -1,0 +1,2 @@
+export * from "./handler.js";
+export * from "./runner.js";

--- a/agent/azure-gpt/src/execute/runner.ts
+++ b/agent/azure-gpt/src/execute/runner.ts
@@ -1,0 +1,61 @@
+export interface GenerativeTextClient {
+  generate(prompt: string): Promise<{
+    output: string;
+    input_tokens: number;
+    output_tokens: number;
+  }>;
+}
+
+export interface AzureOpenAiTextClientOptions {
+  endpoint: string;
+  deployment: string;
+  apiKey: string;
+  apiVersion: string;
+}
+
+export function createAzureOpenAiTextClient(
+  opts: AzureOpenAiTextClientOptions,
+): GenerativeTextClient {
+  const endpoint = opts.endpoint.replace(/\/$/, "");
+  const url = new URL(
+    `${endpoint}/openai/deployments/${encodeURIComponent(opts.deployment)}/chat/completions`,
+  );
+  url.searchParams.set("api-version", opts.apiVersion);
+
+  return {
+    async generate(prompt: string) {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "api-key": opts.apiKey,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: prompt }],
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Azure OpenAI execute failed with HTTP ${response.status}`);
+      }
+
+      const body = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string | null } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+      };
+      const output = body.choices?.[0]?.message?.content;
+      if (output === undefined || output === null) {
+        throw new Error("Azure OpenAI returned no execute content");
+      }
+      if (!body.usage) {
+        throw new Error("Azure OpenAI execute response missing usage");
+      }
+
+      return {
+        output,
+        input_tokens: body.usage.prompt_tokens ?? 0,
+        output_tokens: body.usage.completion_tokens ?? 0,
+      };
+    },
+  };
+}

--- a/agent/azure-gpt/src/server.ts
+++ b/agent/azure-gpt/src/server.ts
@@ -5,11 +5,13 @@ import { FALLBACK_PRICING } from "@agent-tasker/protocol";
 import { AGENT_ID } from "./index.js";
 import { createApp } from "./app.js";
 import { AzureOpenAiBidEstimator, createAzureOpenAiJsonClient } from "./bid/estimator.js";
+import { createAzureOpenAiTextClient } from "./execute/runner.js";
 
 const port = Number(process.env["PORT"] ?? 8080);
 const jwksUrl = process.env["JWKS_URL"];
 const azureOpenAiEndpoint = process.env["AZURE_OPENAI_ENDPOINT"];
 const azureOpenAiApiKey = process.env["AZURE_OPENAI_API_KEY"];
+const executeDeployment = process.env["AZURE_OPENAI_DEPLOYMENT"] ?? "gpt-5";
 const bidDeployment = process.env["AZURE_OPENAI_BID_DEPLOYMENT"] ?? "gpt-5-mini";
 const apiVersion = process.env["AZURE_OPENAI_API_VERSION"] ?? "2025-04-01-preview";
 
@@ -38,7 +40,14 @@ const estimator = new AzureOpenAiBidEstimator(
   }),
 );
 
-const app = createApp({ verifier, estimator, pricing });
+const client = createAzureOpenAiTextClient({
+  endpoint: azureOpenAiEndpoint,
+  deployment: executeDeployment,
+  apiKey: azureOpenAiApiKey,
+  apiVersion,
+});
+
+const app = createApp({ verifier, estimator, pricing, client });
 
 serve({ fetch: app.fetch, port }, (info) => {
   console.log(`${AGENT_ID} agent listening on :${info.port}`);

--- a/agent/azure-gpt/test/app.test.ts
+++ b/agent/azure-gpt/test/app.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@agent-tasker/protocol";
 import { createApp } from "../src/app.js";
 import type { BidEstimator } from "../src/bid/estimator.js";
+import type { GenerativeTextClient } from "../src/execute/runner.js";
 
 const KID = "test-kid";
 const AUDIENCE = "azure-gpt" as const;
@@ -29,6 +30,12 @@ let app: Hono;
 const stubEstimator: BidEstimator = {
   async estimate() {
     return { input_tokens: 4000, output_tokens: 1000 };
+  },
+};
+
+const stubClient: GenerativeTextClient = {
+  async generate(prompt) {
+    return { output: `summary of: ${prompt}`, input_tokens: 4100, output_tokens: 950 };
   },
 };
 
@@ -67,7 +74,7 @@ beforeEach(() => {
     getKey: createLocalJWKSet({ keys: [publicJwk] }),
     expectedAudience: AUDIENCE,
   });
-  app = createApp({ verifier, estimator: stubEstimator, pricing: PRICING });
+  app = createApp({ verifier, estimator: stubEstimator, pricing: PRICING, client: stubClient });
 });
 
 describe("GET /health", () => {
@@ -143,7 +150,7 @@ describe("POST /bid", () => {
 });
 
 describe("POST /execute", () => {
-  it("verifies a valid execute token before returning not implemented", async () => {
+  it("returns a Result for a valid request", async () => {
     const t = await token({ taskId: "task-exec-1", phase: "execute" });
     const res = await app.request("/execute", {
       method: "POST",
@@ -151,13 +158,17 @@ describe("POST /execute", () => {
       body: JSON.stringify({ task_id: "task-exec-1", spec: { prompt: "do the thing" } }),
     });
 
-    expect(res.status).toBe(501);
-    expect(await res.json()).toEqual({
-      error: {
-        code: "not_implemented",
-        message: "azure-gpt execute handler is not implemented yet",
-      },
-    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      task_id: string;
+      agent_id: string;
+      output: string;
+      actual_usage: { input_tokens: number; output_tokens: number };
+    };
+    expect(body.task_id).toBe("task-exec-1");
+    expect(body.agent_id).toBe("azure-gpt");
+    expect(body.output).toBe("summary of: do the thing");
+    expect(body.actual_usage).toEqual({ input_tokens: 4100, output_tokens: 950 });
   });
 
   it("rejects bid-phase token on /execute with 401", async () => {

--- a/agent/azure-gpt/test/execute/handler.test.ts
+++ b/agent/azure-gpt/test/execute/handler.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { handleExecute } from "../../src/execute/handler.js";
+import type { GenerativeTextClient } from "../../src/execute/runner.js";
+
+describe("handleExecute", () => {
+  it("returns an Azure/GPT Result with actual token usage", async () => {
+    const client: GenerativeTextClient = {
+      async generate(prompt) {
+        expect(prompt).toBe("write the summary");
+        return {
+          output: "done",
+          input_tokens: 1200,
+          output_tokens: 300,
+        };
+      },
+    };
+
+    await expect(
+      handleExecute({ task_id: "task-1", spec: { prompt: "write the summary" } }, { client }),
+    ).resolves.toEqual({
+      task_id: "task-1",
+      agent_id: "azure-gpt",
+      output: "done",
+      actual_usage: {
+        input_tokens: 1200,
+        output_tokens: 300,
+      },
+    });
+  });
+});

--- a/agent/azure-gpt/test/execute/runner.test.ts
+++ b/agent/azure-gpt/test/execute/runner.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAzureOpenAiTextClient } from "../../src/execute/runner.js";
+
+describe("createAzureOpenAiTextClient", () => {
+  it("calls Azure OpenAI chat completions and maps output plus usage", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "completed output" } }],
+          usage: { prompt_tokens: 321, completion_tokens: 98 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createAzureOpenAiTextClient({
+      endpoint: "https://example.openai.azure.com/",
+      deployment: "gpt-5",
+      apiKey: "test-key",
+      apiVersion: "2025-04-01-preview",
+    });
+
+    await expect(client.generate("do the work")).resolves.toEqual({
+      output: "completed output",
+      input_tokens: 321,
+      output_tokens: 98,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL(
+        "https://example.openai.azure.com/openai/deployments/gpt-5/chat/completions?api-version=2025-04-01-preview",
+      ),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "api-key": "test-key" }),
+        body: expect.stringContaining("do the work"),
+      }),
+    );
+
+    fetchMock.mockRestore();
+  });
+
+  it("throws on non-2xx responses", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 429 }));
+    const client = createAzureOpenAiTextClient({
+      endpoint: "https://example.openai.azure.com",
+      deployment: "gpt-5",
+      apiKey: "test-key",
+      apiVersion: "2025-04-01-preview",
+    });
+
+    await expect(client.generate("do the work")).rejects.toThrow(
+      /Azure OpenAI execute failed with HTTP 429/,
+    );
+
+    fetchMock.mockRestore();
+  });
+
+  it("throws when usage is missing", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = createAzureOpenAiTextClient({
+      endpoint: "https://example.openai.azure.com",
+      deployment: "gpt-5",
+      apiKey: "test-key",
+      apiVersion: "2025-04-01-preview",
+    });
+
+    await expect(client.generate("do the work")).rejects.toThrow(
+      /Azure OpenAI execute response missing usage/,
+    );
+
+    fetchMock.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add Azure/GPT execute handler returning protocol Result with actual usage
- add Azure OpenAI chat-completions text client and wire /execute through it
- update app/server wiring and add handler/runner/app tests

Closes #59

## Tests
- pnpm --filter @agent-tasker/agent-azure-gpt test
- pnpm --filter @agent-tasker/agent-azure-gpt typecheck
- pnpm --filter @agent-tasker/agent-azure-gpt build
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test
- terraform fmt -check -recursive infra