### PR TITLE
Track win rates by tier

### DIFF
--- a/coordinator/src/ledger/firestore-store.ts
+++ b/coordinator/src/ledger/firestore-store.ts
@@ -24,13 +24,20 @@ import { applyBidAccuracySample, computeBidAccuracySample } from "./mape.js";
 import {
   AgentDeclineRollupSchema,
   AgentMapeRollupSchema,
+  AgentWinRateRollupSchema,
   BidRecordSchema,
   TaskRecordSchema,
   type AgentDeclineRollup,
   type AgentMapeRollup,
+  type AgentWinRateRollup,
   type BidRecord,
   type TaskRecord,
 } from "./types.js";
+import {
+  applyWinRateBidRemoval,
+  applyWinRateBidUpdate,
+  applyWinRateWinUpdate,
+} from "./win-rates.js";
 
 // Production-backed ledger store. Schema validation on read defends against
 // drift between deployed code and historical documents — any field rename
@@ -40,11 +47,13 @@ export class FirestoreLedgerStore implements LedgerStore {
   private readonly tasksCollection: CollectionReference;
   private readonly mapeRollupsCollection: CollectionReference;
   private readonly declineRollupsCollection: CollectionReference;
+  private readonly winRateRollupsCollection: CollectionReference;
 
   constructor(private readonly firestore: Firestore) {
     this.tasksCollection = firestore.collection("tasks");
     this.mapeRollupsCollection = firestore.collection("agent_mape_rollups");
     this.declineRollupsCollection = firestore.collection("agent_decline_rollups");
+    this.winRateRollupsCollection = firestore.collection("agent_win_rate_rollups");
   }
 
   async createTask(input: CreateTaskInput): Promise<TaskRecord> {
@@ -96,7 +105,7 @@ export class FirestoreLedgerStore implements LedgerStore {
       const previousBid = previousBidSnap.exists
         ? BidRecordSchema.parse(previousBidSnap.data())
         : undefined;
-      await this.writeDeclineRollup(tx, previousBid, record);
+      await this.writeBidResponseRollups(tx, previousBid, record);
       tx.set(bidRef, stripUndefined(record));
       return record;
     });
@@ -117,6 +126,12 @@ export class FirestoreLedgerStore implements LedgerStore {
     const snap = await this.declineRollupRef(agentId).get();
     if (!snap.exists) return null;
     return AgentDeclineRollupSchema.parse(snap.data());
+  }
+
+  async getAgentWinRateRollup(agentId: AgentId): Promise<AgentWinRateRollup | null> {
+    const snap = await this.winRateRollupRef(agentId).get();
+    if (!snap.exists) return null;
+    return AgentWinRateRollupSchema.parse(snap.data());
   }
 
   async awardTask(input: AwardTaskInput): Promise<TaskRecord> {
@@ -177,7 +192,7 @@ export class FirestoreLedgerStore implements LedgerStore {
         updated_at: nowIso(input.now),
         result: input.result,
       };
-      await this.writeMapeRollup(tx, next);
+      await this.writeSettlementRollups(tx, next);
       tx.set(ref, stripUndefined(next));
       return next;
     });
@@ -212,29 +227,67 @@ export class FirestoreLedgerStore implements LedgerStore {
     return this.declineRollupsCollection.doc(agentId);
   }
 
-  private async writeDeclineRollup(
+  private winRateRollupRef(agentId: AgentId): DocumentReference {
+    return this.winRateRollupsCollection.doc(agentId);
+  }
+
+  private async writeBidResponseRollups(
     tx: Transaction,
     previousBid: BidRecord | undefined,
     nextBid: BidRecord,
   ): Promise<void> {
-    const rollupRef = this.declineRollupRef(nextBid.agent_id);
-    const previousRollupSnap = await tx.get(rollupRef);
-    const previousRollup = previousRollupSnap.exists
-      ? AgentDeclineRollupSchema.parse(previousRollupSnap.data())
+    const declineRollupRef = this.declineRollupRef(nextBid.agent_id);
+    const winRateRollupRef = this.winRateRollupRef(nextBid.agent_id);
+    const previousDeclineRollupSnap = await tx.get(declineRollupRef);
+    const previousBidForWinRate =
+      previousBid && !isNoBid(previousBid.response) ? previousBid.response : undefined;
+    const shouldUpdateWinRate = previousBidForWinRate !== undefined || !isNoBid(nextBid.response);
+    const previousWinRateRollupSnap = shouldUpdateWinRate ? await tx.get(winRateRollupRef) : null;
+
+    const previousDeclineRollup = previousDeclineRollupSnap.exists
+      ? AgentDeclineRollupSchema.parse(previousDeclineRollupSnap.data())
       : null;
     tx.set(
-      rollupRef,
+      declineRollupRef,
       stripUndefined(
-        applyDeclineRollupUpdate(previousRollup, {
+        applyDeclineRollupUpdate(previousDeclineRollup, {
           previousResponse: previousBid?.response,
           nextResponse: nextBid.response,
           updatedAt: nextBid.timestamp,
         }),
       ),
     );
+
+    const previousWinRateRollup = previousWinRateRollupSnap?.exists
+      ? AgentWinRateRollupSchema.parse(previousWinRateRollupSnap.data())
+      : null;
+    if (isNoBid(nextBid.response)) {
+      if (!previousBidForWinRate) return;
+      tx.set(
+        winRateRollupRef,
+        stripUndefined(
+          applyWinRateBidRemoval(previousWinRateRollup, {
+            previousBid: previousBidForWinRate,
+            updatedAt: nextBid.timestamp,
+          }),
+        ),
+      );
+      return;
+    }
+
+    tx.set(
+      winRateRollupRef,
+      stripUndefined(
+        applyWinRateBidUpdate(previousWinRateRollup, {
+          previousBid: previousBidForWinRate,
+          nextBid: nextBid.response,
+          updatedAt: nextBid.timestamp,
+        }),
+      ),
+    );
   }
 
-  private async writeMapeRollup(tx: Transaction, task: TaskRecord): Promise<void> {
+  private async writeSettlementRollups(tx: Transaction, task: TaskRecord): Promise<void> {
     if (!task.winner_agent_id || !task.result) return;
 
     const bidSnap = await tx.get(
@@ -244,20 +297,38 @@ export class FirestoreLedgerStore implements LedgerStore {
     const bidRecord = BidRecordSchema.parse(bidSnap.data());
     if (isNoBid(bidRecord.response)) return;
 
-    const sample = computeBidAccuracySample(bidRecord.response, task.result);
-    if (!sample) return;
+    const mapeRollupRef = this.mapeRollupRef(task.winner_agent_id);
+    const winRateRollupRef = this.winRateRollupRef(task.winner_agent_id);
+    const previousMapeRollupSnap = await tx.get(mapeRollupRef);
+    const previousWinRateRollupSnap = await tx.get(winRateRollupRef);
 
-    const rollupRef = this.mapeRollupRef(task.winner_agent_id);
-    const previousSnap = await tx.get(rollupRef);
-    const previous = previousSnap.exists ? AgentMapeRollupSchema.parse(previousSnap.data()) : null;
+    const sample = computeBidAccuracySample(bidRecord.response, task.result);
+    if (sample) {
+      const previousMapeRollup = previousMapeRollupSnap.exists
+        ? AgentMapeRollupSchema.parse(previousMapeRollupSnap.data())
+        : null;
+      tx.set(
+        mapeRollupRef,
+        stripUndefined(
+          applyBidAccuracySample(previousMapeRollup, {
+            agentId: task.winner_agent_id,
+            taskId: task.task_id,
+            updatedAt: task.updated_at,
+            sample,
+          }),
+        ),
+      );
+    }
+
+    const previousWinRateRollup = previousWinRateRollupSnap.exists
+      ? AgentWinRateRollupSchema.parse(previousWinRateRollupSnap.data())
+      : null;
     tx.set(
-      rollupRef,
+      winRateRollupRef,
       stripUndefined(
-        applyBidAccuracySample(previous, {
-          agentId: task.winner_agent_id,
-          taskId: task.task_id,
+        applyWinRateWinUpdate(previousWinRateRollup, {
+          winningBid: bidRecord.response,
           updatedAt: task.updated_at,
-          sample,
         }),
       ),
     );

--- a/coordinator/src/ledger/in-memory-store.ts
+++ b/coordinator/src/ledger/in-memory-store.ts
@@ -15,7 +15,18 @@ import type {
 } from "./store.js";
 import { applyDeclineRollupUpdate } from "./declines.js";
 import { applyBidAccuracySample, computeBidAccuracySample } from "./mape.js";
-import type { AgentDeclineRollup, AgentMapeRollup, BidRecord, TaskRecord } from "./types.js";
+import type {
+  AgentDeclineRollup,
+  AgentMapeRollup,
+  AgentWinRateRollup,
+  BidRecord,
+  TaskRecord,
+} from "./types.js";
+import {
+  applyWinRateBidRemoval,
+  applyWinRateBidUpdate,
+  applyWinRateWinUpdate,
+} from "./win-rates.js";
 
 // In-memory ledger backing — single-process, single-test usage. Maps are
 // keyed by taskId for tasks and by `${taskId}:${agent_id}` for bids.
@@ -27,6 +38,7 @@ export class InMemoryLedgerStore implements LedgerStore {
   private readonly bids = new Map<string, BidRecord>();
   private readonly mapeRollups = new Map<AgentId, AgentMapeRollup>();
   private readonly declineRollups = new Map<AgentId, AgentDeclineRollup>();
+  private readonly winRateRollups = new Map<AgentId, AgentWinRateRollup>();
 
   async createTask(input: CreateTaskInput): Promise<TaskRecord> {
     if (this.tasks.has(input.taskId)) {
@@ -70,6 +82,7 @@ export class InMemoryLedgerStore implements LedgerStore {
     const previous = this.bids.get(bidKey(input.taskId, input.response.agent_id));
     this.bids.set(bidKey(input.taskId, input.response.agent_id), record);
     this.writeDeclineRollup(previous, record);
+    this.writeWinRateBidRollup(previous, record);
     return clone(record);
   }
 
@@ -90,6 +103,11 @@ export class InMemoryLedgerStore implements LedgerStore {
 
   async getAgentDeclineRollup(agentId: AgentId): Promise<AgentDeclineRollup | null> {
     const record = this.declineRollups.get(agentId);
+    return record ? clone(record) : null;
+  }
+
+  async getAgentWinRateRollup(agentId: AgentId): Promise<AgentWinRateRollup | null> {
+    const record = this.winRateRollups.get(agentId);
     return record ? clone(record) : null;
   }
 
@@ -156,6 +174,7 @@ export class InMemoryLedgerStore implements LedgerStore {
     };
     this.tasks.set(input.taskId, next);
     this.writeMapeRollup(next, input.result);
+    this.writeWinRateWinRollup(next);
     return clone(next);
   }
 
@@ -208,6 +227,47 @@ export class InMemoryLedgerStore implements LedgerStore {
         previousResponse: previous?.response,
         nextResponse: next.response,
         updatedAt: next.timestamp,
+      }),
+    );
+  }
+
+  private writeWinRateBidRollup(previous: BidRecord | undefined, next: BidRecord): void {
+    const previousBid = previous && !isNoBid(previous.response) ? previous.response : undefined;
+    if (isNoBid(next.response)) {
+      if (!previousBid) return;
+      const previousRollup = this.winRateRollups.get(next.agent_id) ?? null;
+      this.winRateRollups.set(
+        next.agent_id,
+        applyWinRateBidRemoval(previousRollup, {
+          previousBid,
+          updatedAt: next.timestamp,
+        }),
+      );
+      return;
+    }
+
+    const previousRollup = this.winRateRollups.get(next.agent_id) ?? null;
+    this.winRateRollups.set(
+      next.agent_id,
+      applyWinRateBidUpdate(previousRollup, {
+        previousBid,
+        nextBid: next.response,
+        updatedAt: next.timestamp,
+      }),
+    );
+  }
+
+  private writeWinRateWinRollup(task: TaskRecord): void {
+    if (!task.winner_agent_id) return;
+    const bidRecord = this.bids.get(bidKey(task.task_id, task.winner_agent_id));
+    if (!bidRecord || isNoBid(bidRecord.response)) return;
+
+    const previousRollup = this.winRateRollups.get(task.winner_agent_id) ?? null;
+    this.winRateRollups.set(
+      task.winner_agent_id,
+      applyWinRateWinUpdate(previousRollup, {
+        winningBid: bidRecord.response,
+        updatedAt: task.updated_at,
       }),
     );
   }

--- a/coordinator/src/ledger/store.ts
+++ b/coordinator/src/ledger/store.ts
@@ -7,7 +7,13 @@ import type {
   TaskId,
   TaskSpec,
 } from "@agent-tasker/protocol";
-import type { AgentDeclineRollup, AgentMapeRollup, BidRecord, TaskRecord } from "./types.js";
+import type {
+  AgentDeclineRollup,
+  AgentMapeRollup,
+  AgentWinRateRollup,
+  BidRecord,
+  TaskRecord,
+} from "./types.js";
 
 // Persistence layer for the auction. All transition methods are idempotent at
 // the document-key level — retrying the same call with the same input
@@ -41,6 +47,8 @@ export interface LedgerStore {
   getAgentMapeRollup(agentId: AgentId): Promise<AgentMapeRollup | null>;
 
   getAgentDeclineRollup(agentId: AgentId): Promise<AgentDeclineRollup | null>;
+
+  getAgentWinRateRollup(agentId: AgentId): Promise<AgentWinRateRollup | null>;
 
   // Transitions bidding → awarded. Re-auction may also transition
   // executing → awarded with a different winner after excluding a failed

--- a/coordinator/src/ledger/types.ts
+++ b/coordinator/src/ledger/types.ts
@@ -8,6 +8,7 @@ import {
   TaskIdSchema,
   TaskSpecSchema,
   TaskStatusSchema,
+  TierSchema,
 } from "@agent-tasker/protocol";
 
 const Iso8601 = z.string().datetime({ offset: true });
@@ -103,3 +104,31 @@ export const AgentDeclineRollupSchema = z.object({
   last_no_bid_reason: NoBidReasonSchema.optional(),
 });
 export type AgentDeclineRollup = z.infer<typeof AgentDeclineRollupSchema>;
+
+const TierStatsSchema = z.object({
+  bid_count: z.number().int().nonnegative(),
+  win_count: z.number().int().nonnegative(),
+  win_rate: z.number().min(0).max(1),
+});
+
+const TierStatsByTierSchema = z.object({
+  small: TierStatsSchema,
+  medium: TierStatsSchema,
+  frontier: TierStatsSchema,
+});
+
+// Per-agent win concentration at agent_win_rate_rollups/{agent_id}. Bid
+// attempts are recorded when real bids arrive; wins are recorded on settle
+// against the winning bid's declared tier.
+export const AgentWinRateRollupSchema = z.object({
+  agent_id: AgentIdSchema,
+  updated_at: Iso8601,
+  bid_count: z.number().int().nonnegative(),
+  win_count: z.number().int().nonnegative(),
+  win_rate: z.number().min(0).max(1),
+  tiers: TierStatsByTierSchema,
+  last_task_id: TaskIdSchema,
+  last_event: z.enum(["bid", "win"]),
+  last_tier: TierSchema,
+});
+export type AgentWinRateRollup = z.infer<typeof AgentWinRateRollupSchema>;

--- a/coordinator/src/ledger/win-rates.ts
+++ b/coordinator/src/ledger/win-rates.ts
@@ -1,0 +1,95 @@
+import type { Bid, Tier } from "@agent-tasker/protocol";
+import type { AgentWinRateRollup } from "./types.js";
+
+const TIERS = ["small", "medium", "frontier"] as const satisfies readonly Tier[];
+
+export function applyWinRateBidUpdate(
+  previousRollup: AgentWinRateRollup | null,
+  args: {
+    previousBid: Bid | undefined;
+    nextBid: Bid;
+    updatedAt: string;
+  },
+): AgentWinRateRollup {
+  const rollup = cloneRollup(previousRollup, args.nextBid.agent_id);
+
+  if (args.previousBid) {
+    rollup.bid_count -= 1;
+    rollup.tiers[args.previousBid.tier].bid_count -= 1;
+  }
+
+  rollup.bid_count += 1;
+  rollup.tiers[args.nextBid.tier].bid_count += 1;
+  rollup.updated_at = args.updatedAt;
+  rollup.last_task_id = args.nextBid.task_id;
+  rollup.last_event = "bid";
+  rollup.last_tier = args.nextBid.tier;
+  return withRates(rollup);
+}
+
+export function applyWinRateBidRemoval(
+  previousRollup: AgentWinRateRollup | null,
+  args: {
+    previousBid: Bid;
+    updatedAt: string;
+  },
+): AgentWinRateRollup {
+  const rollup = cloneRollup(previousRollup, args.previousBid.agent_id);
+  rollup.bid_count -= 1;
+  rollup.tiers[args.previousBid.tier].bid_count -= 1;
+  rollup.updated_at = args.updatedAt;
+  rollup.last_task_id = args.previousBid.task_id;
+  rollup.last_event = "bid";
+  rollup.last_tier = args.previousBid.tier;
+  return withRates(rollup);
+}
+
+export function applyWinRateWinUpdate(
+  previousRollup: AgentWinRateRollup | null,
+  args: {
+    winningBid: Bid;
+    updatedAt: string;
+  },
+): AgentWinRateRollup {
+  const rollup = cloneRollup(previousRollup, args.winningBid.agent_id);
+  rollup.win_count += 1;
+  rollup.tiers[args.winningBid.tier].win_count += 1;
+  rollup.updated_at = args.updatedAt;
+  rollup.last_task_id = args.winningBid.task_id;
+  rollup.last_event = "win";
+  rollup.last_tier = args.winningBid.tier;
+  return withRates(rollup);
+}
+
+function cloneRollup(
+  rollup: AgentWinRateRollup | null,
+  agentId: Bid["agent_id"],
+): AgentWinRateRollup {
+  if (rollup) return structuredClone(rollup);
+  return {
+    agent_id: agentId,
+    updated_at: "1970-01-01T00:00:00.000Z",
+    bid_count: 0,
+    win_count: 0,
+    win_rate: 0,
+    tiers: Object.fromEntries(
+      TIERS.map((tier) => [tier, { bid_count: 0, win_count: 0, win_rate: 0 }]),
+    ) as AgentWinRateRollup["tiers"],
+    last_task_id: "",
+    last_event: "bid",
+    last_tier: "small",
+  };
+}
+
+function withRates(rollup: AgentWinRateRollup): AgentWinRateRollup {
+  rollup.win_rate = rate(rollup.win_count, rollup.bid_count);
+  for (const tier of TIERS) {
+    const stats = rollup.tiers[tier];
+    stats.win_rate = rate(stats.win_count, stats.bid_count);
+  }
+  return rollup;
+}
+
+function rate(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : numerator / denominator;
+}

--- a/coordinator/test/ledger/in-memory-store.test.ts
+++ b/coordinator/test/ledger/in-memory-store.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import type { AgentId, Bid, NoBid, PricingEntry, Result, TaskSpec } from "@agent-tasker/protocol";
+import type {
+  AgentId,
+  Bid,
+  NoBid,
+  PricingEntry,
+  Result,
+  TaskSpec,
+  Tier,
+} from "@agent-tasker/protocol";
 import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
 import {
   InvalidTransitionError,
@@ -22,11 +30,11 @@ const PRICING: PricingEntry[] = [
   },
 ];
 
-function makeBid(agentId: AgentId, bidUsd: number, taskId = TASK_ID): Bid {
+function makeBid(agentId: AgentId, bidUsd: number, taskId = TASK_ID, tier: Tier = "frontier"): Bid {
   return {
     task_id: taskId,
     agent_id: agentId,
-    tier: "frontier",
+    tier,
     model_family: "gemini",
     model_id: "gemini-2-5-pro",
     est_input_tokens: 4000,
@@ -191,6 +199,30 @@ describe("recordBidResponse", () => {
     expect(rollup?.last_no_bid_reason).toBeUndefined();
   });
 
+  it("tracks per-agent bid attempts by tier for win-rate rollups", async () => {
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.02, TASK_ID, "small"),
+      pricingSnapshot: PRICING,
+    });
+
+    const rollup = await store.getAgentWinRateRollup("gcp-gemini");
+    expect(rollup).toMatchObject({
+      agent_id: "gcp-gemini",
+      bid_count: 1,
+      win_count: 0,
+      win_rate: 0,
+      last_task_id: TASK_ID,
+      last_event: "bid",
+      last_tier: "small",
+      tiers: {
+        small: { bid_count: 1, win_count: 0, win_rate: 0 },
+        medium: { bid_count: 0, win_count: 0, win_rate: 0 },
+        frontier: { bid_count: 0, win_count: 0, win_rate: 0 },
+      },
+    });
+  });
+
   it("is idempotent on (task_id, agent_id) — final write wins", async () => {
     await store.recordBidResponse({
       taskId: TASK_ID,
@@ -232,6 +264,54 @@ describe("recordBidResponse", () => {
         internal_error: 0,
       },
       last_response_kind: "bid",
+    });
+  });
+
+  it("adjusts win-rate bid counts when a bid response is overwritten", async () => {
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.02, TASK_ID, "small"),
+      pricingSnapshot: PRICING,
+    });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.03, TASK_ID, "frontier"),
+      pricingSnapshot: PRICING,
+    });
+
+    const rollup = await store.getAgentWinRateRollup("gcp-gemini");
+    expect(rollup).toMatchObject({
+      bid_count: 1,
+      win_count: 0,
+      tiers: {
+        small: { bid_count: 0, win_count: 0, win_rate: 0 },
+        frontier: { bid_count: 1, win_count: 0, win_rate: 0 },
+      },
+      last_tier: "frontier",
+    });
+  });
+
+  it("removes win-rate bid counts when a bid is overwritten by no_bid", async () => {
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("aws-nova", 0.02, TASK_ID, "medium"),
+      pricingSnapshot: PRICING,
+    });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeNoBid("aws-nova"),
+      pricingSnapshot: PRICING,
+    });
+
+    const rollup = await store.getAgentWinRateRollup("aws-nova");
+    expect(rollup).toMatchObject({
+      bid_count: 0,
+      win_count: 0,
+      win_rate: 0,
+      tiers: {
+        medium: { bid_count: 0, win_count: 0, win_rate: 0 },
+      },
+      last_tier: "medium",
     });
   });
 
@@ -424,6 +504,27 @@ describe("markExecuting / completeTask / failTask", () => {
     expect(rollup?.mape).toBeCloseTo((0.26875 + 0.4625) / 2);
     expect(rollup?.mean_signed_percentage_error).toBeCloseTo((-0.26875 + 0.4625) / 2);
     expect(rollup?.last_task_id).toBe(secondTaskId);
+  });
+
+  it("completeTask updates the winner's win-rate rollup by tier", async () => {
+    await store.markExecuting(TASK_ID);
+    await store.completeTask({ taskId: TASK_ID, result: makeResult("gcp-gemini") });
+
+    const rollup = await store.getAgentWinRateRollup("gcp-gemini");
+    expect(rollup).toMatchObject({
+      agent_id: "gcp-gemini",
+      bid_count: 1,
+      win_count: 1,
+      win_rate: 1,
+      last_task_id: TASK_ID,
+      last_event: "win",
+      last_tier: "frontier",
+      tiers: {
+        frontier: { bid_count: 1, win_count: 1, win_rate: 1 },
+        small: { bid_count: 0, win_count: 0, win_rate: 0 },
+        medium: { bid_count: 0, win_count: 0, win_rate: 0 },
+      },
+    });
   });
 
   it("completeTask rejects directly from awarded (must mark executing first)", async () => {


### PR DESCRIPTION
## Summary
- add per-agent win-rate rollups with per-tier bid/win counts
- update bid-attempt counts when real bids arrive, including overwrite correction
- update winner win counts on task settlement
- persist/read win-rate rollups in both in-memory and Firestore ledgers

Closes #68

## Tests
- pnpm --filter @agent-tasker/coordinator test -- test/ledger/in-memory-store.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm lint
- pnpm typecheck
- pnpm format
- pnpm test