### PR TITLE
Add AWS Nova Lambda API stack

### DIFF
--- a/infra/agent-aws-nova/.terraform.lock.hcl
+++ b/infra/agent-aws-nova/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.7"
+  hashes = [
+    "h1:oRWx6ZDIdlNBF90L8TzV9X7pQ+P403hoCDiBfmUfhC0=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.100"

--- a/infra/agent-aws-nova/api_gateway.tf
+++ b/infra/agent-aws-nova/api_gateway.tf
@@ -1,0 +1,56 @@
+resource "aws_apigatewayv2_api" "agent" {
+  name          = local.agent_name
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_headers = ["authorization", "content-type"]
+    allow_methods = ["GET", "POST", "OPTIONS"]
+    allow_origins = ["*"]
+    max_age       = 300
+  }
+}
+
+resource "aws_apigatewayv2_integration" "agent" {
+  api_id = aws_apigatewayv2_api.agent.id
+
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.agent.invoke_arn
+  payload_format_version = "2.0"
+  timeout_milliseconds   = 29000
+}
+
+resource "aws_apigatewayv2_route" "health" {
+  api_id = aws_apigatewayv2_api.agent.id
+
+  route_key = "GET /health"
+  target    = "integrations/${aws_apigatewayv2_integration.agent.id}"
+}
+
+resource "aws_apigatewayv2_route" "bid" {
+  api_id = aws_apigatewayv2_api.agent.id
+
+  route_key = "POST /bid"
+  target    = "integrations/${aws_apigatewayv2_integration.agent.id}"
+}
+
+resource "aws_apigatewayv2_route" "execute" {
+  api_id = aws_apigatewayv2_api.agent.id
+
+  route_key = "POST /execute"
+  target    = "integrations/${aws_apigatewayv2_integration.agent.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id = aws_apigatewayv2_api.agent.id
+
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "api_gateway" {
+  statement_id  = "AllowApiGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.agent.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.agent.execution_arn}/*/*"
+}

--- a/infra/agent-aws-nova/functions/placeholder/index.mjs
+++ b/infra/agent-aws-nova/functions/placeholder/index.mjs
@@ -1,0 +1,24 @@
+export async function handler(event) {
+  const path = event.rawPath ?? "/";
+  const method = event.requestContext?.http?.method ?? "GET";
+
+  if (method === "GET" && path === "/health") {
+    return {
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true, agent_id: "aws-nova" }),
+    };
+  }
+
+  return {
+    statusCode: 501,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      error: {
+        code: "not_implemented",
+        message:
+          "aws-nova handler deployment is provisioned; runtime implementation lands in follow-up issues",
+      },
+    }),
+  };
+}

--- a/infra/agent-aws-nova/iam.tf
+++ b/infra/agent-aws-nova/iam.tf
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "agent_assume_role" {
 }
 
 resource "aws_iam_role" "agent_runtime" {
-  name               = "${local.name_prefix}-aws-nova-runtime"
+  name               = "${local.agent_name}-runtime"
   description        = "Runtime role for the AWS/Nova agent; Bedrock access is limited to Amazon Nova models."
   assume_role_policy = data.aws_iam_policy_document.agent_assume_role.json
 }
@@ -47,7 +47,27 @@ data "aws_iam_policy_document" "agent_bedrock_nova" {
 }
 
 resource "aws_iam_role_policy" "agent_bedrock_nova" {
-  name   = "${local.name_prefix}-aws-nova-bedrock"
+  name   = "${local.agent_name}-bedrock"
   role   = aws_iam_role.agent_runtime.id
   policy = data.aws_iam_policy_document.agent_bedrock_nova.json
+}
+
+data "aws_iam_policy_document" "agent_logs" {
+  statement {
+    sid    = "WriteOwnLambdaLogs"
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["${aws_cloudwatch_log_group.agent.arn}:*"]
+  }
+}
+
+resource "aws_iam_role_policy" "agent_logs" {
+  name   = "${local.agent_name}-logs"
+  role   = aws_iam_role.agent_runtime.id
+  policy = data.aws_iam_policy_document.agent_logs.json
 }

--- a/infra/agent-aws-nova/lambda.tf
+++ b/infra/agent-aws-nova/lambda.tf
@@ -1,0 +1,43 @@
+data "archive_file" "agent_placeholder" {
+  type        = "zip"
+  source_dir  = "${path.module}/functions/placeholder"
+  output_path = "${path.module}/functions/.dist/aws-nova-placeholder.zip"
+}
+
+resource "aws_cloudwatch_log_group" "agent" {
+  name              = "/aws/lambda/${local.agent_name}"
+  retention_in_days = 14
+}
+
+resource "aws_lambda_function" "agent" {
+  function_name = local.agent_name
+  description   = "AWS/Nova agent HTTP handler for /health, /bid, and /execute."
+
+  role = aws_iam_role.agent_runtime.arn
+
+  runtime     = "nodejs22.x"
+  handler     = "index.handler"
+  memory_size = var.agent_memory_mb
+  timeout     = var.agent_timeout_seconds
+
+  filename         = data.archive_file.agent_placeholder.output_path
+  source_code_hash = data.archive_file.agent_placeholder.output_base64sha256
+
+  environment {
+    variables = {
+      AGENT_ID                 = "aws-nova"
+      AWS_NOVA_BID_MODEL_ID    = var.bedrock_bid_model_id
+      AWS_NOVA_EXEC_MODEL_ID   = var.bedrock_execute_model_id
+      JWKS_URL                 = var.jwks_url
+      NODE_OPTIONS             = "--enable-source-maps"
+      POWERTOOLS_SERVICE_NAME  = "agent-aws-nova"
+      POWERTOOLS_TRACE_ENABLED = "true"
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.agent,
+    aws_iam_role_policy.agent_bedrock_nova,
+    aws_iam_role_policy.agent_logs,
+  ]
+}

--- a/infra/agent-aws-nova/main.tf
+++ b/infra/agent-aws-nova/main.tf
@@ -10,6 +10,7 @@ data "aws_partition" "current" {}
 
 locals {
   name_prefix = "${var.project}-${var.env}"
+  agent_name  = "${local.name_prefix}-aws-nova"
 
   common_tags = merge(
     {

--- a/infra/agent-aws-nova/outputs.tf
+++ b/infra/agent-aws-nova/outputs.tf
@@ -8,6 +8,16 @@ output "agent_runtime_role_name" {
   value       = aws_iam_role.agent_runtime.name
 }
 
+output "agent_lambda_function_name" {
+  description = "AWS/Nova Lambda function name."
+  value       = aws_lambda_function.agent.function_name
+}
+
+output "agent_api_endpoint" {
+  description = "HTTP API Gateway endpoint for the AWS/Nova agent. Coordinator per-agent endpoint config points at this."
+  value       = aws_apigatewayv2_api.agent.api_endpoint
+}
+
 output "nova_foundation_model_arns" {
   description = "Bedrock foundation-model ARNs the AWS/Nova runtime role may invoke."
   value       = local.nova_foundation_model_arns

--- a/infra/agent-aws-nova/variables.tf
+++ b/infra/agent-aws-nova/variables.tf
@@ -25,3 +25,32 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "agent_memory_mb" {
+  description = "Memory allocated to the AWS/Nova Lambda function."
+  type        = number
+  default     = 512
+}
+
+variable "agent_timeout_seconds" {
+  description = "Lambda timeout for /bid and /execute requests. Kept below API Gateway's hard timeout; long executions move to async follow-ups if needed."
+  type        = number
+  default     = 29
+}
+
+variable "jwks_url" {
+  description = "Coordinator JWKS URL the AWS/Nova agent will use for RS256 token verification."
+  type        = string
+}
+
+variable "bedrock_bid_model_id" {
+  description = "Bedrock model ID pinned for the AWS/Nova bid estimator."
+  type        = string
+  default     = "amazon.nova-micro-v1:0"
+}
+
+variable "bedrock_execute_model_id" {
+  description = "Bedrock model ID pinned for the AWS/Nova execution model."
+  type        = string
+  default     = "amazon.nova-pro-v1:0"
+}

--- a/infra/agent-aws-nova/versions.tf
+++ b/infra/agent-aws-nova/versions.tf
@@ -2,6 +2,11 @@ terraform {
   required_version = ">= 1.7"
 
   required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.7"
+    }
+
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.100"


### PR DESCRIPTION
## Summary
- add Node 22 AWS/Nova Lambda infrastructure with 512MB default memory
- expose API Gateway HTTP API routes for GET /health, POST /bid, and POST /execute
- add placeholder Lambda package so Terraform can deploy the endpoint shape before runtime handlers land
- add scoped Lambda log permissions and outputs for endpoint/function discovery

Closes #43

## Tests
- terraform fmt -check -recursive infra
- terraform init -backend=false -input=false -no-color (infra/agent-aws-nova)
- terraform validate -no-color (infra/agent-aws-nova; required escalation locally for provider plugin execution)
- pnpm lint
- pnpm format
- pnpm typecheck
- pnpm test