### PR TITLE
Add initial eval fixtures

### DIFF
--- a/eval/fixtures/frontier-multistep-plan.json
+++ b/eval/fixtures/frontier-multistep-plan.json
@@ -1,0 +1,12 @@
+{
+  "name": "frontier-multistep-plan",
+  "tier": "frontier",
+  "expected_usd_range": {
+    "min": 0.01,
+    "max": 0.25
+  },
+  "task": {
+    "prompt": "Create a phased implementation plan for adding a new cloud agent to the auction system. Include protocol changes, infrastructure tasks, security checks, eval coverage, and rollout risks. Separate the work into milestones with acceptance criteria.",
+    "min_tier": "frontier"
+  }
+}

--- a/eval/fixtures/medium-structured-extraction.json
+++ b/eval/fixtures/medium-structured-extraction.json
@@ -1,0 +1,12 @@
+{
+  "name": "medium-structured-extraction",
+  "tier": "medium",
+  "expected_usd_range": {
+    "min": 0.002,
+    "max": 0.08
+  },
+  "task": {
+    "prompt": "Extract a JSON object from the following customer note with keys account_name, renewal_risk, requested_follow_up, and open_questions. Note: Contoso Analytics is happy with uptime but worried about token spend. They asked for a pricing review next Tuesday and want to know whether batch evals can run overnight.",
+    "min_tier": "medium"
+  }
+}

--- a/eval/fixtures/small-summary.json
+++ b/eval/fixtures/small-summary.json
@@ -1,0 +1,11 @@
+{
+  "name": "small-summary",
+  "tier": "small",
+  "expected_usd_range": {
+    "min": 0.0005,
+    "max": 0.03
+  },
+  "task": {
+    "prompt": "Summarize this release note in three concise bullets: The coordinator now records bid responses, awards the lowest bidder using Vickrey pricing, and stores final task results for later replay."
+  }
+}

--- a/eval/src/index.ts
+++ b/eval/src/index.ts
@@ -11,6 +11,11 @@ import {
 export interface EvalFixture {
   name: string;
   task: TaskSpec;
+  tier?: "small" | "medium" | "frontier";
+  expected_usd_range?: {
+    min: number;
+    max: number;
+  };
 }
 
 export interface EvalRunOptions {
@@ -76,10 +81,15 @@ export function parseFixture(raw: unknown, fallbackName = "fixture"): EvalFixtur
   const taskInput = "task" in raw ? raw["task"] : raw;
   const task = TaskSpecSchema.parse(taskInput);
   const name = raw["name"];
-  return {
+  const fixture: EvalFixture = {
     name: typeof name === "string" && name.length > 0 ? name : fallbackName,
     task,
   };
+  const tier = raw["tier"];
+  if (tier === "small" || tier === "medium" || tier === "frontier") fixture.tier = tier;
+  const expectedRange = parseExpectedUsdRange(raw["expected_usd_range"]);
+  if (expectedRange) fixture.expected_usd_range = expectedRange;
+  return fixture;
 }
 
 export async function runEval(options: EvalRunOptions): Promise<EvalSummary> {
@@ -185,6 +195,15 @@ function normalizeBaseUrl(value: string): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseExpectedUsdRange(value: unknown): EvalFixture["expected_usd_range"] | undefined {
+  if (!isRecord(value)) return undefined;
+  const min = value["min"];
+  const max = value["max"];
+  if (typeof min !== "number" || typeof max !== "number") return undefined;
+  if (min < 0 || max < min) throw new Error("expected_usd_range must be nonnegative and ordered");
+  return { min, max };
 }
 
 function parsePositiveInt(value: string | undefined, name: string): number {

--- a/eval/test/index.test.ts
+++ b/eval/test/index.test.ts
@@ -1,3 +1,5 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseFixture, runEval, summarizeResults } from "../src/index.js";
 
@@ -12,6 +14,39 @@ describe("parseFixture", () => {
       name: "summary",
       task: { prompt: "summarize this" },
     });
+  });
+
+  it("preserves tier and expected USD range metadata", () => {
+    const fixture = parseFixture({
+      name: "summary",
+      tier: "small",
+      expected_usd_range: { min: 0.001, max: 0.02 },
+      task: { prompt: "summarize this" },
+    });
+
+    expect(fixture).toMatchObject({
+      tier: "small",
+      expected_usd_range: { min: 0.001, max: 0.02 },
+    });
+  });
+
+  it("loads every checked-in fixture", async () => {
+    const fixturesDir = new URL("../fixtures", import.meta.url);
+    const files = (await readdir(fixturesDir)).filter((file) => file.endsWith(".json"));
+
+    expect(files.sort()).toEqual([
+      "frontier-multistep-plan.json",
+      "medium-structured-extraction.json",
+      "small-summary.json",
+    ]);
+
+    for (const file of files) {
+      const raw = JSON.parse(await readFile(join(fixturesDir.pathname, file), "utf8")) as unknown;
+      const fixture = parseFixture(raw, file);
+      expect(fixture.name).toBeTruthy();
+      expect(fixture.task.prompt.length).toBeGreaterThan(20);
+      expect(fixture.expected_usd_range?.max).toBeGreaterThan(fixture.expected_usd_range?.min ?? 0);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- add small, medium, and frontier fixture JSON files with expected USD ranges
- preserve fixture tier and expected_usd_range metadata in the eval parser
- add tests that load and validate the checked-in fixture library

Closes #71

## Tests
- pnpm --filter @agent-tasker/eval test
- pnpm --filter @agent-tasker/eval typecheck
- pnpm lint
- pnpm typecheck
- pnpm format
- pnpm test