### PR TITLE
Add MAPE-aware eval scoring

### DIFF
--- a/eval/src/index.ts
+++ b/eval/src/index.ts
@@ -18,6 +18,27 @@ export interface EvalFixture {
   };
 }
 
+export interface EvalExpectedUsdRange {
+  min: number;
+  max: number;
+}
+
+export interface EvalMapeScore {
+  expected_usd_range: EvalExpectedUsdRange & {
+    midpoint: number;
+  };
+  winning_bid: {
+    scored_runs: number;
+    mape: number | null;
+    range_hit_rate: number | null;
+  };
+  auction_price: {
+    scored_runs: number;
+    mape: number | null;
+    range_hit_rate: number | null;
+  };
+}
+
 export interface EvalRunOptions {
   coordinatorUrl: string;
   fixture: EvalFixture;
@@ -48,6 +69,7 @@ export interface EvalSummary {
   winners: Partial<Record<AgentId, number>>;
   average_winning_bid_usd: number | null;
   average_auction_price_usd: number | null;
+  score: EvalMapeScore | null;
   results: EvalRunResult[];
 }
 
@@ -97,13 +119,19 @@ export async function runEval(options: EvalRunOptions): Promise<EvalSummary> {
   for (let i = 1; i <= options.runs; i += 1) {
     results.push(await runOnce(options, i));
   }
-  return summarizeResults(options.fixture.name, options.runs, results);
+  return summarizeResults(
+    options.fixture.name,
+    options.runs,
+    results,
+    options.fixture.expected_usd_range,
+  );
 }
 
 export function summarizeResults(
   fixtureName: string,
   runsRequested: number,
   results: EvalRunResult[],
+  expectedUsdRange?: EvalExpectedUsdRange,
 ): EvalSummary {
   const completedResults = results.filter((result) => result.status === "completed");
   const failedResults = results.filter((result) => result.status === "failed");
@@ -121,6 +149,7 @@ export function summarizeResults(
     winners,
     average_winning_bid_usd: averageDefined(completedResults.map((r) => r.winning_bid_usd)),
     average_auction_price_usd: averageDefined(completedResults.map((r) => r.auction_price_usd)),
+    score: expectedUsdRange ? scoreResults(completedResults, expectedUsdRange) : null,
     results,
   };
 }
@@ -187,6 +216,54 @@ function averageDefined(values: Array<number | undefined>): number | null {
   const defined = values.filter((value): value is number => value !== undefined);
   if (defined.length === 0) return null;
   return defined.reduce((sum, value) => sum + value, 0) / defined.length;
+}
+
+function scoreResults(
+  completedResults: EvalRunResult[],
+  expectedUsdRange: EvalExpectedUsdRange,
+): EvalMapeScore {
+  return {
+    expected_usd_range: {
+      ...expectedUsdRange,
+      midpoint: expectedMidpoint(expectedUsdRange),
+    },
+    winning_bid: scorePriceSeries(
+      completedResults.map((result) => result.winning_bid_usd),
+      expectedUsdRange,
+    ),
+    auction_price: scorePriceSeries(
+      completedResults.map((result) => result.auction_price_usd),
+      expectedUsdRange,
+    ),
+  };
+}
+
+function scorePriceSeries(
+  values: Array<number | undefined>,
+  expectedUsdRange: EvalExpectedUsdRange,
+): EvalMapeScore["winning_bid"] {
+  const defined = values.filter((value): value is number => value !== undefined);
+  const midpoint = expectedMidpoint(expectedUsdRange);
+  return {
+    scored_runs: defined.length,
+    mape:
+      defined.length > 0 && midpoint > 0 ? averageAbsolutePercentageError(defined, midpoint) : null,
+    range_hit_rate:
+      defined.length > 0
+        ? defined.filter((value) => value >= expectedUsdRange.min && value <= expectedUsdRange.max)
+            .length / defined.length
+        : null,
+  };
+}
+
+function averageAbsolutePercentageError(values: number[], expected: number): number {
+  return (
+    values.reduce((sum, value) => sum + Math.abs(value - expected) / expected, 0) / values.length
+  );
+}
+
+function expectedMidpoint(expectedUsdRange: EvalExpectedUsdRange): number {
+  return (expectedUsdRange.min + expectedUsdRange.max) / 2;
 }
 
 function normalizeBaseUrl(value: string): string {

--- a/eval/test/index.test.ts
+++ b/eval/test/index.test.ts
@@ -77,6 +77,53 @@ describe("summarizeResults", () => {
       winners: { "gcp-gemini": 1 },
       average_winning_bid_usd: 0.02,
       average_auction_price_usd: 0.04,
+      score: null,
+    });
+  });
+
+  it("scores repeated stochastic runs against the fixture expected USD range", () => {
+    const summary = summarizeResults(
+      "fixture",
+      3,
+      [
+        {
+          run: 1,
+          task_id: "task-1",
+          status: "completed",
+          winner_agent_id: "gcp-gemini",
+          winning_bid_usd: 0.02,
+          auction_price_usd: 0.03,
+        },
+        {
+          run: 2,
+          task_id: "task-2",
+          status: "completed",
+          winner_agent_id: "gcp-gemini",
+          winning_bid_usd: 0.04,
+          auction_price_usd: 0.06,
+        },
+        {
+          run: 3,
+          task_id: "task-3",
+          status: "failed",
+          failure_reason: "all agents declined",
+        },
+      ],
+      { min: 0.02, max: 0.04 },
+    );
+
+    expect(summary.score).toEqual({
+      expected_usd_range: { min: 0.02, max: 0.04, midpoint: 0.03 },
+      winning_bid: {
+        scored_runs: 2,
+        mape: expect.closeTo(1 / 3),
+        range_hit_rate: 1,
+      },
+      auction_price: {
+        scored_runs: 2,
+        mape: 0.5,
+        range_hit_rate: 0.5,
+      },
     });
   });
 });
@@ -125,6 +172,49 @@ describe("runEval", () => {
       winner_agent_id: "gcp-gemini",
       input_tokens: 10,
       output_tokens: 5,
+    });
+  });
+
+  it("includes MAPE scoring when the fixture declares an expected USD range", async () => {
+    let taskId = 0;
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      if (init?.method === "POST") {
+        taskId += 1;
+        return jsonResponse(202, {
+          task_id: `task-${taskId}`,
+          status_url: `http://coordinator.test/tasks/task-${taskId}`,
+        });
+      }
+      return jsonResponse(200, {
+        task_id: `task-${taskId}`,
+        status: "completed",
+        winner_agent_id: "gcp-gemini",
+        winning_bid_usd: taskId === 1 ? 0.02 : 0.04,
+        auction_price_usd: taskId === 1 ? 0.03 : 0.05,
+        result: {
+          actual_usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      });
+    };
+
+    const summary = await runEval({
+      coordinatorUrl: "http://coordinator.test",
+      fixture: {
+        name: "summary",
+        expected_usd_range: { min: 0.02, max: 0.04 },
+        task: { prompt: "summarize this" },
+      },
+      runs: 2,
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+      fetchImpl,
+      wait: async () => {},
+    });
+
+    expect(summary.score?.winning_bid).toMatchObject({
+      scored_runs: 2,
+      mape: expect.closeTo(1 / 3),
+      range_hit_rate: 1,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add an eval score block derived from fixture expected USD ranges
- score repeated completed runs with MAPE and range-hit rate for winning bid and auction price
- cover direct summary scoring and runEval scoring propagation in tests

Closes #72

## Tests
- pnpm --filter @agent-tasker/eval test
- pnpm --filter @agent-tasker/eval typecheck
- pnpm --filter @agent-tasker/eval build