### PR TITLE
Track decline rates by reason

### DIFF
--- a/coordinator/src/ledger/declines.ts
+++ b/coordinator/src/ledger/declines.ts
@@ -1,0 +1,74 @@
+import { isNoBid, type BidResponse, type NoBidReason } from "@agent-tasker/protocol";
+import type { AgentDeclineRollup } from "./types.js";
+
+const REASONS = ["context_overflow", "policy", "capability", "internal_error"] as const;
+
+type ReasonCounts = AgentDeclineRollup["decline_reasons"];
+
+export function applyDeclineRollupUpdate(
+  previousRollup: AgentDeclineRollup | null,
+  args: {
+    previousResponse: BidResponse | undefined;
+    nextResponse: BidResponse;
+    updatedAt: string;
+  },
+): AgentDeclineRollup {
+  const counts = previousRollup?.decline_reasons
+    ? { ...previousRollup.decline_reasons }
+    : emptyReasonCounts();
+  let bidResponseCount = previousRollup?.bid_response_count ?? 0;
+  let bidCount = previousRollup?.bid_count ?? 0;
+  let declineCount = previousRollup?.decline_count ?? 0;
+
+  if (args.previousResponse) {
+    const previousImpact = responseImpact(args.previousResponse);
+    bidResponseCount -= previousImpact.bidResponseCount;
+    bidCount -= previousImpact.bidCount;
+    declineCount -= previousImpact.declineCount;
+    if (previousImpact.reason) counts[previousImpact.reason] -= 1;
+  }
+
+  const nextImpact = responseImpact(args.nextResponse);
+  bidResponseCount += nextImpact.bidResponseCount;
+  bidCount += nextImpact.bidCount;
+  declineCount += nextImpact.declineCount;
+  if (nextImpact.reason) counts[nextImpact.reason] += 1;
+
+  return {
+    agent_id: args.nextResponse.agent_id,
+    updated_at: args.updatedAt,
+    bid_response_count: bidResponseCount,
+    bid_count: bidCount,
+    decline_count: declineCount,
+    decline_rate: bidResponseCount === 0 ? 0 : declineCount / bidResponseCount,
+    decline_reasons: counts,
+    last_task_id: args.nextResponse.task_id,
+    last_response_kind: isNoBid(args.nextResponse) ? "no_bid" : "bid",
+    last_no_bid_reason: isNoBid(args.nextResponse) ? args.nextResponse.reason : undefined,
+  };
+}
+
+function responseImpact(response: BidResponse): {
+  bidResponseCount: number;
+  bidCount: number;
+  declineCount: number;
+  reason?: NoBidReason;
+} {
+  if (isNoBid(response)) {
+    return {
+      bidResponseCount: 1,
+      bidCount: 0,
+      declineCount: 1,
+      reason: response.reason,
+    };
+  }
+  return {
+    bidResponseCount: 1,
+    bidCount: 1,
+    declineCount: 0,
+  };
+}
+
+function emptyReasonCounts(): ReasonCounts {
+  return Object.fromEntries(REASONS.map((reason) => [reason, 0])) as ReasonCounts;
+}

--- a/coordinator/src/ledger/firestore-store.ts
+++ b/coordinator/src/ledger/firestore-store.ts
@@ -19,11 +19,14 @@ import type {
   LedgerStore,
   RecordBidResponseInput,
 } from "./store.js";
+import { applyDeclineRollupUpdate } from "./declines.js";
 import { applyBidAccuracySample, computeBidAccuracySample } from "./mape.js";
 import {
+  AgentDeclineRollupSchema,
   AgentMapeRollupSchema,
   BidRecordSchema,
   TaskRecordSchema,
+  type AgentDeclineRollup,
   type AgentMapeRollup,
   type BidRecord,
   type TaskRecord,
@@ -36,10 +39,12 @@ import {
 export class FirestoreLedgerStore implements LedgerStore {
   private readonly tasksCollection: CollectionReference;
   private readonly mapeRollupsCollection: CollectionReference;
+  private readonly declineRollupsCollection: CollectionReference;
 
   constructor(private readonly firestore: Firestore) {
     this.tasksCollection = firestore.collection("tasks");
     this.mapeRollupsCollection = firestore.collection("agent_mape_rollups");
+    this.declineRollupsCollection = firestore.collection("agent_decline_rollups");
   }
 
   async createTask(input: CreateTaskInput): Promise<TaskRecord> {
@@ -87,6 +92,11 @@ export class FirestoreLedgerStore implements LedgerStore {
         response: input.response,
         pricing_snapshot: input.pricingSnapshot,
       };
+      const previousBidSnap = await tx.get(bidRef);
+      const previousBid = previousBidSnap.exists
+        ? BidRecordSchema.parse(previousBidSnap.data())
+        : undefined;
+      await this.writeDeclineRollup(tx, previousBid, record);
       tx.set(bidRef, stripUndefined(record));
       return record;
     });
@@ -101,6 +111,12 @@ export class FirestoreLedgerStore implements LedgerStore {
     const snap = await this.mapeRollupRef(agentId).get();
     if (!snap.exists) return null;
     return AgentMapeRollupSchema.parse(snap.data());
+  }
+
+  async getAgentDeclineRollup(agentId: AgentId): Promise<AgentDeclineRollup | null> {
+    const snap = await this.declineRollupRef(agentId).get();
+    if (!snap.exists) return null;
+    return AgentDeclineRollupSchema.parse(snap.data());
   }
 
   async awardTask(input: AwardTaskInput): Promise<TaskRecord> {
@@ -190,6 +206,32 @@ export class FirestoreLedgerStore implements LedgerStore {
 
   private mapeRollupRef(agentId: AgentId): DocumentReference {
     return this.mapeRollupsCollection.doc(agentId);
+  }
+
+  private declineRollupRef(agentId: AgentId): DocumentReference {
+    return this.declineRollupsCollection.doc(agentId);
+  }
+
+  private async writeDeclineRollup(
+    tx: Transaction,
+    previousBid: BidRecord | undefined,
+    nextBid: BidRecord,
+  ): Promise<void> {
+    const rollupRef = this.declineRollupRef(nextBid.agent_id);
+    const previousRollupSnap = await tx.get(rollupRef);
+    const previousRollup = previousRollupSnap.exists
+      ? AgentDeclineRollupSchema.parse(previousRollupSnap.data())
+      : null;
+    tx.set(
+      rollupRef,
+      stripUndefined(
+        applyDeclineRollupUpdate(previousRollup, {
+          previousResponse: previousBid?.response,
+          nextResponse: nextBid.response,
+          updatedAt: nextBid.timestamp,
+        }),
+      ),
+    );
   }
 
   private async writeMapeRollup(tx: Transaction, task: TaskRecord): Promise<void> {

--- a/coordinator/src/ledger/in-memory-store.ts
+++ b/coordinator/src/ledger/in-memory-store.ts
@@ -13,8 +13,9 @@ import type {
   LedgerStore,
   RecordBidResponseInput,
 } from "./store.js";
+import { applyDeclineRollupUpdate } from "./declines.js";
 import { applyBidAccuracySample, computeBidAccuracySample } from "./mape.js";
-import type { AgentMapeRollup, BidRecord, TaskRecord } from "./types.js";
+import type { AgentDeclineRollup, AgentMapeRollup, BidRecord, TaskRecord } from "./types.js";
 
 // In-memory ledger backing — single-process, single-test usage. Maps are
 // keyed by taskId for tasks and by `${taskId}:${agent_id}` for bids.
@@ -25,6 +26,7 @@ export class InMemoryLedgerStore implements LedgerStore {
   private readonly tasks = new Map<string, TaskRecord>();
   private readonly bids = new Map<string, BidRecord>();
   private readonly mapeRollups = new Map<AgentId, AgentMapeRollup>();
+  private readonly declineRollups = new Map<AgentId, AgentDeclineRollup>();
 
   async createTask(input: CreateTaskInput): Promise<TaskRecord> {
     if (this.tasks.has(input.taskId)) {
@@ -65,7 +67,9 @@ export class InMemoryLedgerStore implements LedgerStore {
       response: input.response,
       pricing_snapshot: input.pricingSnapshot,
     };
+    const previous = this.bids.get(bidKey(input.taskId, input.response.agent_id));
     this.bids.set(bidKey(input.taskId, input.response.agent_id), record);
+    this.writeDeclineRollup(previous, record);
     return clone(record);
   }
 
@@ -81,6 +85,11 @@ export class InMemoryLedgerStore implements LedgerStore {
 
   async getAgentMapeRollup(agentId: AgentId): Promise<AgentMapeRollup | null> {
     const record = this.mapeRollups.get(agentId);
+    return record ? clone(record) : null;
+  }
+
+  async getAgentDeclineRollup(agentId: AgentId): Promise<AgentDeclineRollup | null> {
+    const record = this.declineRollups.get(agentId);
     return record ? clone(record) : null;
   }
 
@@ -187,6 +196,18 @@ export class InMemoryLedgerStore implements LedgerStore {
         taskId: task.task_id,
         updatedAt: task.updated_at,
         sample,
+      }),
+    );
+  }
+
+  private writeDeclineRollup(previous: BidRecord | undefined, next: BidRecord): void {
+    const previousRollup = this.declineRollups.get(next.agent_id) ?? null;
+    this.declineRollups.set(
+      next.agent_id,
+      applyDeclineRollupUpdate(previousRollup, {
+        previousResponse: previous?.response,
+        nextResponse: next.response,
+        updatedAt: next.timestamp,
       }),
     );
   }

--- a/coordinator/src/ledger/store.ts
+++ b/coordinator/src/ledger/store.ts
@@ -7,7 +7,7 @@ import type {
   TaskId,
   TaskSpec,
 } from "@agent-tasker/protocol";
-import type { AgentMapeRollup, BidRecord, TaskRecord } from "./types.js";
+import type { AgentDeclineRollup, AgentMapeRollup, BidRecord, TaskRecord } from "./types.js";
 
 // Persistence layer for the auction. All transition methods are idempotent at
 // the document-key level — retrying the same call with the same input
@@ -39,6 +39,8 @@ export interface LedgerStore {
   listBids(taskId: TaskId): Promise<BidRecord[]>;
 
   getAgentMapeRollup(agentId: AgentId): Promise<AgentMapeRollup | null>;
+
+  getAgentDeclineRollup(agentId: AgentId): Promise<AgentDeclineRollup | null>;
 
   // Transitions bidding → awarded. Re-auction may also transition
   // executing → awarded with a different winner after excluding a failed

--- a/coordinator/src/ledger/types.ts
+++ b/coordinator/src/ledger/types.ts
@@ -78,3 +78,28 @@ export const AgentMapeRollupSchema = z.object({
   last_signed_percentage_error: z.number(),
 });
 export type AgentMapeRollup = z.infer<typeof AgentMapeRollupSchema>;
+
+const DeclineReasonCountsSchema = z.object({
+  context_overflow: z.number().int().nonnegative(),
+  policy: z.number().int().nonnegative(),
+  capability: z.number().int().nonnegative(),
+  internal_error: z.number().int().nonnegative(),
+});
+
+// Per-agent decline health at agent_decline_rollups/{agent_id}. Updated on
+// every bid response, including idempotent overwrites, so the denominator is
+// all observed bid responses and the numerator is no_bid responses split by
+// protocol reason.
+export const AgentDeclineRollupSchema = z.object({
+  agent_id: AgentIdSchema,
+  updated_at: Iso8601,
+  bid_response_count: z.number().int().nonnegative(),
+  bid_count: z.number().int().nonnegative(),
+  decline_count: z.number().int().nonnegative(),
+  decline_rate: z.number().min(0).max(1),
+  decline_reasons: DeclineReasonCountsSchema,
+  last_task_id: TaskIdSchema,
+  last_response_kind: z.enum(["bid", "no_bid"]),
+  last_no_bid_reason: NoBidReasonSchema.optional(),
+});
+export type AgentDeclineRollup = z.infer<typeof AgentDeclineRollupSchema>;

--- a/coordinator/test/ledger/in-memory-store.test.ts
+++ b/coordinator/test/ledger/in-memory-store.test.ts
@@ -146,6 +146,51 @@ describe("recordBidResponse", () => {
     });
   });
 
+  it("tracks per-agent decline counts and rates by reason", async () => {
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeNoBid("aws-nova"),
+      pricingSnapshot: PRICING,
+    });
+
+    const rollup = await store.getAgentDeclineRollup("aws-nova");
+    expect(rollup).toMatchObject({
+      agent_id: "aws-nova",
+      bid_response_count: 1,
+      bid_count: 0,
+      decline_count: 1,
+      decline_rate: 1,
+      decline_reasons: {
+        context_overflow: 0,
+        policy: 0,
+        capability: 1,
+        internal_error: 0,
+      },
+      last_task_id: TASK_ID,
+      last_response_kind: "no_bid",
+      last_no_bid_reason: "capability",
+    });
+  });
+
+  it("tracks accepted bids in the decline-rate denominator", async () => {
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.02),
+      pricingSnapshot: PRICING,
+    });
+
+    const rollup = await store.getAgentDeclineRollup("gcp-gemini");
+    expect(rollup).toMatchObject({
+      agent_id: "gcp-gemini",
+      bid_response_count: 1,
+      bid_count: 1,
+      decline_count: 0,
+      decline_rate: 0,
+      last_response_kind: "bid",
+    });
+    expect(rollup?.last_no_bid_reason).toBeUndefined();
+  });
+
   it("is idempotent on (task_id, agent_id) — final write wins", async () => {
     await store.recordBidResponse({
       taskId: TASK_ID,
@@ -160,6 +205,34 @@ describe("recordBidResponse", () => {
     const bids = await store.listBids(TASK_ID);
     expect(bids).toHaveLength(1);
     expect(bids[0]?.response).toMatchObject({ bid_usd: 0.02 });
+  });
+
+  it("adjusts decline rollups when a bid response is overwritten", async () => {
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeNoBid("aws-nova"),
+      pricingSnapshot: PRICING,
+    });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("aws-nova", 0.02),
+      pricingSnapshot: PRICING,
+    });
+
+    const rollup = await store.getAgentDeclineRollup("aws-nova");
+    expect(rollup).toMatchObject({
+      bid_response_count: 1,
+      bid_count: 1,
+      decline_count: 0,
+      decline_rate: 0,
+      decline_reasons: {
+        context_overflow: 0,
+        policy: 0,
+        capability: 0,
+        internal_error: 0,
+      },
+      last_response_kind: "bid",
+    });
   });
 
   it("rejects writes after the bidding window has closed", async () => {


### PR DESCRIPTION
## Summary
- add per-agent decline rollups with counts by no_bid reason
- include bid responses in the denominator so decline_rate reflects bids vs declines
- adjust rollups correctly when a task/agent bid response is overwritten
- persist/read decline rollups in both in-memory and Firestore ledgers

Closes #67

## Tests
- pnpm --filter @agent-tasker/coordinator test -- test/ledger/in-memory-store.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm lint
- pnpm typecheck
- pnpm format
- pnpm test