### PR TITLE
Add cross-cloud egress monitoring

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -67,6 +67,9 @@ export interface HttpAuctionRunnerOptions {
   // never throws past `start()` — every failure path is reflected in the
   // ledger.
   onError?: (taskId: TaskId, err: unknown) => void;
+  // Emits one event per coordinator→agent request so cross-cloud egress can
+  // be tracked by logs-based metrics and smoke-tested without live cloud IO.
+  egressRecorder?: EgressRecorder;
 }
 
 const DEFAULT_BID_TIMEOUT_MS = 5_000;
@@ -74,6 +77,9 @@ const DEFAULT_BID_INITIAL_WAIT_MS = 2_000;
 const DEFAULT_BID_EXTENSION_MS = 1_000;
 const DEFAULT_EXECUTE_TIMEOUT_MS = 60_000;
 export const EXECUTION_OVERRUN_MULTIPLIER = 10;
+const DEFAULT_AGENT_EGRESS_RECORDER: EgressRecorder = (event) => {
+  console.log(JSON.stringify({ event: "coordinator.agent_egress_bytes", ...event }));
+};
 
 export class HttpAuctionRunner implements AuctionRunner {
   private readonly settlements = new Map<TaskId, Promise<void>>();
@@ -205,6 +211,14 @@ export class HttpAuctionRunner implements AuctionRunner {
             taskId,
             phase: "bid",
           });
+          this.recordAgentEgress({
+            taskId,
+            agentId: agent.agentId,
+            phase: "bid",
+            url: `${agent.baseUrl}/bid`,
+            body,
+            bearerToken: token,
+          });
           const res = await fetchImpl(`${agent.baseUrl}/bid`, {
             method: "POST",
             headers: {
@@ -264,23 +278,112 @@ export class HttpAuctionRunner implements AuctionRunner {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     let res: Response;
+    const requestBody = JSON.stringify({ task_id: taskId, spec });
     try {
+      this.recordAgentEgress({
+        taskId,
+        agentId,
+        phase: "execute",
+        url: `${agent.baseUrl}/execute`,
+        body: requestBody,
+        bearerToken: token,
+      });
       res = await fetchImpl(`${agent.baseUrl}/execute`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
           authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ task_id: taskId, spec }),
+        body: requestBody,
         signal: controller.signal,
       });
     } finally {
       clearTimeout(timer);
     }
     if (!res.ok) throw new Error(`execute returned ${res.status}`);
-    const body = (await res.json()) as unknown;
-    return ResultSchema.parse(body);
+    const responseBody = (await res.json()) as unknown;
+    return ResultSchema.parse(responseBody);
   }
+
+  private recordAgentEgress({
+    taskId,
+    agentId,
+    phase,
+    url,
+    body,
+    bearerToken,
+  }: {
+    taskId: TaskId;
+    agentId: AgentId;
+    phase: JwtPhase;
+    url: string;
+    body: string;
+    bearerToken: string;
+  }): void {
+    const target = new URL(url);
+    const cloudLeg = cloudLegForAgent(agentId);
+    const event: AgentEgressEvent = {
+      task_id: taskId,
+      agent_id: agentId,
+      phase,
+      cloud_leg: cloudLeg,
+      cross_cloud_billable: cloudLeg !== "gcp",
+      egress_class: cloudLeg === "gcp" ? "same_cloud" : "cross_cloud",
+      bytes_out: estimateHttpRequestBytes({
+        method: "POST",
+        path: target.pathname,
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${bearerToken}`,
+        },
+        body,
+      }),
+    };
+    (this.opts.egressRecorder ?? DEFAULT_AGENT_EGRESS_RECORDER)(event);
+  }
+}
+
+export type AgentCloudLeg = "aws" | "azure" | "gcp";
+
+export interface AgentEgressEvent {
+  task_id: TaskId;
+  agent_id: AgentId;
+  phase: JwtPhase;
+  cloud_leg: AgentCloudLeg;
+  cross_cloud_billable: boolean;
+  egress_class: "cross_cloud" | "same_cloud";
+  bytes_out: number;
+}
+
+export type EgressRecorder = (event: AgentEgressEvent) => void;
+
+export function cloudLegForAgent(agentId: AgentId): AgentCloudLeg {
+  if (agentId === "aws-nova") return "aws";
+  if (agentId === "azure-gpt") return "azure";
+  return "gcp";
+}
+
+export function estimateHttpRequestBytes({
+  method,
+  path,
+  headers,
+  body,
+}: {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body: string;
+}): number {
+  const requestLineBytes = byteLength(`${method} ${path} HTTP/1.1\r\n`);
+  const headerBytes = Object.entries(headers).reduce(
+    (total, [name, value]) => total + byteLength(`${name}: ${value}\r\n`),
+    0,
+  );
+  return requestLineBytes + headerBytes + byteLength("\r\n") + byteLength(body);
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
 }
 
 export function computeActualUsdFromBidPrices(bid: Bid, result: Result): number {

--- a/coordinator/test/integration/e2e-gcp-gemini.test.ts
+++ b/coordinator/test/integration/e2e-gcp-gemini.test.ts
@@ -92,6 +92,7 @@ beforeAll(async () => {
     agents: [{ agentId: "gcp-gemini", baseUrl: agentUrl }],
     tokenSigner,
     pricingSnapshot: PRICING_SNAPSHOT,
+    egressRecorder: () => {},
   });
   coordinatorApp = createCoordinatorApp({ store, runner });
 });

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -11,10 +11,13 @@ import type {
 } from "@agent-tasker/protocol";
 import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
 import {
+  type AgentEgressEvent,
   type AgentAccuracyLookup,
   HttpAuctionRunner,
   type AgentEndpoint,
   type TaskTokenSigner,
+  cloudLegForAgent,
+  estimateHttpRequestBytes,
 } from "../../src/auction/http-runner.js";
 import { startFakeAgent, type FakeAgent } from "./fake-agent.js";
 
@@ -75,6 +78,7 @@ async function startAuction(opts: {
   tieBreakRandom?: () => number;
   bidTimeoutMs?: number;
   spec?: TaskSpec;
+  egressRecorder?: (event: AgentEgressEvent) => void;
 }): Promise<HttpAuctionRunner> {
   await store.createTask({
     taskId: opts.taskId,
@@ -88,6 +92,7 @@ async function startAuction(opts: {
     ...(opts.accuracyByAgent !== undefined ? { accuracyByAgent: opts.accuracyByAgent } : {}),
     ...(opts.tieBreakRandom !== undefined ? { tieBreakRandom: opts.tieBreakRandom } : {}),
     ...(opts.bidTimeoutMs !== undefined ? { bidTimeoutMs: opts.bidTimeoutMs } : {}),
+    egressRecorder: opts.egressRecorder ?? (() => {}),
   });
   runner.start(opts.taskId);
   await runner.settle(opts.taskId);
@@ -474,5 +479,94 @@ describe("HttpAuctionRunner", () => {
     expect(gemini.executeCalls).toBe(1);
     expect(nova.executeCalls).toBe(1);
     expect(azure.executeCalls).toBe(0);
+  });
+
+  it("records per-agent request egress for cross-cloud smoke tests", async () => {
+    const taskId = "task-egress-smoke";
+    const egressEvents: AgentEgressEvent[] = [];
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "gcp-gemini",
+        output: "gemini did it",
+        actual_usage: { input_tokens: 4000, output_tokens: 1000 },
+      }),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (req) => bidFor("aws-nova", 0.04, req.task_id),
+    });
+    const azure = await startFakeAgent({
+      agentId: "azure-gpt",
+      onBid: (req) => bidFor("azure-gpt", 0.06, req.task_id),
+    });
+    agents.push(gemini, nova, azure);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+        { agentId: "azure-gpt", baseUrl: azure.url },
+      ],
+      egressRecorder: (event) => egressEvents.push(event),
+    });
+
+    expect(egressEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          task_id: taskId,
+          agent_id: "gcp-gemini",
+          phase: "bid",
+          cloud_leg: "gcp",
+          cross_cloud_billable: false,
+        }),
+        expect.objectContaining({
+          task_id: taskId,
+          agent_id: "aws-nova",
+          phase: "bid",
+          cloud_leg: "aws",
+          cross_cloud_billable: true,
+        }),
+        expect.objectContaining({
+          task_id: taskId,
+          agent_id: "azure-gpt",
+          phase: "bid",
+          cloud_leg: "azure",
+          cross_cloud_billable: true,
+        }),
+        expect.objectContaining({
+          task_id: taskId,
+          agent_id: "gcp-gemini",
+          phase: "execute",
+          cloud_leg: "gcp",
+          cross_cloud_billable: false,
+        }),
+      ]),
+    );
+    expect(egressEvents.every((event) => event.bytes_out > 0)).toBe(true);
+  });
+
+  it("estimates request bytes with UTF-8 body and header length", () => {
+    const bytes = estimateHttpRequestBytes({
+      method: "POST",
+      path: "/bid",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer token",
+      },
+      body: JSON.stringify({ prompt: "hello µ" }),
+    });
+
+    expect(bytes).toBeGreaterThan(JSON.stringify({ prompt: "hello µ" }).length);
+  });
+
+  it("maps agent ids to cloud legs used by the egress dashboard", () => {
+    expect(cloudLegForAgent("gcp-gemini")).toBe("gcp");
+    expect(cloudLegForAgent("gcp-orchestrator")).toBe("gcp");
+    expect(cloudLegForAgent("aws-nova")).toBe("aws");
+    expect(cloudLegForAgent("azure-gpt")).toBe("azure");
   });
 });

--- a/infra/coordinator/egress_monitoring.tf
+++ b/infra/coordinator/egress_monitoring.tf
@@ -1,0 +1,159 @@
+# Logs-based metric + Cloud Monitoring dashboard for coordinator-to-agent
+# request egress. Phase 2's AWS leg is the first billable cross-cloud path;
+# Phase 3 adds Azure to the same labels without another metric.
+
+resource "google_logging_metric" "coordinator_agent_egress_bytes" {
+  project = var.project_id
+  name    = "${local.name_prefix}-agent-egress-bytes"
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="${google_cloud_run_v2_service.coordinator.name}"
+    jsonPayload.event="coordinator.agent_egress_bytes"
+  EOT
+
+  value_extractor = "EXTRACT(jsonPayload.bytes_out)"
+
+  label_extractors = {
+    agent_id     = "EXTRACT(jsonPayload.agent_id)"
+    cloud_leg    = "EXTRACT(jsonPayload.cloud_leg)"
+    egress_class = "EXTRACT(jsonPayload.egress_class)"
+    phase        = "EXTRACT(jsonPayload.phase)"
+  }
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    unit         = "By"
+    display_name = "Coordinator agent egress bytes"
+
+    labels {
+      key         = "agent_id"
+      value_type  = "STRING"
+      description = "Agent endpoint receiving the coordinator request."
+    }
+
+    labels {
+      key         = "cloud_leg"
+      value_type  = "STRING"
+      description = "Target cloud for the agent endpoint: gcp, aws, or azure."
+    }
+
+    labels {
+      key         = "egress_class"
+      value_type  = "STRING"
+      description = "same_cloud for GCP-local agents, cross_cloud for AWS/Azure legs."
+    }
+
+    labels {
+      key         = "phase"
+      value_type  = "STRING"
+      description = "Auction protocol phase that sent the request."
+    }
+  }
+}
+
+resource "google_monitoring_dashboard" "cross_cloud_egress" {
+  project = var.project_id
+
+  dashboard_json = jsonencode({
+    displayName = "${local.name_prefix} cross-cloud egress"
+    mosaicLayout = {
+      columns = 12
+      tiles = [
+        {
+          xPos   = 0
+          yPos   = 0
+          width  = 12
+          height = 4
+          widget = {
+            title = "Coordinator bytes out by cloud leg"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType = "STACKED_AREA"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.coordinator_agent_egress_bytes.name}\" resource.type=\"cloud_run_revision\""
+                      aggregation = {
+                        alignmentPeriod    = "60s"
+                        perSeriesAligner   = "ALIGN_SUM"
+                        crossSeriesReducer = "REDUCE_SUM"
+                        groupByFields      = ["metric.label.cloud_leg"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "bytes / min"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          xPos   = 0
+          yPos   = 4
+          width  = 6
+          height = 4
+          widget = {
+            title = "Billable cross-cloud bytes"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType = "LINE"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.coordinator_agent_egress_bytes.name}\" resource.type=\"cloud_run_revision\" metric.label.egress_class=\"cross_cloud\""
+                      aggregation = {
+                        alignmentPeriod    = "60s"
+                        perSeriesAligner   = "ALIGN_SUM"
+                        crossSeriesReducer = "REDUCE_SUM"
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "bytes / min"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          xPos   = 6
+          yPos   = 4
+          width  = 6
+          height = 4
+          widget = {
+            title = "Coordinator bytes out by phase"
+            xyChart = {
+              dataSets = [
+                {
+                  plotType = "STACKED_BAR"
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.coordinator_agent_egress_bytes.name}\" resource.type=\"cloud_run_revision\""
+                      aggregation = {
+                        alignmentPeriod    = "60s"
+                        perSeriesAligner   = "ALIGN_SUM"
+                        crossSeriesReducer = "REDUCE_SUM"
+                        groupByFields      = ["metric.label.phase"]
+                      }
+                    }
+                  }
+                }
+              ]
+              yAxis = {
+                label = "bytes / min"
+                scale = "LINEAR"
+              }
+            }
+          }
+        }
+      ]
+    }
+  })
+}

--- a/infra/coordinator/outputs.tf
+++ b/infra/coordinator/outputs.tf
@@ -42,3 +42,8 @@ output "pricing_refresh_runtime_service_account_email" {
   description = "Pricing-refresh function runtime SA. #38 adds roles/billing.viewer to this principal so the Cloud Billing Catalog parser can fetch SKUs."
   value       = google_service_account.pricing_refresh_runtime.email
 }
+
+output "cross_cloud_egress_dashboard_id" {
+  description = "Cloud Monitoring dashboard that charts coordinator→agent bytes out by cloud leg, phase, and billable cross-cloud total."
+  value       = google_monitoring_dashboard.cross_cloud_egress.id
+}


### PR DESCRIPTION
## Summary
- emit structured coordinator→agent egress-byte events for /bid and /execute requests
- add smoke-test coverage for AWS, Azure, and GCP cloud-leg classification
- add a Cloud Logging metric and Cloud Monitoring dashboard for bytes by cloud leg, billable cross-cloud total, and phase

Closes #65

## Tests
- pnpm --filter @agent-tasker/coordinator test
- pnpm lint
- pnpm typecheck
- pnpm format
- pnpm test
- terraform -chdir=infra/coordinator fmt -check
- terraform -chdir=infra/coordinator validate