### PR TITLE
Add AWS Bedrock pricing parser

### DIFF
--- a/infra/coordinator/functions/pricing-refresh/aws.js
+++ b/infra/coordinator/functions/pricing-refresh/aws.js
@@ -1,0 +1,98 @@
+const AWS_BEDROCK_PRICE_LIST_URL =
+  "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/index.json";
+
+const NOVA_TARGETS = [
+  { modelId: "amazon.nova-micro", patterns: [/nova\s*micro/i] },
+  { modelId: "amazon.nova-lite", patterns: [/nova\s*lite/i] },
+  { modelId: "amazon.nova-pro", patterns: [/nova\s*pro/i] },
+];
+
+function findTarget(text) {
+  return NOVA_TARGETS.find((target) => target.patterns.some((pattern) => pattern.test(text)));
+}
+
+function classifyDirection(text) {
+  if (/input|prompt/i.test(text)) return "in";
+  if (/output|completion|response|generated/i.test(text)) return "out";
+  return undefined;
+}
+
+function priceToNumber(pricePerUnit) {
+  const usd = pricePerUnit?.USD;
+  if (usd === undefined) return undefined;
+  const parsed = Number(usd);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizeToMtoken(price, unitText) {
+  const text = unitText.toLowerCase();
+  let normalized;
+  if (/1,?000,?000|million|mtok|m token/.test(text)) return price;
+  if (/1,?000|thousand|1k|k token/.test(text)) normalized = price * 1_000;
+  else if (/\btoken(s)?\b/.test(text)) normalized = price * 1_000_000;
+  else normalized = price;
+  return Math.round(normalized * 1_000_000_000_000) / 1_000_000_000_000;
+}
+
+function productText(product) {
+  const attrs = product.attributes ?? {};
+  return [
+    product.productFamily,
+    attrs.modelName,
+    attrs.group,
+    attrs.groupDescription,
+    attrs.operation,
+    attrs.usagetype,
+    attrs.usageType,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function dimensionsForSku(priceList, sku) {
+  const terms = priceList.terms?.OnDemand?.[sku] ?? {};
+  return Object.values(terms).flatMap((term) => Object.values(term.priceDimensions ?? {}));
+}
+
+export function parseAwsBedrockPrices(priceList) {
+  const collected = {};
+
+  for (const [sku, product] of Object.entries(priceList.products ?? {})) {
+    const baseText = productText(product);
+    const target = findTarget(baseText);
+    if (!target) continue;
+
+    for (const dimension of dimensionsForSku(priceList, sku)) {
+      const dimensionOnlyText = [dimension.description, dimension.unit, dimension.rateCode]
+        .filter(Boolean)
+        .join(" ");
+      const dimensionText = [baseText, dimensionOnlyText].filter(Boolean).join(" ");
+      const direction = classifyDirection(dimensionOnlyText) ?? classifyDirection(baseText);
+      if (!direction) continue;
+
+      const price = priceToNumber(dimension.pricePerUnit);
+      if (price === undefined) continue;
+
+      collected[target.modelId] ??= {};
+      collected[target.modelId][direction] ??= normalizeToMtoken(price, dimensionText);
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(collected)
+      .filter(([, prices]) => prices.in !== undefined && prices.out !== undefined)
+      .map(([modelId, prices]) => [
+        modelId,
+        { in: prices.in, out: prices.out, source: "aws-price-list" },
+      ]),
+  );
+}
+
+export async function fetchAwsBedrockPrices(fetchImpl = fetch) {
+  const response = await fetchImpl(AWS_BEDROCK_PRICE_LIST_URL);
+  if (!response.ok) {
+    throw new Error(`AWS Bedrock price list failed with HTTP ${response.status}`);
+  }
+
+  return parseAwsBedrockPrices(await response.json());
+}

--- a/infra/coordinator/functions/pricing-refresh/aws.test.js
+++ b/infra/coordinator/functions/pricing-refresh/aws.test.js
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { fetchAwsBedrockPrices, parseAwsBedrockPrices } from "./aws.js";
+
+function product(modelName, sku) {
+  return [
+    sku,
+    {
+      productFamily: "Text Generation",
+      attributes: {
+        servicecode: "AmazonBedrock",
+        modelName,
+        group: "Bedrock model inference",
+        usagetype: `${modelName.replaceAll(" ", "")}-InputTokens`,
+      },
+    },
+  ];
+}
+
+function dimension(description, usd, unit = "1K tokens") {
+  return {
+    description,
+    unit,
+    pricePerUnit: { USD: usd },
+  };
+}
+
+function term(inputDescription, inputUsd, outputDescription, outputUsd) {
+  return {
+    offer: {
+      priceDimensions: {
+        in: dimension(inputDescription, inputUsd),
+        out: dimension(outputDescription, outputUsd),
+      },
+    },
+  };
+}
+
+describe("parseAwsBedrockPrices", () => {
+  it("maps Nova input and output token prices to canonical model ids", () => {
+    const priceList = {
+      products: Object.fromEntries([
+        product("Amazon Nova Micro", "NOVA_MICRO"),
+        product("Amazon Nova Lite", "NOVA_LITE"),
+        product("Amazon Nova Pro", "NOVA_PRO"),
+        product("Titan Embeddings", "TITAN"),
+      ]),
+      terms: {
+        OnDemand: {
+          NOVA_MICRO: term(
+            "Amazon Nova Micro input tokens per 1K tokens",
+            "0.000035",
+            "Amazon Nova Micro output tokens per 1K tokens",
+            "0.00014",
+          ),
+          NOVA_LITE: term(
+            "Amazon Nova Lite input tokens per 1K tokens",
+            "0.00006",
+            "Amazon Nova Lite output tokens per 1K tokens",
+            "0.00024",
+          ),
+          NOVA_PRO: term(
+            "Amazon Nova Pro input tokens per 1K tokens",
+            "0.0008",
+            "Amazon Nova Pro output tokens per 1K tokens",
+            "0.0032",
+          ),
+        },
+      },
+    };
+
+    assert.deepEqual(parseAwsBedrockPrices(priceList), {
+      "amazon.nova-micro": { in: 0.035, out: 0.14, source: "aws-price-list" },
+      "amazon.nova-lite": { in: 0.06, out: 0.24, source: "aws-price-list" },
+      "amazon.nova-pro": { in: 0.8, out: 3.2, source: "aws-price-list" },
+    });
+  });
+
+  it("throws when the public price list fetch fails", async () => {
+    await assert.rejects(
+      fetchAwsBedrockPrices(async () => new Response("{}", { status: 503 })),
+      /AWS Bedrock price list failed with HTTP 503/,
+    );
+  });
+});

--- a/infra/coordinator/functions/pricing-refresh/index.js
+++ b/infra/coordinator/functions/pricing-refresh/index.js
@@ -4,9 +4,10 @@
 // without an extra collection-group query.
 //
 // Scope today: reads live GCP Cloud Billing Catalog SKUs for Vertex AI
-// Gemini and GAEP where exposed, then merges them over FALLBACK_PRICING
-// constants (CLAUDE.md "for SKUs not exposed cleanly in [the Catalog API],
-// fall back to maintained constants in /protocol").
+// Gemini / GAEP plus AWS Bedrock's public Price List for Nova, then merges
+// them over FALLBACK_PRICING constants (CLAUDE.md "for SKUs not exposed
+// cleanly in [the Catalog API], fall back to maintained constants in
+// /protocol").
 //
 // Last-known-good behaviour (#39): per-day snapshots are append-only —
 // writes upsert `pricing/{model}/snapshots/{date}` so today's failure
@@ -19,6 +20,7 @@
 
 import { Firestore } from "@google-cloud/firestore";
 import { GoogleAuth } from "google-auth-library";
+import { fetchAwsBedrockPrices } from "./aws.js";
 import { parseGcpCatalogPrices } from "./catalog.js";
 
 const CATALOG_BASE_URL = "https://cloudbilling.googleapis.com/v1";
@@ -154,6 +156,18 @@ export const refreshPricing = async (req, res) => {
     });
   } catch (err) {
     log("ERROR", "pricing-refresh: catalog fetch failed; using fallback prices", {
+      error: err.message,
+    });
+  }
+
+  try {
+    const awsPrices = await fetchAwsBedrockPrices();
+    pricesByModel = { ...pricesByModel, ...awsPrices };
+    log("INFO", "pricing-refresh: AWS Bedrock prices loaded", {
+      models: Object.keys(awsPrices).sort(),
+    });
+  } catch (err) {
+    log("ERROR", "pricing-refresh: AWS Bedrock fetch failed; using fallback prices", {
       error: err.message,
     });
   }


### PR DESCRIPTION
## Summary
- add AWS Bedrock Price List parser for Nova Micro/Lite/Pro input and output token SKUs
- fetch the public AmazonBedrock offer index and merge live Nova prices over fallbacks
- keep per-vendor fetch failures isolated so last-known-good/fallback pricing still writes
- add parser tests for Nova SKU mapping and fetch failure behavior

Closes #36

## Tests
- npm test (infra/coordinator/functions/pricing-refresh)
- pnpm lint
- pnpm format
- pnpm typecheck
- pnpm test
- terraform fmt -check -recursive infra