### PR TITLE
Add AWS Nova bid estimator prompt

### DIFF
--- a/agent/aws-nova/package.json
+++ b/agent/aws-nova/package.json
@@ -8,10 +8,12 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
     "@agent-tasker/agent": "workspace:*",
-    "@agent-tasker/protocol": "workspace:*"
+    "@agent-tasker/protocol": "workspace:*",
+    "zod": "^3.25.76"
   }
 }

--- a/agent/aws-nova/src/bid/estimator.ts
+++ b/agent/aws-nova/src/bid/estimator.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import type { TaskSpec } from "@agent-tasker/protocol";
+
+export interface BidEstimator {
+  estimate(spec: TaskSpec): Promise<{ input_tokens: number; output_tokens: number }>;
+}
+
+export interface GenerativeJsonClient {
+  generateJson(prompt: string): Promise<unknown>;
+}
+
+const EstimateResultSchema = z.object({
+  est_input_tokens: z.number().int().nonnegative(),
+  est_output_tokens: z.number().int().nonnegative(),
+});
+
+export function buildNovaBidPrompt(spec: TaskSpec): string {
+  return `You estimate Amazon Nova Pro token usage for a sealed-bid agent market.
+
+Use Nova-family tokenization behavior, not Claude, Gemini, or GPT examples. Be conservative: code, JSON, YAML, URLs, tables, long identifiers, and punctuation-heavy text generally tokenize denser than plain prose. Attachments are referenced by hash; count only metadata unless the task requires fetching or reading them, then budget the likely retrieved text as input.
+
+Examples calibrated for Nova-style bids:
+- "Summarize this 900-word product memo in five bullets" -> {"est_input_tokens":1400,"est_output_tokens":220}
+- "Review this TypeScript function and return fixed code" with a 120-line snippet -> {"est_input_tokens":2600,"est_output_tokens":900}
+- "Compare three attached policy PDFs and cite conflicts" with attachment hashes only -> {"est_input_tokens":8000,"est_output_tokens":1600}
+
+Task prompt:
+---
+${spec.prompt}
+---
+${spec.min_tier ? `Minimum tier requested by client: ${spec.min_tier}\n` : ""}${
+    spec.attachments?.length
+      ? `Attachments: ${spec.attachments.length} hash reference(s); include fetch/read budget only if needed by the prompt.\n`
+      : ""
+  }
+Return only JSON:
+{"est_input_tokens": integer, "est_output_tokens": integer}`;
+}
+
+export class NovaBidEstimator implements BidEstimator {
+  constructor(private readonly client: GenerativeJsonClient) {}
+
+  async estimate(spec: TaskSpec): Promise<{ input_tokens: number; output_tokens: number }> {
+    const raw = await this.client.generateJson(buildNovaBidPrompt(spec));
+    const parsed = EstimateResultSchema.parse(raw);
+    return {
+      input_tokens: parsed.est_input_tokens,
+      output_tokens: parsed.est_output_tokens,
+    };
+  }
+}

--- a/agent/aws-nova/src/bid/index.ts
+++ b/agent/aws-nova/src/bid/index.ts
@@ -1,0 +1,1 @@
+export * from "./estimator.js";

--- a/agent/aws-nova/src/index.ts
+++ b/agent/aws-nova/src/index.ts
@@ -1,1 +1,3 @@
 export const AGENT_ID = "aws-nova";
+
+export * from "./bid/index.js";

--- a/agent/aws-nova/test/bid/estimator.test.ts
+++ b/agent/aws-nova/test/bid/estimator.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildNovaBidPrompt,
+  NovaBidEstimator,
+  type GenerativeJsonClient,
+} from "../../src/bid/estimator.js";
+
+describe("buildNovaBidPrompt", () => {
+  it("uses Nova-specific guidance instead of reusing other model-family prompts", () => {
+    const prompt = buildNovaBidPrompt({
+      prompt: "Refactor this JSON-heavy Lambda handler.",
+      min_tier: "frontier",
+      attachments: [{ uri: "sha256:abc123", mime_type: "application/json" }],
+    });
+
+    expect(prompt).toContain("Amazon Nova Pro");
+    expect(prompt).toContain("Nova-family tokenization");
+    expect(prompt).toContain("not Claude, Gemini, or GPT examples");
+    expect(prompt).toContain("JSON");
+    expect(prompt).toContain("Attachments: 1 hash reference");
+    expect(prompt).toContain("Minimum tier requested by client: frontier");
+    expect(prompt).toContain('"est_input_tokens"');
+    expect(prompt).toContain('"est_output_tokens"');
+  });
+});
+
+describe("NovaBidEstimator", () => {
+  it("returns parsed token estimates from the Nova prompt client", async () => {
+    const client: GenerativeJsonClient = {
+      async generateJson(prompt) {
+        expect(prompt).toContain("Write a migration plan");
+        expect(prompt).toContain("Amazon Nova Pro");
+        return { est_input_tokens: 2400, est_output_tokens: 700 };
+      },
+    };
+
+    await expect(
+      new NovaBidEstimator(client).estimate({ prompt: "Write a migration plan" }),
+    ).resolves.toEqual({
+      input_tokens: 2400,
+      output_tokens: 700,
+    });
+  });
+
+  it("rejects malformed estimator output", async () => {
+    const client: GenerativeJsonClient = {
+      async generateJson() {
+        return { est_input_tokens: -1, est_output_tokens: 50 };
+      },
+    };
+
+    await expect(
+      new NovaBidEstimator(client).estimate({ prompt: "bad estimate" }),
+    ).rejects.toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@agent-tasker/protocol':
         specifier: workspace:*
         version: link:../../protocol
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   agent/azure-gpt:
     dependencies:


### PR DESCRIPTION
## Summary
- add AWS/Nova bid estimator with Nova-specific token-estimation prompt examples
- include guidance for code/JSON/tables/attachment hash references instead of reusing other model-family prompts
- add parser validation for estimator JSON output and unit coverage for prompt content
- enable AWS/Nova package tests and add zod as a direct dependency

Closes #44

## Tests
- pnpm --filter @agent-tasker/agent-aws-nova test
- pnpm --filter @agent-tasker/agent-aws-nova typecheck
- pnpm lint
- pnpm format
- pnpm typecheck
- pnpm test