### PR TITLE
Add ledger replay tooling

### DIFF
--- a/coordinator/src/ledger/index.ts
+++ b/coordinator/src/ledger/index.ts
@@ -2,3 +2,4 @@ export * from "./types.js";
 export * from "./store.js";
 export * from "./in-memory-store.js";
 export * from "./firestore-store.js";
+export * from "./replay.js";

--- a/coordinator/src/ledger/replay.ts
+++ b/coordinator/src/ledger/replay.ts
@@ -1,0 +1,148 @@
+import { isNoBid, type AgentId, type Bid, type NoBid, type TaskId } from "@agent-tasker/protocol";
+import { computeActualUsdFromBidPrices } from "../auction/http-runner.js";
+import type { LedgerStore } from "./store.js";
+import type { BidRecord, TaskRecord } from "./types.js";
+
+export interface LedgerReplay {
+  task: TaskRecord;
+  bids: ReplayBid[];
+  no_bids: ReplayNoBid[];
+  award: ReplayAward | null;
+  settlement: ReplaySettlement | null;
+}
+
+export interface ReplayBid {
+  agent_id: AgentId;
+  bid_usd: number;
+  tier: Bid["tier"];
+  model_family: Bid["model_family"];
+  model_id: string;
+  pricing_snapshot: BidRecord["pricing_snapshot"];
+  est_input_tokens: number;
+  est_output_tokens: number;
+}
+
+export interface ReplayNoBid {
+  agent_id: AgentId;
+  reason: Exclude<BidRecord["no_bid_reason"], undefined>;
+}
+
+export interface ReplayAward {
+  winner_agent_id: AgentId;
+  winning_bid_usd: number;
+  auction_price_usd: number;
+}
+
+export interface ReplaySettlement {
+  winner_agent_id: AgentId;
+  output: string;
+  actual_usage: NonNullable<TaskRecord["result"]>["actual_usage"];
+  actual_usd_from_bid_prices: number | null;
+  bid_error_usd: number | null;
+  absolute_percentage_error: number | null;
+}
+
+export class LedgerReplayTaskNotFoundError extends Error {
+  constructor(taskId: TaskId) {
+    super(`cannot replay missing task ${taskId}`);
+    this.name = "LedgerReplayTaskNotFoundError";
+  }
+}
+
+export async function replayTaskFromLedger(
+  store: LedgerStore,
+  taskId: TaskId,
+): Promise<LedgerReplay> {
+  const task = await store.getTask(taskId);
+  if (!task) throw new LedgerReplayTaskNotFoundError(taskId);
+
+  const bidRecords = await store.listBids(taskId);
+  const bids = bidRecords.filter(isBidRecord).map(toReplayBid);
+  const noBids = bidRecords.filter(isNoBidRecord).map(toReplayNoBid);
+  const winningBid = findWinningBidRecord(bidRecords, task.winner_agent_id);
+
+  return {
+    task,
+    bids,
+    no_bids: noBids,
+    award: toReplayAward(task),
+    settlement: toReplaySettlement(task, winningBid),
+  };
+}
+
+function isBidRecord(record: BidRecord): record is BidRecord & { response: Bid } {
+  return !isNoBid(record.response);
+}
+
+function isNoBidRecord(record: BidRecord): record is BidRecord & { response: NoBid } {
+  return isNoBid(record.response);
+}
+
+function findWinningBidRecord(
+  bidRecords: BidRecord[],
+  winnerAgentId: AgentId | undefined,
+): (BidRecord & { response: Bid }) | undefined {
+  if (!winnerAgentId) return undefined;
+  return bidRecords.find(
+    (record): record is BidRecord & { response: Bid } =>
+      record.agent_id === winnerAgentId && isBidRecord(record),
+  );
+}
+
+function toReplayBid(record: BidRecord & { response: Bid }): ReplayBid {
+  return {
+    agent_id: record.agent_id,
+    bid_usd: record.response.bid_usd,
+    tier: record.response.tier,
+    model_family: record.response.model_family,
+    model_id: record.response.model_id,
+    pricing_snapshot: record.pricing_snapshot,
+    est_input_tokens: record.response.est_input_tokens,
+    est_output_tokens: record.response.est_output_tokens,
+  };
+}
+
+function toReplayNoBid(record: BidRecord & { response: NoBid }): ReplayNoBid {
+  return {
+    agent_id: record.agent_id,
+    reason: record.response.reason,
+  };
+}
+
+function toReplayAward(task: TaskRecord): ReplayAward | null {
+  if (
+    !task.winner_agent_id ||
+    task.winning_bid_usd === undefined ||
+    task.auction_price_usd === undefined
+  ) {
+    return null;
+  }
+  return {
+    winner_agent_id: task.winner_agent_id,
+    winning_bid_usd: task.winning_bid_usd,
+    auction_price_usd: task.auction_price_usd,
+  };
+}
+
+function toReplaySettlement(
+  task: TaskRecord,
+  winningBid: (BidRecord & { response: Bid }) | undefined,
+): ReplaySettlement | null {
+  if (!task.winner_agent_id || !task.result) return null;
+
+  const actualUsd = winningBid
+    ? computeActualUsdFromBidPrices(winningBid.response, task.result)
+    : null;
+  const bidErrorUsd = actualUsd === null ? null : actualUsd - winningBid!.response.bid_usd;
+  return {
+    winner_agent_id: task.winner_agent_id,
+    output: task.result.output,
+    actual_usage: task.result.actual_usage,
+    actual_usd_from_bid_prices: actualUsd,
+    bid_error_usd: bidErrorUsd,
+    absolute_percentage_error:
+      actualUsd === null || winningBid!.response.bid_usd === 0
+        ? null
+        : Math.abs(bidErrorUsd! / winningBid!.response.bid_usd),
+  };
+}

--- a/coordinator/test/ledger/replay.test.ts
+++ b/coordinator/test/ledger/replay.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AgentId, Bid, NoBid, PricingEntry, Result, TaskSpec } from "@agent-tasker/protocol";
+import { InMemoryLedgerStore } from "../../src/ledger/in-memory-store.js";
+import { LedgerReplayTaskNotFoundError, replayTaskFromLedger } from "../../src/ledger/replay.js";
+
+const TASK_ID = "task-replay-1";
+const SPEC: TaskSpec = { prompt: "summarize the attached transcript" };
+const PRICING: PricingEntry[] = [
+  {
+    model_id: "gemini-2-5-pro",
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10,
+    effective_date: "2026-05-15",
+  },
+];
+
+function makeBid(agentId: AgentId, bidUsd: number): Bid {
+  return {
+    task_id: TASK_ID,
+    agent_id: agentId,
+    tier: "frontier",
+    model_family: agentId === "aws-nova" ? "nova" : "gemini",
+    model_id: agentId === "aws-nova" ? "amazon.nova-pro" : "gemini-2-5-pro",
+    est_input_tokens: 4000,
+    est_output_tokens: 1000,
+    price_in_usd_per_mtoken: 1.25,
+    price_out_usd_per_mtoken: 10,
+    bid_usd: bidUsd,
+    expires_at: "2026-05-20T12:00:00Z",
+    signature: "stub",
+  };
+}
+
+function makeNoBid(agentId: AgentId): NoBid {
+  return {
+    task_id: TASK_ID,
+    agent_id: agentId,
+    status: "no_bid",
+    reason: "capability",
+  };
+}
+
+function makeResult(agentId: AgentId): Result {
+  return {
+    task_id: TASK_ID,
+    agent_id: agentId,
+    output: "summary text",
+    actual_usage: { input_tokens: 4100, output_tokens: 950 },
+  };
+}
+
+let store: InMemoryLedgerStore;
+
+beforeEach(() => {
+  store = new InMemoryLedgerStore();
+});
+
+describe("replayTaskFromLedger", () => {
+  it("reconstructs bids, no_bids, award, pricing snapshot, and settlement math", async () => {
+    await store.createTask({ taskId: TASK_ID, spec: SPEC });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.02),
+      pricingSnapshot: PRICING,
+    });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("aws-nova", 0.04),
+      pricingSnapshot: PRICING,
+    });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeNoBid("gcp-orchestrator"),
+      pricingSnapshot: PRICING,
+    });
+    await store.awardTask({
+      taskId: TASK_ID,
+      winnerAgentId: "gcp-gemini",
+      winningBidUsd: 0.02,
+      auctionPriceUsd: 0.04,
+    });
+    await store.markExecuting(TASK_ID);
+    await store.completeTask({ taskId: TASK_ID, result: makeResult("gcp-gemini") });
+
+    const replay = await replayTaskFromLedger(store, TASK_ID);
+
+    expect(replay.task.status).toBe("completed");
+    expect(replay.bids).toEqual([
+      expect.objectContaining({
+        agent_id: "gcp-gemini",
+        bid_usd: 0.02,
+        pricing_snapshot: PRICING,
+      }),
+      expect.objectContaining({
+        agent_id: "aws-nova",
+        bid_usd: 0.04,
+        pricing_snapshot: PRICING,
+      }),
+    ]);
+    expect(replay.no_bids).toEqual([{ agent_id: "gcp-orchestrator", reason: "capability" }]);
+    expect(replay.award).toEqual({
+      winner_agent_id: "gcp-gemini",
+      winning_bid_usd: 0.02,
+      auction_price_usd: 0.04,
+    });
+    expect(replay.settlement).toMatchObject({
+      winner_agent_id: "gcp-gemini",
+      output: "summary text",
+      actual_usage: { input_tokens: 4100, output_tokens: 950 },
+    });
+    expect(replay.settlement?.actual_usd_from_bid_prices).toBeCloseTo(0.014625);
+    expect(replay.settlement?.bid_error_usd).toBeCloseTo(-0.005375);
+    expect(replay.settlement?.absolute_percentage_error).toBeCloseTo(0.26875);
+  });
+
+  it("returns null award and settlement for an unawarded task", async () => {
+    await store.createTask({ taskId: TASK_ID, spec: SPEC });
+    await store.recordBidResponse({
+      taskId: TASK_ID,
+      response: makeBid("gcp-gemini", 0.02),
+      pricingSnapshot: PRICING,
+    });
+
+    const replay = await replayTaskFromLedger(store, TASK_ID);
+
+    expect(replay.award).toBeNull();
+    expect(replay.settlement).toBeNull();
+    expect(replay.bids).toHaveLength(1);
+  });
+
+  it("throws a typed error for missing tasks", async () => {
+    await expect(replayTaskFromLedger(store, "missing")).rejects.toThrow(
+      LedgerReplayTaskNotFoundError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add ledger replay builder over LedgerStore for reconstructing task auctions
- include bids, no_bids, award fields, per-bid pricing snapshots, and settlement math
- add tests for completed, unawarded, and missing-task replay paths

Closes #69

## Tests
- pnpm --filter @agent-tasker/coordinator test -- test/ledger/replay.test.ts
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm lint
- pnpm typecheck
- pnpm format
- pnpm test