### PR TITLE
Instrument agents with OpenTelemetry

### DIFF
--- a/agent/aws-nova/src/execute/handler.ts
+++ b/agent/aws-nova/src/execute/handler.ts
@@ -1,4 +1,5 @@
 import type { ExecuteRequest, Result } from "@agent-tasker/protocol";
+import { withAgentSpan } from "@agent-tasker/agent";
 import { AGENT_ID } from "../index.js";
 import type { GenerativeTextClient } from "./runner.js";
 
@@ -10,14 +11,21 @@ export async function handleExecute(
   req: ExecuteRequest,
   deps: ExecuteHandlerDeps,
 ): Promise<Result> {
-  const { output, input_tokens, output_tokens } = await deps.client.generate(req.spec.prompt);
-  return {
-    task_id: req.task_id,
-    agent_id: AGENT_ID,
-    output,
-    actual_usage: {
-      input_tokens,
-      output_tokens,
+  return withAgentSpan(
+    "agent.execute",
+    { task_id: req.task_id, agent_id: AGENT_ID, phase: "execute" },
+    async (span) => {
+      const { output, input_tokens, output_tokens } = await deps.client.generate(req.spec.prompt);
+      span.setAttributes({ input_tokens, output_tokens });
+      return {
+        task_id: req.task_id,
+        agent_id: AGENT_ID,
+        output,
+        actual_usage: {
+          input_tokens,
+          output_tokens,
+        },
+      };
     },
-  };
+  );
 }

--- a/agent/aws-nova/src/index.ts
+++ b/agent/aws-nova/src/index.ts
@@ -1,4 +1,14 @@
+import { startAgentTelemetry, type AgentTelemetryHandle } from "@agent-tasker/agent";
+
 export const AGENT_ID = "aws-nova";
+export const TELEMETRY_SERVICE_NAME = `agent-tasker-${AGENT_ID}`;
+
+export function startTelemetry(env?: NodeJS.ProcessEnv): AgentTelemetryHandle | null {
+  return startAgentTelemetry({
+    serviceName: TELEMETRY_SERVICE_NAME,
+    ...(env ? { env } : {}),
+  });
+}
 
 export * from "./bid/index.js";
 export * from "./execute/index.js";

--- a/agent/azure-gpt/src/app.ts
+++ b/agent/azure-gpt/src/app.ts
@@ -1,7 +1,12 @@
 import { Hono } from "hono";
 import type { PricingEntry } from "@agent-tasker/protocol";
-import { AnnounceRequestSchema, ExecuteRequestSchema } from "@agent-tasker/protocol";
-import { getTokenClaims, requireTaskToken, type TaskTokenVerifier } from "@agent-tasker/agent";
+import { AnnounceRequestSchema, ExecuteRequestSchema, isNoBid } from "@agent-tasker/protocol";
+import {
+  getTokenClaims,
+  requireTaskToken,
+  withAgentSpan,
+  type TaskTokenVerifier,
+} from "@agent-tasker/agent";
 import { handleBid } from "./bid/handler.js";
 import type { BidEstimator } from "./bid/estimator.js";
 import { handleExecute } from "./execute/handler.js";
@@ -35,10 +40,22 @@ export function createApp(opts: CreateAppOptions) {
       );
     }
 
-    const result = await handleBid(parsed.data, {
-      estimator: opts.estimator,
-      pricing: opts.pricing,
-    });
+    const result = await withAgentSpan(
+      "agent.bid",
+      { task_id: parsed.data.task_id, agent_id: AGENT_ID, phase: "bid" },
+      async (span) => {
+        const bidResult = await handleBid(parsed.data, {
+          estimator: opts.estimator,
+          pricing: opts.pricing,
+        });
+        if (isNoBid(bidResult)) {
+          span.setAttribute("no_bid_reason", bidResult.reason);
+        } else {
+          span.setAttributes({ tier: bidResult.tier, bid_usd: bidResult.bid_usd });
+        }
+        return bidResult;
+      },
+    );
     return c.json(result);
   });
 
@@ -57,7 +74,18 @@ export function createApp(opts: CreateAppOptions) {
       );
     }
 
-    const result = await handleExecute(parsed.data, { client: opts.client });
+    const result = await withAgentSpan(
+      "agent.execute",
+      { task_id: parsed.data.task_id, agent_id: AGENT_ID, phase: "execute" },
+      async (span) => {
+        const executeResult = await handleExecute(parsed.data, { client: opts.client });
+        span.setAttributes({
+          input_tokens: executeResult.actual_usage.input_tokens,
+          output_tokens: executeResult.actual_usage.output_tokens,
+        });
+        return executeResult;
+      },
+    );
     return c.json(result);
   });
 

--- a/agent/azure-gpt/src/server.ts
+++ b/agent/azure-gpt/src/server.ts
@@ -1,6 +1,6 @@
 import { serve } from "@hono/node-server";
 import { createRemoteJWKSet } from "jose";
-import { createTaskTokenVerifier } from "@agent-tasker/agent";
+import { createTaskTokenVerifier, startAgentTelemetry } from "@agent-tasker/agent";
 import { FALLBACK_PRICING } from "@agent-tasker/protocol";
 import { AGENT_ID } from "./index.js";
 import { createApp } from "./app.js";
@@ -14,6 +14,7 @@ const azureOpenAiApiKey = process.env["AZURE_OPENAI_API_KEY"];
 const executeDeployment = process.env["AZURE_OPENAI_DEPLOYMENT"] ?? "gpt-5";
 const bidDeployment = process.env["AZURE_OPENAI_BID_DEPLOYMENT"] ?? "gpt-5-mini";
 const apiVersion = process.env["AZURE_OPENAI_API_VERSION"] ?? "2025-04-01-preview";
+const telemetry = startAgentTelemetry({ serviceName: `agent-tasker-${AGENT_ID}` });
 
 if (!jwksUrl || !azureOpenAiEndpoint || !azureOpenAiApiKey) {
   console.error("JWKS_URL, AZURE_OPENAI_ENDPOINT, and AZURE_OPENAI_API_KEY env vars are required");
@@ -51,4 +52,10 @@ const app = createApp({ verifier, estimator, pricing, client });
 
 serve({ fetch: app.fetch, port }, (info) => {
   console.log(`${AGENT_ID} agent listening on :${info.port}`);
+});
+
+process.once("SIGTERM", () => {
+  void telemetry?.shutdown().finally(() => {
+    process.exit(0);
+  });
 });

--- a/agent/gcp-gemini/src/app.ts
+++ b/agent/gcp-gemini/src/app.ts
@@ -2,10 +2,16 @@ import { Hono } from "hono";
 import {
   AnnounceRequestSchema,
   ExecuteRequestSchema,
+  isNoBid,
   type PricingEntry,
 } from "@agent-tasker/protocol";
-import { getTokenClaims, requireTaskToken, type TaskTokenVerifier } from "@agent-tasker/agent";
-import { handleBid } from "./bid/handler.js";
+import {
+  getTokenClaims,
+  requireTaskToken,
+  withAgentSpan,
+  type TaskTokenVerifier,
+} from "@agent-tasker/agent";
+import { AGENT_ID, handleBid } from "./bid/handler.js";
 import type { BidEstimator } from "./bid/estimator.js";
 import { handleExecute } from "./execute/handler.js";
 import type { GenerativeTextClient } from "./execute/runner.js";
@@ -23,7 +29,7 @@ export interface CreateAppOptions {
 export function createApp(opts: CreateAppOptions) {
   const app = new Hono();
 
-  app.get("/health", (c) => c.json({ ok: true, agent_id: "gcp-gemini" }));
+  app.get("/health", (c) => c.json({ ok: true, agent_id: AGENT_ID }));
 
   app.post("/bid", requireTaskToken(opts.verifier, "bid"), async (c) => {
     const body = (await c.req.json().catch(() => null)) as unknown;
@@ -41,10 +47,22 @@ export function createApp(opts: CreateAppOptions) {
         401,
       );
     }
-    const result = await handleBid(parsed.data, {
-      estimator: opts.estimator,
-      pricing: opts.pricing,
-    });
+    const result = await withAgentSpan(
+      "agent.bid",
+      { task_id: parsed.data.task_id, agent_id: AGENT_ID, phase: "bid" },
+      async (span) => {
+        const bidResult = await handleBid(parsed.data, {
+          estimator: opts.estimator,
+          pricing: opts.pricing,
+        });
+        if (isNoBid(bidResult)) {
+          span.setAttribute("no_bid_reason", bidResult.reason);
+        } else {
+          span.setAttributes({ tier: bidResult.tier, bid_usd: bidResult.bid_usd });
+        }
+        return bidResult;
+      },
+    );
     return c.json(result);
   });
 
@@ -61,7 +79,18 @@ export function createApp(opts: CreateAppOptions) {
         401,
       );
     }
-    const result = await handleExecute(parsed.data, { client: opts.client });
+    const result = await withAgentSpan(
+      "agent.execute",
+      { task_id: parsed.data.task_id, agent_id: AGENT_ID, phase: "execute" },
+      async (span) => {
+        const executeResult = await handleExecute(parsed.data, { client: opts.client });
+        span.setAttributes({
+          input_tokens: executeResult.actual_usage.input_tokens,
+          output_tokens: executeResult.actual_usage.output_tokens,
+        });
+        return executeResult;
+      },
+    );
     return c.json(result);
   });
 

--- a/agent/gcp-gemini/src/server.ts
+++ b/agent/gcp-gemini/src/server.ts
@@ -1,8 +1,9 @@
 import { serve } from "@hono/node-server";
 import { createRemoteJWKSet } from "jose";
 import { FALLBACK_PRICING } from "@agent-tasker/protocol";
-import { createTaskTokenVerifier } from "@agent-tasker/agent";
+import { createTaskTokenVerifier, startAgentTelemetry } from "@agent-tasker/agent";
 import { createApp } from "./app.js";
+import { AGENT_ID } from "./bid/handler.js";
 import { VertexBidEstimator, createVertexJsonClient } from "./bid/estimator.js";
 import { createVertexTextClient } from "./execute/runner.js";
 
@@ -10,6 +11,7 @@ import { createVertexTextClient } from "./execute/runner.js";
 // infra/agent-gcp-gemini Terraform, then wires Vertex AI clients +
 // the JWT verifier and serves the Hono app on $PORT.
 
+const telemetry = startAgentTelemetry({ serviceName: `agent-tasker-${AGENT_ID}` });
 const port = Number(process.env["PORT"] ?? 8080);
 const projectId = process.env["GCP_PROJECT_ID"];
 const location = process.env["GCP_LOCATION"] ?? "us-central1";
@@ -24,7 +26,7 @@ if (!projectId || !jwksUrl) {
 
 const verifier = createTaskTokenVerifier({
   getKey: createRemoteJWKSet(new URL(jwksUrl), { cacheMaxAge: 10 * 60_000 }),
-  expectedAudience: "gcp-gemini",
+  expectedAudience: AGENT_ID,
 });
 
 const estimator = new VertexBidEstimator(
@@ -49,4 +51,10 @@ serve({ fetch: app.fetch, port }, (info) => {
   console.log(
     `gcp-gemini agent listening on :${info.port} (project ${projectId}, location ${location})`,
   );
+});
+
+process.once("SIGTERM", () => {
+  void telemetry?.shutdown().finally(() => {
+    process.exit(0);
+  });
 });

--- a/agent/gcp-orchestrator/src/index.ts
+++ b/agent/gcp-orchestrator/src/index.ts
@@ -1,1 +1,11 @@
+import { startAgentTelemetry, type AgentTelemetryHandle } from "@agent-tasker/agent";
+
 export const AGENT_ID = "gcp-orchestrator";
+export const TELEMETRY_SERVICE_NAME = `agent-tasker-${AGENT_ID}`;
+
+export function startTelemetry(env?: NodeJS.ProcessEnv): AgentTelemetryHandle | null {
+  return startAgentTelemetry({
+    serviceName: TELEMETRY_SERVICE_NAME,
+    ...(env ? { env } : {}),
+  });
+}

--- a/agent/package.json
+++ b/agent/package.json
@@ -22,6 +22,10 @@
   },
   "dependencies": {
     "@agent-tasker/protocol": "workspace:*",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "^0.76.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+    "@opentelemetry/sdk-node": "^0.218.0",
     "hono": "^4.12.21",
     "jose": "^6.2.3",
     "zod": "^3.25.76"

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,2 +1,3 @@
 export { PROTOCOL_VERSION } from "@agent-tasker/protocol";
 export * from "./jwt/index.js";
+export * from "./observability/index.js";

--- a/agent/src/observability/index.ts
+++ b/agent/src/observability/index.ts
@@ -1,0 +1,1 @@
+export * from "./telemetry.js";

--- a/agent/src/observability/telemetry.ts
+++ b/agent/src/observability/telemetry.ts
@@ -1,0 +1,64 @@
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { SpanStatusCode, trace, type Attributes, type Span } from "@opentelemetry/api";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+export interface AgentTelemetryOptions {
+  serviceName: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface AgentTelemetryHandle {
+  shutdown(): Promise<void>;
+}
+
+export function startAgentTelemetry(options: AgentTelemetryOptions): AgentTelemetryHandle | null {
+  const env = options.env ?? process.env;
+  if (env["OTEL_SDK_DISABLED"] === "true") return null;
+
+  const sdk = new NodeSDK({
+    serviceName: env["OTEL_SERVICE_NAME"] ?? options.serviceName,
+    ...(env["OTEL_TRACES_EXPORTER"] === "none" ? {} : { traceExporter: new OTLPTraceExporter() }),
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        "@opentelemetry/instrumentation-fs": { enabled: false },
+      }),
+    ],
+  });
+
+  try {
+    sdk.start();
+    return {
+      shutdown: () => sdk.shutdown(),
+    };
+  } catch (err) {
+    console.warn(`${options.serviceName} OpenTelemetry startup failed`, err);
+    return null;
+  }
+}
+
+export async function withAgentSpan<T>(
+  name: string,
+  attributes: Attributes,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  return trace
+    .getTracer("agent-tasker-agent")
+    .startActiveSpan(name, { attributes }, async (span) => {
+      try {
+        const result = await fn(span);
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result;
+      } catch (err) {
+        if (err instanceof Error) {
+          span.recordException(err);
+          span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+        } else {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
+        }
+        throw err;
+      } finally {
+        span.end();
+      }
+    });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,18 @@ importers:
       '@agent-tasker/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/auto-instrumentations-node':
+        specifier: ^0.76.0
+        version: 0.76.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
       hono:
         specifier: ^4.12.21
         version: 4.12.21


### PR DESCRIPTION
## Summary
- add shared agent OpenTelemetry bootstrap/span helpers
- start telemetry in GCP Gemini and Azure GPT HTTP agent entrypoints
- wrap agent bid/execute work with task/agent/phase/tier/bid/token span attributes
- expose telemetry bootstraps for AWS Nova and the current GCP Orchestrator package stub

Closes #74

## Tests
- pnpm typecheck
- pnpm test