### PR TITLE
Write MAPE rollups on settle

### DIFF
--- a/coordinator/src/ledger/firestore-store.ts
+++ b/coordinator/src/ledger/firestore-store.ts
@@ -4,7 +4,7 @@ import {
   type DocumentReference,
   type Transaction,
 } from "@google-cloud/firestore";
-import { isNoBid, type TaskId, type TaskStatus } from "@agent-tasker/protocol";
+import { isNoBid, type AgentId, type TaskId, type TaskStatus } from "@agent-tasker/protocol";
 import {
   InvalidTransitionError,
   TaskAlreadyExistsError,
@@ -19,7 +19,15 @@ import type {
   LedgerStore,
   RecordBidResponseInput,
 } from "./store.js";
-import { BidRecordSchema, TaskRecordSchema, type BidRecord, type TaskRecord } from "./types.js";
+import { applyBidAccuracySample, computeBidAccuracySample } from "./mape.js";
+import {
+  AgentMapeRollupSchema,
+  BidRecordSchema,
+  TaskRecordSchema,
+  type AgentMapeRollup,
+  type BidRecord,
+  type TaskRecord,
+} from "./types.js";
 
 // Production-backed ledger store. Schema validation on read defends against
 // drift between deployed code and historical documents — any field rename
@@ -27,9 +35,11 @@ import { BidRecordSchema, TaskRecordSchema, type BidRecord, type TaskRecord } fr
 // silent undefined downstream.
 export class FirestoreLedgerStore implements LedgerStore {
   private readonly tasksCollection: CollectionReference;
+  private readonly mapeRollupsCollection: CollectionReference;
 
   constructor(private readonly firestore: Firestore) {
     this.tasksCollection = firestore.collection("tasks");
+    this.mapeRollupsCollection = firestore.collection("agent_mape_rollups");
   }
 
   async createTask(input: CreateTaskInput): Promise<TaskRecord> {
@@ -85,6 +95,12 @@ export class FirestoreLedgerStore implements LedgerStore {
   async listBids(taskId: TaskId): Promise<BidRecord[]> {
     const snap = await this.taskRef(taskId).collection("bids").orderBy("timestamp", "asc").get();
     return snap.docs.map((d) => BidRecordSchema.parse(d.data()));
+  }
+
+  async getAgentMapeRollup(agentId: AgentId): Promise<AgentMapeRollup | null> {
+    const snap = await this.mapeRollupRef(agentId).get();
+    if (!snap.exists) return null;
+    return AgentMapeRollupSchema.parse(snap.data());
   }
 
   async awardTask(input: AwardTaskInput): Promise<TaskRecord> {
@@ -145,6 +161,7 @@ export class FirestoreLedgerStore implements LedgerStore {
         updated_at: nowIso(input.now),
         result: input.result,
       };
+      await this.writeMapeRollup(tx, next);
       tx.set(ref, stripUndefined(next));
       return next;
     });
@@ -169,6 +186,39 @@ export class FirestoreLedgerStore implements LedgerStore {
 
   private taskRef(taskId: TaskId): DocumentReference {
     return this.tasksCollection.doc(taskId);
+  }
+
+  private mapeRollupRef(agentId: AgentId): DocumentReference {
+    return this.mapeRollupsCollection.doc(agentId);
+  }
+
+  private async writeMapeRollup(tx: Transaction, task: TaskRecord): Promise<void> {
+    if (!task.winner_agent_id || !task.result) return;
+
+    const bidSnap = await tx.get(
+      this.taskRef(task.task_id).collection("bids").doc(task.winner_agent_id),
+    );
+    if (!bidSnap.exists) return;
+    const bidRecord = BidRecordSchema.parse(bidSnap.data());
+    if (isNoBid(bidRecord.response)) return;
+
+    const sample = computeBidAccuracySample(bidRecord.response, task.result);
+    if (!sample) return;
+
+    const rollupRef = this.mapeRollupRef(task.winner_agent_id);
+    const previousSnap = await tx.get(rollupRef);
+    const previous = previousSnap.exists ? AgentMapeRollupSchema.parse(previousSnap.data()) : null;
+    tx.set(
+      rollupRef,
+      stripUndefined(
+        applyBidAccuracySample(previous, {
+          agentId: task.winner_agent_id,
+          taskId: task.task_id,
+          updatedAt: task.updated_at,
+          sample,
+        }),
+      ),
+    );
   }
 
   private async readTask(

--- a/coordinator/src/ledger/in-memory-store.ts
+++ b/coordinator/src/ledger/in-memory-store.ts
@@ -1,4 +1,4 @@
-import { isNoBid, type TaskId } from "@agent-tasker/protocol";
+import { isNoBid, type AgentId, type TaskId } from "@agent-tasker/protocol";
 import {
   InvalidTransitionError,
   TaskAlreadyExistsError,
@@ -13,7 +13,8 @@ import type {
   LedgerStore,
   RecordBidResponseInput,
 } from "./store.js";
-import type { BidRecord, TaskRecord } from "./types.js";
+import { applyBidAccuracySample, computeBidAccuracySample } from "./mape.js";
+import type { AgentMapeRollup, BidRecord, TaskRecord } from "./types.js";
 
 // In-memory ledger backing — single-process, single-test usage. Maps are
 // keyed by taskId for tasks and by `${taskId}:${agent_id}` for bids.
@@ -23,6 +24,7 @@ import type { BidRecord, TaskRecord } from "./types.js";
 export class InMemoryLedgerStore implements LedgerStore {
   private readonly tasks = new Map<string, TaskRecord>();
   private readonly bids = new Map<string, BidRecord>();
+  private readonly mapeRollups = new Map<AgentId, AgentMapeRollup>();
 
   async createTask(input: CreateTaskInput): Promise<TaskRecord> {
     if (this.tasks.has(input.taskId)) {
@@ -75,6 +77,11 @@ export class InMemoryLedgerStore implements LedgerStore {
     }
     out.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
     return out;
+  }
+
+  async getAgentMapeRollup(agentId: AgentId): Promise<AgentMapeRollup | null> {
+    const record = this.mapeRollups.get(agentId);
+    return record ? clone(record) : null;
   }
 
   async awardTask(input: AwardTaskInput): Promise<TaskRecord> {
@@ -139,6 +146,7 @@ export class InMemoryLedgerStore implements LedgerStore {
       result: input.result,
     };
     this.tasks.set(input.taskId, next);
+    this.writeMapeRollup(next, input.result);
     return clone(next);
   }
 
@@ -161,6 +169,26 @@ export class InMemoryLedgerStore implements LedgerStore {
     };
     this.tasks.set(input.taskId, next);
     return clone(next);
+  }
+
+  private writeMapeRollup(task: TaskRecord, result: TaskRecord["result"]): void {
+    if (!task.winner_agent_id || !result) return;
+    const bidRecord = this.bids.get(bidKey(task.task_id, task.winner_agent_id));
+    if (!bidRecord || isNoBid(bidRecord.response)) return;
+
+    const sample = computeBidAccuracySample(bidRecord.response, result);
+    if (!sample) return;
+
+    const previous = this.mapeRollups.get(task.winner_agent_id) ?? null;
+    this.mapeRollups.set(
+      task.winner_agent_id,
+      applyBidAccuracySample(previous, {
+        agentId: task.winner_agent_id,
+        taskId: task.task_id,
+        updatedAt: task.updated_at,
+        sample,
+      }),
+    );
   }
 
   private requireTask(taskId: TaskId): TaskRecord {

--- a/coordinator/src/ledger/mape.ts
+++ b/coordinator/src/ledger/mape.ts
@@ -1,0 +1,59 @@
+import type { Bid, Result } from "@agent-tasker/protocol";
+import type { AgentMapeRollup } from "./types.js";
+
+export interface BidAccuracySample {
+  bidUsd: number;
+  actualUsd: number;
+  absolutePercentageError: number;
+  signedPercentageError: number;
+}
+
+export function computeBidAccuracySample(bid: Bid, result: Result): BidAccuracySample | null {
+  if (bid.bid_usd <= 0) return null;
+  const actualUsd = computeActualUsd(bid, result);
+  const signedPercentageError = (actualUsd - bid.bid_usd) / bid.bid_usd;
+  return {
+    bidUsd: bid.bid_usd,
+    actualUsd,
+    absolutePercentageError: Math.abs(signedPercentageError),
+    signedPercentageError,
+  };
+}
+
+export function applyBidAccuracySample(
+  previous: AgentMapeRollup | null,
+  args: {
+    agentId: Bid["agent_id"];
+    taskId: Bid["task_id"];
+    updatedAt: string;
+    sample: BidAccuracySample;
+  },
+): AgentMapeRollup {
+  const settledTaskCount = (previous?.settled_task_count ?? 0) + 1;
+  const absolutePercentageErrorSum =
+    (previous?.absolute_percentage_error_sum ?? 0) + args.sample.absolutePercentageError;
+  const signedPercentageErrorSum =
+    (previous?.signed_percentage_error_sum ?? 0) + args.sample.signedPercentageError;
+
+  return {
+    agent_id: args.agentId,
+    updated_at: args.updatedAt,
+    settled_task_count: settledTaskCount,
+    absolute_percentage_error_sum: absolutePercentageErrorSum,
+    signed_percentage_error_sum: signedPercentageErrorSum,
+    mape: absolutePercentageErrorSum / settledTaskCount,
+    mean_signed_percentage_error: signedPercentageErrorSum / settledTaskCount,
+    last_task_id: args.taskId,
+    last_bid_usd: args.sample.bidUsd,
+    last_actual_usd: args.sample.actualUsd,
+    last_absolute_percentage_error: args.sample.absolutePercentageError,
+    last_signed_percentage_error: args.sample.signedPercentageError,
+  };
+}
+
+function computeActualUsd(bid: Bid, result: Result): number {
+  return (
+    (result.actual_usage.input_tokens / 1_000_000) * bid.price_in_usd_per_mtoken +
+    (result.actual_usage.output_tokens / 1_000_000) * bid.price_out_usd_per_mtoken
+  );
+}

--- a/coordinator/src/ledger/store.ts
+++ b/coordinator/src/ledger/store.ts
@@ -7,7 +7,7 @@ import type {
   TaskId,
   TaskSpec,
 } from "@agent-tasker/protocol";
-import type { BidRecord, TaskRecord } from "./types.js";
+import type { AgentMapeRollup, BidRecord, TaskRecord } from "./types.js";
 
 // Persistence layer for the auction. All transition methods are idempotent at
 // the document-key level — retrying the same call with the same input
@@ -38,6 +38,8 @@ export interface LedgerStore {
 
   listBids(taskId: TaskId): Promise<BidRecord[]>;
 
+  getAgentMapeRollup(agentId: AgentId): Promise<AgentMapeRollup | null>;
+
   // Transitions bidding → awarded. Re-auction may also transition
   // executing → awarded with a different winner after excluding a failed
   // executor. Idempotent only if the *same* winner + pricing is reasserted.
@@ -47,7 +49,8 @@ export interface LedgerStore {
   markExecuting(taskId: TaskId, now?: Date): Promise<TaskRecord>;
 
   // Transitions executing → completed. Idempotent if the same result is
-  // reasserted.
+  // reasserted. On first completion, writes the winning agent's MAPE rollup
+  // when the winning bid record is available and MAPE-eligible.
   completeTask(input: CompleteTaskInput): Promise<TaskRecord>;
 
   // Move into the terminal `failed` state from any non-terminal state.

--- a/coordinator/src/ledger/types.ts
+++ b/coordinator/src/ledger/types.ts
@@ -59,3 +59,22 @@ export const BidRecordSchema = z.object({
   pricing_snapshot: z.array(PricingEntrySchema),
 });
 export type BidRecord = z.infer<typeof BidRecordSchema>;
+
+// Per-agent rolling bid accuracy at agent_mape_rollups/{agent_id}. Updated
+// when a winning task settles so tie-breaking and later score-weighted
+// auction layers can read one small document instead of scanning history.
+export const AgentMapeRollupSchema = z.object({
+  agent_id: AgentIdSchema,
+  updated_at: Iso8601,
+  settled_task_count: z.number().int().nonnegative(),
+  absolute_percentage_error_sum: z.number().nonnegative(),
+  signed_percentage_error_sum: z.number(),
+  mape: z.number().nonnegative(),
+  mean_signed_percentage_error: z.number(),
+  last_task_id: TaskIdSchema,
+  last_bid_usd: z.number().nonnegative(),
+  last_actual_usd: z.number().nonnegative(),
+  last_absolute_percentage_error: z.number().nonnegative(),
+  last_signed_percentage_error: z.number(),
+});
+export type AgentMapeRollup = z.infer<typeof AgentMapeRollupSchema>;

--- a/coordinator/test/ledger/in-memory-store.test.ts
+++ b/coordinator/test/ledger/in-memory-store.test.ts
@@ -22,9 +22,9 @@ const PRICING: PricingEntry[] = [
   },
 ];
 
-function makeBid(agentId: AgentId, bidUsd: number): Bid {
+function makeBid(agentId: AgentId, bidUsd: number, taskId = TASK_ID): Bid {
   return {
-    task_id: TASK_ID,
+    task_id: taskId,
     agent_id: agentId,
     tier: "frontier",
     model_family: "gemini",
@@ -39,18 +39,18 @@ function makeBid(agentId: AgentId, bidUsd: number): Bid {
   };
 }
 
-function makeNoBid(agentId: AgentId): NoBid {
+function makeNoBid(agentId: AgentId, taskId = TASK_ID): NoBid {
   return {
-    task_id: TASK_ID,
+    task_id: taskId,
     agent_id: agentId,
     status: "no_bid",
     reason: "capability",
   };
 }
 
-function makeResult(agentId: AgentId): Result {
+function makeResult(agentId: AgentId, taskId = TASK_ID): Result {
   return {
-    task_id: TASK_ID,
+    task_id: taskId,
     agent_id: agentId,
     output: "summary text",
     actual_usage: { input_tokens: 4100, output_tokens: 950 },
@@ -266,6 +266,11 @@ describe("awardTask", () => {
 describe("markExecuting / completeTask / failTask", () => {
   beforeEach(async () => {
     await store.createTask({ taskId: TASK_ID, spec: SPEC });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.02),
+      pricingSnapshot: PRICING,
+    });
     await store.awardTask({
       taskId: TASK_ID,
       winnerAgentId: "gcp-gemini",
@@ -291,6 +296,61 @@ describe("markExecuting / completeTask / failTask", () => {
     const record = await store.completeTask({ taskId: TASK_ID, result });
     expect(record.status).toBe("completed");
     expect(record.result).toEqual(result);
+  });
+
+  it("completeTask updates the winner's rolling MAPE rollup", async () => {
+    await store.markExecuting(TASK_ID);
+
+    const completedAt = new Date("2026-05-20T12:00:00Z");
+    await store.completeTask({
+      taskId: TASK_ID,
+      result: makeResult("gcp-gemini"),
+      now: completedAt,
+    });
+
+    const rollup = await store.getAgentMapeRollup("gcp-gemini");
+    expect(rollup).toMatchObject({
+      agent_id: "gcp-gemini",
+      updated_at: completedAt.toISOString(),
+      settled_task_count: 1,
+      last_task_id: TASK_ID,
+      last_bid_usd: 0.02,
+    });
+    expect(rollup?.last_actual_usd).toBeCloseTo(0.014625);
+    expect(rollup?.last_signed_percentage_error).toBeCloseTo(-0.26875);
+    expect(rollup?.last_absolute_percentage_error).toBeCloseTo(0.26875);
+    expect(rollup?.mape).toBeCloseTo(0.26875);
+    expect(rollup?.mean_signed_percentage_error).toBeCloseTo(-0.26875);
+  });
+
+  it("completeTask rolls MAPE forward across multiple settled tasks", async () => {
+    await store.markExecuting(TASK_ID);
+    await store.completeTask({ taskId: TASK_ID, result: makeResult("gcp-gemini") });
+
+    const secondTaskId = "task-test-2";
+    await store.createTask({ taskId: secondTaskId, spec: SPEC });
+    await store.recordBidResponse({
+      taskId: secondTaskId,
+      response: makeBid("gcp-gemini", 0.01, secondTaskId),
+      pricingSnapshot: PRICING,
+    });
+    await store.awardTask({
+      taskId: secondTaskId,
+      winnerAgentId: "gcp-gemini",
+      auctionPriceUsd: 0.02,
+      winningBidUsd: 0.01,
+    });
+    await store.markExecuting(secondTaskId);
+    await store.completeTask({
+      taskId: secondTaskId,
+      result: makeResult("gcp-gemini", secondTaskId),
+    });
+
+    const rollup = await store.getAgentMapeRollup("gcp-gemini");
+    expect(rollup?.settled_task_count).toBe(2);
+    expect(rollup?.mape).toBeCloseTo((0.26875 + 0.4625) / 2);
+    expect(rollup?.mean_signed_percentage_error).toBeCloseTo((-0.26875 + 0.4625) / 2);
+    expect(rollup?.last_task_id).toBe(secondTaskId);
   });
 
   it("completeTask rejects directly from awarded (must mark executing first)", async () => {


### PR DESCRIPTION
## Summary
- add per-agent MAPE rollup records updated when a winning task completes
- compute actual USD from the winner's bid prices and execution usage
- persist rolling MAPE and signed error in both in-memory and Firestore ledgers
- add tests for first-settlement and rolling MAPE updates

Closes #66

## Tests
- pnpm --filter @agent-tasker/coordinator test
- pnpm lint
- pnpm typecheck
- pnpm format
- pnpm test