### PR TITLE
Add Azure OpenAI pricing parser

### DIFF
--- a/infra/coordinator/functions/pricing-refresh/azure.js
+++ b/infra/coordinator/functions/pricing-refresh/azure.js
@@ -1,0 +1,90 @@
+const AZURE_RETAIL_PRICES_URL = "https://prices.azure.com/api/retail/prices";
+
+const AZURE_OPENAI_FILTER =
+  "serviceName eq 'Azure OpenAI' or serviceName eq 'Azure OpenAI Service'";
+
+const GPT_TARGETS = [
+  { modelId: "gpt-5-mini", patterns: [/gpt[-\s]?5[-\s]?mini/i] },
+  { modelId: "gpt-5", patterns: [/gpt[-\s]?5(?![-\s]?mini)/i] },
+];
+
+function findTarget(text) {
+  return GPT_TARGETS.find((target) => target.patterns.some((pattern) => pattern.test(text)));
+}
+
+function classifyDirection(text) {
+  if (/input|prompt/i.test(text)) return "in";
+  if (/output|completion|response|generated/i.test(text)) return "out";
+  return undefined;
+}
+
+function normalizeToMtoken(price, unitText) {
+  const text = unitText.toLowerCase();
+  let normalized;
+  if (/1,?000,?000|million|mtok|m token/.test(text)) normalized = price;
+  else if (/1,?000|thousand|1k|k token/.test(text)) normalized = price * 1_000;
+  else if (/\btoken(s)?\b/.test(text)) normalized = price * 1_000_000;
+  else normalized = price;
+  return Math.round(normalized * 1_000_000_000_000) / 1_000_000_000_000;
+}
+
+function itemText(item) {
+  return [
+    item.productName,
+    item.skuName,
+    item.meterName,
+    item.armSkuName,
+    item.serviceName,
+    item.type,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function parseAzureOpenAiPrices(items) {
+  const collected = {};
+
+  for (const item of items) {
+    const text = itemText(item);
+    const target = findTarget(text);
+    if (!target) continue;
+
+    const direction = classifyDirection(text);
+    if (!direction) continue;
+    if (item.unitPrice === undefined || item.unitPrice === null) continue;
+
+    collected[target.modelId] ??= {};
+    collected[target.modelId][direction] ??= normalizeToMtoken(
+      Number(item.unitPrice),
+      [text, item.unitOfMeasure].join(" "),
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(collected)
+      .filter(([, prices]) => prices.in !== undefined && prices.out !== undefined)
+      .map(([modelId, prices]) => [
+        modelId,
+        { in: prices.in, out: prices.out, source: "azure-retail-prices" },
+      ]),
+  );
+}
+
+export async function fetchAzureOpenAiPrices(fetchImpl = fetch) {
+  const items = [];
+  let nextUrl = new URL(AZURE_RETAIL_PRICES_URL);
+  nextUrl.searchParams.set("$filter", AZURE_OPENAI_FILTER);
+
+  while (nextUrl) {
+    const response = await fetchImpl(nextUrl);
+    if (!response.ok) {
+      throw new Error(`Azure Retail Prices API failed with HTTP ${response.status}`);
+    }
+
+    const body = await response.json();
+    items.push(...(body.Items ?? []));
+    nextUrl = body.NextPageLink ? new URL(body.NextPageLink) : undefined;
+  }
+
+  return parseAzureOpenAiPrices(items);
+}

--- a/infra/coordinator/functions/pricing-refresh/azure.test.js
+++ b/infra/coordinator/functions/pricing-refresh/azure.test.js
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { fetchAzureOpenAiPrices, parseAzureOpenAiPrices } from "./azure.js";
+
+function item(model, direction, unitPrice, unitOfMeasure = "1K Tokens") {
+  return {
+    serviceName: "Azure OpenAI Service",
+    productName: `Azure OpenAI ${model}`,
+    skuName: model,
+    meterName: `${model} ${direction} Tokens`,
+    unitPrice,
+    unitOfMeasure,
+  };
+}
+
+describe("parseAzureOpenAiPrices", () => {
+  it("maps GPT-5 retail prices to canonical model ids", () => {
+    const prices = parseAzureOpenAiPrices([
+      item("GPT-5 Mini", "Input", 0.00025),
+      item("GPT-5 Mini", "Output", 0.002),
+      item("GPT-5", "Input", 0.00125),
+      item("GPT-5", "Output", 0.01),
+      item("GPT-4o", "Input", 0.0025),
+    ]);
+
+    assert.deepEqual(prices, {
+      "gpt-5-mini": { in: 0.25, out: 2, source: "azure-retail-prices" },
+      "gpt-5": { in: 1.25, out: 10, source: "azure-retail-prices" },
+    });
+  });
+
+  it("follows Azure Retail Prices pagination", async () => {
+    const seen = [];
+    const prices = await fetchAzureOpenAiPrices(async (url) => {
+      seen.push(url.toString());
+      if (seen.length === 1) {
+        return Response.json({
+          Items: [item("GPT-5 Mini", "Input", 0.00025)],
+          NextPageLink: "https://prices.azure.com/api/retail/prices?page=2",
+        });
+      }
+      return Response.json({
+        Items: [item("GPT-5 Mini", "Output", 0.002)],
+      });
+    });
+
+    assert.equal(seen.length, 2);
+    assert.deepEqual(prices["gpt-5-mini"], {
+      in: 0.25,
+      out: 2,
+      source: "azure-retail-prices",
+    });
+  });
+
+  it("throws when the retail prices fetch fails", async () => {
+    await assert.rejects(
+      fetchAzureOpenAiPrices(async () => new Response("{}", { status: 502 })),
+      /Azure Retail Prices API failed with HTTP 502/,
+    );
+  });
+});

--- a/infra/coordinator/functions/pricing-refresh/index.js
+++ b/infra/coordinator/functions/pricing-refresh/index.js
@@ -4,10 +4,10 @@
 // without an extra collection-group query.
 //
 // Scope today: reads live GCP Cloud Billing Catalog SKUs for Vertex AI
-// Gemini / GAEP plus AWS Bedrock's public Price List for Nova, then merges
-// them over FALLBACK_PRICING constants (CLAUDE.md "for SKUs not exposed
-// cleanly in [the Catalog API], fall back to maintained constants in
-// /protocol").
+// Gemini / GAEP, AWS Bedrock's public Price List for Nova, and Azure
+// Retail Prices for GPT deployments, then merges them over FALLBACK_PRICING
+// constants (CLAUDE.md "for SKUs not exposed cleanly in [the Catalog API],
+// fall back to maintained constants in /protocol").
 //
 // Last-known-good behaviour (#39): per-day snapshots are append-only —
 // writes upsert `pricing/{model}/snapshots/{date}` so today's failure
@@ -21,6 +21,7 @@
 import { Firestore } from "@google-cloud/firestore";
 import { GoogleAuth } from "google-auth-library";
 import { fetchAwsBedrockPrices } from "./aws.js";
+import { fetchAzureOpenAiPrices } from "./azure.js";
 import { parseGcpCatalogPrices } from "./catalog.js";
 
 const CATALOG_BASE_URL = "https://cloudbilling.googleapis.com/v1";
@@ -168,6 +169,18 @@ export const refreshPricing = async (req, res) => {
     });
   } catch (err) {
     log("ERROR", "pricing-refresh: AWS Bedrock fetch failed; using fallback prices", {
+      error: err.message,
+    });
+  }
+
+  try {
+    const azurePrices = await fetchAzureOpenAiPrices();
+    pricesByModel = { ...pricesByModel, ...azurePrices };
+    log("INFO", "pricing-refresh: Azure OpenAI prices loaded", {
+      models: Object.keys(azurePrices).sort(),
+    });
+  } catch (err) {
+    log("ERROR", "pricing-refresh: Azure OpenAI fetch failed; using fallback prices", {
       error: err.message,
     });
   }


### PR DESCRIPTION
## Summary
- add Azure Retail Prices parser for GPT-5 mini and GPT-5 input/output token pricing
- follow Azure Retail Prices pagination and merge live GPT prices over fallbacks
- keep Azure fetch failures isolated from other vendor pricing writes
- add parser tests for GPT SKU mapping, pagination, and fetch failures

Closes #37

## Tests
- npm test (infra/coordinator/functions/pricing-refresh)
- pnpm lint
- pnpm format
- pnpm typecheck
- pnpm test
- terraform fmt -check -recursive infra