### PR TITLE
Add AWS Nova IAM role

### DIFF
--- a/infra/agent-aws-nova/.terraform.lock.hcl
+++ b/infra/agent-aws-nova/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.100"
+  hashes = [
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/agent-aws-nova/backend.hcl.example
+++ b/infra/agent-aws-nova/backend.hcl.example
@@ -1,0 +1,14 @@
+# Usage:
+#   terraform init -backend-config=backend.hcl
+#
+# Manual prereqs:
+#   - S3 bucket for Terraform state
+#   - optional DynamoDB table for state locking if your environment uses it
+#
+# bucket = "agent-tasker-dev-terraform-state"
+# key    = "agent-aws-nova/terraform.tfstate"
+# region = "us-east-1"
+#
+# Optional:
+# dynamodb_table = "agent-tasker-dev-terraform-locks"
+# encrypt        = true

--- a/infra/agent-aws-nova/iam.tf
+++ b/infra/agent-aws-nova/iam.tf
@@ -1,0 +1,53 @@
+# Runtime identity for the AWS/Nova agent.
+#
+# The model-family lock is load-bearing: this role can invoke only Amazon
+# Nova Bedrock foundation models in the configured region. It cannot call
+# Anthropic, Meta, Cohere, or any future non-Nova provider family through
+# Bedrock. The Lambda/API Gateway stack that assumes this role lands in #43.
+
+data "aws_iam_policy_document" "agent_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "agent_runtime" {
+  name               = "${local.name_prefix}-aws-nova-runtime"
+  description        = "Runtime role for the AWS/Nova agent; Bedrock access is limited to Amazon Nova models."
+  assume_role_policy = data.aws_iam_policy_document.agent_assume_role.json
+}
+
+locals {
+  nova_foundation_model_arns = [
+    "arn:${data.aws_partition.current.partition}:bedrock:${var.aws_region}::foundation-model/amazon.nova-micro-v1:*",
+    "arn:${data.aws_partition.current.partition}:bedrock:${var.aws_region}::foundation-model/amazon.nova-lite-v1:*",
+    "arn:${data.aws_partition.current.partition}:bedrock:${var.aws_region}::foundation-model/amazon.nova-pro-v1:*",
+  ]
+}
+
+data "aws_iam_policy_document" "agent_bedrock_nova" {
+  statement {
+    sid    = "InvokeAmazonNovaOnly"
+    effect = "Allow"
+
+    actions = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream",
+    ]
+
+    resources = local.nova_foundation_model_arns
+  }
+}
+
+resource "aws_iam_role_policy" "agent_bedrock_nova" {
+  name   = "${local.name_prefix}-aws-nova-bedrock"
+  role   = aws_iam_role.agent_runtime.id
+  policy = data.aws_iam_policy_document.agent_bedrock_nova.json
+}

--- a/infra/agent-aws-nova/main.tf
+++ b/infra/agent-aws-nova/main.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+data "aws_partition" "current" {}
+
+locals {
+  name_prefix = "${var.project}-${var.env}"
+
+  common_tags = merge(
+    {
+      project = var.project
+      env     = var.env
+      module  = "agent-aws-nova"
+    },
+    var.tags,
+  )
+}

--- a/infra/agent-aws-nova/outputs.tf
+++ b/infra/agent-aws-nova/outputs.tf
@@ -1,0 +1,14 @@
+output "agent_runtime_role_arn" {
+  description = "IAM role ARN for the AWS/Nova agent runtime. The Lambda stack in #43 assumes this role."
+  value       = aws_iam_role.agent_runtime.arn
+}
+
+output "agent_runtime_role_name" {
+  description = "IAM role name for the AWS/Nova agent runtime."
+  value       = aws_iam_role.agent_runtime.name
+}
+
+output "nova_foundation_model_arns" {
+  description = "Bedrock foundation-model ARNs the AWS/Nova runtime role may invoke."
+  value       = local.nova_foundation_model_arns
+}

--- a/infra/agent-aws-nova/variables.tf
+++ b/infra/agent-aws-nova/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  description = "AWS region hosting the AWS/Nova agent stack and Bedrock runtime."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project" {
+  description = "Project name prefix used in resource naming and tags."
+  type        = string
+  default     = "agent-tasker"
+}
+
+variable "env" {
+  description = "Environment name (e.g. dev, staging, prod). Used in resource names."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,16}$", var.env))
+    error_message = "env must be 1-16 chars of [a-z0-9-]."
+  }
+}
+
+variable "tags" {
+  description = "Extra tags to merge onto every AWS resource that supports tags."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/agent-aws-nova/versions.tf
+++ b/infra/agent-aws-nova/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+
+  # Backend is left as a partial config so each environment supplies the
+  # S3 state bucket/key details:
+  #
+  #   terraform init -backend-config=backend.hcl
+  #
+  # See backend.hcl.example.
+  backend "s3" {}
+}


### PR DESCRIPTION
## Summary
- add a new infra/agent-aws-nova Terraform root with AWS provider/backend conventions
- create a Lambda-assumable AWS/Nova runtime role
- attach an inline Bedrock policy limited to Amazon Nova foundation-model ARNs only
- expose role and allowed-model ARN outputs for the upcoming Lambda/API Gateway stack

Closes #42

## Tests
- terraform fmt -check -recursive infra
- terraform init -backend=false -input=false -no-color (infra/agent-aws-nova)
- terraform validate -no-color (infra/agent-aws-nova; required escalation locally for provider plugin execution)
- pnpm lint
- pnpm format
- pnpm typecheck
- pnpm test