### PR TITLE
Add GCP pricing catalog parser

### DIFF
--- a/infra/coordinator/functions/pricing-refresh/catalog.js
+++ b/infra/coordinator/functions/pricing-refresh/catalog.js
@@ -1,0 +1,116 @@
+const GCP_PRICING_TARGETS = [
+  {
+    modelId: "gemini-2-5-flash",
+    modelPatterns: [/gemini\s*2(?:\.|-)?5\s*flash/i, /gemini-2\.5-flash/i],
+  },
+  {
+    modelId: "gemini-2-5-pro",
+    modelPatterns: [/gemini\s*2(?:\.|-)?5\s*pro/i, /gemini-2\.5-pro/i],
+  },
+  {
+    modelId: "gemini-enterprise-agent-platform",
+    modelPatterns: [
+      /gemini enterprise agent platform/i,
+      /\bgaep\b/i,
+      /vertex ai agent/i,
+      /agent engine/i,
+    ],
+    platform: true,
+  },
+];
+
+function moneyToNumber(money) {
+  const units = Number(money?.units ?? 0);
+  const nanos = Number(money?.nanos ?? 0);
+  return units + nanos / 1_000_000_000;
+}
+
+function pricePerMtoken(pricingExpression) {
+  const tieredRates = pricingExpression?.tieredRates ?? [];
+  const firstRate = tieredRates[0];
+  if (!firstRate?.unitPrice) return undefined;
+
+  const unitPrice = moneyToNumber(firstRate.unitPrice);
+  const unitText = [
+    pricingExpression.usageUnit,
+    pricingExpression.usageUnitDescription,
+    pricingExpression.baseUnit,
+    pricingExpression.baseUnitDescription,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (/1,?000,?000|million|mtok|m token/.test(unitText)) return unitPrice;
+  if (/1,?000|thousand|k token/.test(unitText)) return unitPrice * 1_000;
+  if (/\btoken(s)?\b/.test(unitText)) return unitPrice * 1_000_000;
+  return unitPrice;
+}
+
+function skuUnitPricePerMtoken(sku) {
+  const pricingInfo = sku.pricingInfo ?? [];
+  for (const info of pricingInfo) {
+    const expression = info.pricingExpression;
+    if (expression?.usageUnit && !/token|character|request|operation/i.test(expression.usageUnit)) {
+      continue;
+    }
+    const price = pricePerMtoken(expression);
+    if (price !== undefined) return price;
+  }
+  return undefined;
+}
+
+function classifySku(sku) {
+  const text = [
+    sku.description,
+    sku.category?.resourceFamily,
+    sku.category?.resourceGroup,
+    sku.category?.usageType,
+    sku.serviceRegions?.join(" "),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const target = GCP_PRICING_TARGETS.find((candidate) =>
+    candidate.modelPatterns.some((pattern) => pattern.test(text)),
+  );
+  if (!target) return undefined;
+
+  if (/input|prompt|cache\s*read/i.test(text)) return { modelId: target.modelId, direction: "in" };
+  if (/output|completion|response|generated/i.test(text)) {
+    return { modelId: target.modelId, direction: "out" };
+  }
+  if (target.platform && /request|operation|consumption|tool|step/i.test(text)) {
+    return { modelId: target.modelId, direction: "platform" };
+  }
+  return undefined;
+}
+
+export function parseGcpCatalogPrices(skus) {
+  const collected = {};
+
+  for (const sku of skus) {
+    const classification = classifySku(sku);
+    if (!classification) continue;
+
+    const price = skuUnitPricePerMtoken(sku);
+    if (price === undefined) continue;
+
+    collected[classification.modelId] ??= {};
+    if (classification.direction === "platform") {
+      collected[classification.modelId].in ??= price;
+      collected[classification.modelId].out ??= price;
+    } else {
+      collected[classification.modelId][classification.direction] ??= price;
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(collected)
+      .filter(([, prices]) => prices.in !== undefined && prices.out !== undefined)
+      .map(([modelId, prices]) => [
+        modelId,
+        { in: prices.in, out: prices.out, source: "gcp-cloud-billing-catalog" },
+      ]),
+  );
+}

--- a/infra/coordinator/functions/pricing-refresh/index.js
+++ b/infra/coordinator/functions/pricing-refresh/index.js
@@ -3,11 +3,10 @@
 // `pricing/{model_id}` "latest" doc the coordinator and bidders can read
 // without an extra collection-group query.
 //
-// Scope today: writes FALLBACK_PRICING constants (CLAUDE.md "for SKUs not
-// exposed cleanly in [the Catalog API], fall back to maintained constants
-// in /protocol"). Real Cloud Billing Catalog integration lives behind the
-// TODO below and will overwrite the `source` field from "fallback" to
-// "catalog" as it lands per-model.
+// Scope today: reads live GCP Cloud Billing Catalog SKUs for Vertex AI
+// Gemini and GAEP where exposed, then merges them over FALLBACK_PRICING
+// constants (CLAUDE.md "for SKUs not exposed cleanly in [the Catalog API],
+// fall back to maintained constants in /protocol").
 //
 // Last-known-good behaviour (#39): per-day snapshots are append-only —
 // writes upsert `pricing/{model}/snapshots/{date}` so today's failure
@@ -19,6 +18,10 @@
 // (verified by Cloud Run's IAM layer before reaching this handler).
 
 import { Firestore } from "@google-cloud/firestore";
+import { GoogleAuth } from "google-auth-library";
+import { parseGcpCatalogPrices } from "./catalog.js";
+
+const CATALOG_BASE_URL = "https://cloudbilling.googleapis.com/v1";
 
 // Hand-maintained copy of /protocol/src/pricing.ts FALLBACK_PRICING. The
 // Cloud Function deploys from infra/coordinator/functions/pricing-refresh/
@@ -34,6 +37,59 @@ const FALLBACK_PRICING = {
   "gemini-2-5-flash": { in: 0.3, out: 2.5 },
   "gemini-2-5-pro": { in: 1.25, out: 10.0 },
 };
+
+class CloudBillingCatalogClient {
+  constructor() {
+    this.auth = new GoogleAuth({
+      scopes: ["https://www.googleapis.com/auth/cloud-billing.readonly"],
+    });
+  }
+
+  async request(path, params = {}) {
+    const client = await this.auth.getClient();
+    const url = new URL(`${CATALOG_BASE_URL}/${path}`);
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+    const response = await client.request({ url: url.toString(), method: "GET" });
+    return response.data;
+  }
+
+  async findVertexAiServiceName() {
+    let pageToken;
+    do {
+      const body = await this.request("services", { pageSize: 5000, pageToken });
+      const service = (body.services ?? []).find((candidate) =>
+        /vertex ai/i.test(candidate.displayName ?? ""),
+      );
+      if (service?.name) return service.name;
+      pageToken = body.nextPageToken;
+    } while (pageToken);
+
+    throw new Error("Cloud Billing Catalog service for Vertex AI was not found");
+  }
+
+  async listSkus(serviceName) {
+    const skus = [];
+    let pageToken;
+    do {
+      const body = await this.request(`${serviceName}/skus`, { pageSize: 5000, pageToken });
+      skus.push(...(body.skus ?? []));
+      pageToken = body.nextPageToken;
+    } while (pageToken);
+    return skus;
+  }
+
+  async fetchGcpPricing() {
+    const serviceName = await this.findVertexAiServiceName();
+    const skus = await this.listSkus(serviceName);
+    return parseGcpCatalogPrices(skus);
+  }
+}
+
+export async function fetchGcpCatalogPrices(catalog = new CloudBillingCatalogClient()) {
+  return catalog.fetchGcpPricing();
+}
 
 function log(level, msg, extra) {
   // Structured logs play well with Cloud Logging — every entry is one
@@ -86,16 +142,24 @@ export const refreshPricing = async (req, res) => {
     return;
   }
 
-  // TODO: Pull live SKUs from the Cloud Billing Catalog (Vertex AI Gemini
-  // + GAEP) and merge over FALLBACK_PRICING per model. The Catalog client
-  // and roles/billing.viewer wiring land alongside. Until then every model
-  // writes with source: "fallback".
-
   const date = todayUtc();
   const firestore = new Firestore({ projectId });
+  let pricesByModel = { ...FALLBACK_PRICING };
+
+  try {
+    const catalogPrices = await fetchGcpCatalogPrices();
+    pricesByModel = { ...pricesByModel, ...catalogPrices };
+    log("INFO", "pricing-refresh: catalog prices loaded", {
+      models: Object.keys(catalogPrices).sort(),
+    });
+  } catch (err) {
+    log("ERROR", "pricing-refresh: catalog fetch failed; using fallback prices", {
+      error: err.message,
+    });
+  }
 
   const results = { written: [], failed: [] };
-  for (const [modelId, prices] of Object.entries(FALLBACK_PRICING)) {
+  for (const [modelId, prices] of Object.entries(pricesByModel)) {
     try {
       await writeOne(firestore, modelId, prices, date);
       results.written.push(modelId);

--- a/infra/coordinator/functions/pricing-refresh/index.test.js
+++ b/infra/coordinator/functions/pricing-refresh/index.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseGcpCatalogPrices } from "./catalog.js";
+
+function sku(description, units, nanos, usageUnit = "1,000,000 tokens") {
+  return {
+    description,
+    category: {
+      resourceFamily: "AI Platform",
+      resourceGroup: "Vertex AI",
+      usageType: "OnDemand",
+    },
+    pricingInfo: [
+      {
+        pricingExpression: {
+          usageUnit,
+          usageUnitDescription: usageUnit,
+          tieredRates: [{ unitPrice: { currencyCode: "USD", units, nanos } }],
+        },
+      },
+    ],
+  };
+}
+
+describe("parseGcpCatalogPrices", () => {
+  it("maps Vertex AI Gemini input and output token SKUs to canonical model ids", () => {
+    const prices = parseGcpCatalogPrices([
+      sku("Vertex AI Gemini 2.5 Flash input tokens", 0, 300_000_000),
+      sku("Vertex AI Gemini 2.5 Flash output tokens", 2, 500_000_000),
+      sku("Vertex AI Gemini 2.5 Pro input tokens", 1, 250_000_000),
+      sku("Vertex AI Gemini 2.5 Pro output tokens", 10, 0),
+      sku("Vertex AI unrelated embedding tokens", 0, 100_000_000),
+    ]);
+
+    assert.deepEqual(prices, {
+      "gemini-2-5-flash": {
+        in: 0.3,
+        out: 2.5,
+        source: "gcp-cloud-billing-catalog",
+      },
+      "gemini-2-5-pro": {
+        in: 1.25,
+        out: 10,
+        source: "gcp-cloud-billing-catalog",
+      },
+    });
+  });
+
+  it("normalizes per-token SKUs to USD per million tokens", () => {
+    const prices = parseGcpCatalogPrices([
+      sku("Vertex AI Gemini 2.5 Flash input token", 0, 3_000_000, "token"),
+      sku("Vertex AI Gemini 2.5 Flash output token", 0, 25_000_000, "token"),
+    ]);
+
+    assert.equal(prices["gemini-2-5-flash"].in, 3000);
+    assert.equal(prices["gemini-2-5-flash"].out, 25000);
+  });
+
+  it("captures GAEP platform consumption SKUs when exposed by the catalog", () => {
+    const prices = parseGcpCatalogPrices([
+      sku("Gemini Enterprise Agent Platform request consumption", 0, 120_000_000, "request"),
+    ]);
+
+    assert.deepEqual(prices["gemini-enterprise-agent-platform"], {
+      in: 0.12,
+      out: 0.12,
+      source: "gcp-cloud-billing-catalog",
+    });
+  });
+});

--- a/infra/coordinator/functions/pricing-refresh/package.json
+++ b/infra/coordinator/functions/pricing-refresh/package.json
@@ -5,10 +5,14 @@
   "type": "module",
   "description": "Daily pricing-refresh Cloud Function. Writes per-model snapshots to Firestore /pricing.",
   "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
   "engines": {
     "node": "22"
   },
   "dependencies": {
-    "@google-cloud/firestore": "^8.6.0"
+    "@google-cloud/firestore": "^8.6.0",
+    "google-auth-library": "^10.6.2"
   }
 }

--- a/infra/coordinator/pricing_refresh.tf
+++ b/infra/coordinator/pricing_refresh.tf
@@ -58,10 +58,8 @@ resource "google_storage_bucket_object" "pricing_refresh_source" {
   source = data.archive_file.pricing_refresh_source.output_path
 }
 
-# Runtime SA — Firestore writer (for the /pricing collection) plus log
-# writer. #38 will add roles/billing.viewer for Cloud Billing Catalog
-# reads; left out today so the placeholder's least-privilege deploy is
-# the actual minimum.
+# Runtime SA — Firestore writer (for the /pricing collection), Cloud
+# Billing Catalog reader, plus log writer.
 resource "google_service_account" "pricing_refresh_runtime" {
   project      = var.project_id
   account_id   = "${local.name_prefix}-pricing-refresh"
@@ -78,6 +76,12 @@ resource "google_project_iam_member" "pricing_refresh_firestore" {
 resource "google_project_iam_member" "pricing_refresh_logs" {
   project = var.project_id
   role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.pricing_refresh_runtime.email}"
+}
+
+resource "google_project_iam_member" "pricing_refresh_billing_catalog" {
+  project = var.project_id
+  role    = "roles/billing.viewer"
   member  = "serviceAccount:${google_service_account.pricing_refresh_runtime.email}"
 }
 
@@ -128,6 +132,7 @@ resource "google_cloudfunctions2_function" "pricing_refresh" {
   }
 
   depends_on = [
+    google_project_iam_member.pricing_refresh_billing_catalog,
     google_project_iam_member.pricing_refresh_firestore,
     google_project_iam_member.pricing_refresh_logs,
   ]


### PR DESCRIPTION
## Summary
- add a Cloud Billing Catalog client for Vertex AI service/SKU discovery
- parse Gemini 2.5 Flash/Pro and exposed GAEP consumption SKUs into canonical pricing records
- merge catalog prices over fallbacks while preserving last-known-good behavior
- grant the pricing refresh function billing catalog read access

Closes #38

## Tests
- npm test (infra/coordinator/functions/pricing-refresh)
- pnpm lint
- pnpm format
- pnpm typecheck
- pnpm test
- terraform fmt -check -recursive infra