### PR TITLE
Configure Grafana OTLP exports

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,21 @@
+# Observability
+
+OpenTelemetry tracing is wired into the coordinator and agent runtimes. Terraform keeps export disabled by default so development deployments do not try to send spans to a local OTLP collector.
+
+To enable Grafana Cloud traces for a stack, set both variables for that Terraform module:
+
+```hcl
+otel_exporter_otlp_endpoint = "https://otlp-gateway-prod-us-central-0.grafana.net/otlp"
+otel_exporter_otlp_headers  = "Authorization=Basic <base64 instance_id:token>"
+```
+
+Use the endpoint shown in the Grafana Cloud OTLP setup page for the account's region. The header value contains the Grafana Cloud instance ID and an access policy token with traces write scope.
+
+When `otel_exporter_otlp_endpoint` is unset, Terraform sets `OTEL_TRACES_EXPORTER=none`. When it is set, Terraform adds:
+
+- `OTEL_SERVICE_NAME`
+- `OTEL_TRACES_EXPORTER=otlp`
+- `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_HEADERS` when provided
+
+`otel_exporter_otlp_headers` is marked sensitive, but it is still stored in Terraform state. Keep state in encrypted, access-controlled backends and rotate the Grafana token if state access changes.

--- a/infra/agent-aws-nova/lambda.tf
+++ b/infra/agent-aws-nova/lambda.tf
@@ -25,13 +25,17 @@ resource "aws_lambda_function" "agent" {
 
   environment {
     variables = {
-      AGENT_ID                 = "aws-nova"
-      AWS_NOVA_BID_MODEL_ID    = var.bedrock_bid_model_id
-      AWS_NOVA_EXEC_MODEL_ID   = var.bedrock_execute_model_id
-      JWKS_URL                 = var.jwks_url
-      NODE_OPTIONS             = "--enable-source-maps"
-      POWERTOOLS_SERVICE_NAME  = "agent-aws-nova"
-      POWERTOOLS_TRACE_ENABLED = "true"
+      AGENT_ID                    = "aws-nova"
+      AWS_NOVA_BID_MODEL_ID       = var.bedrock_bid_model_id
+      AWS_NOVA_EXEC_MODEL_ID      = var.bedrock_execute_model_id
+      JWKS_URL                    = var.jwks_url
+      NODE_OPTIONS                = "--enable-source-maps"
+      OTEL_EXPORTER_OTLP_ENDPOINT = coalesce(var.otel_exporter_otlp_endpoint, "")
+      OTEL_EXPORTER_OTLP_HEADERS  = coalesce(var.otel_exporter_otlp_headers, "")
+      OTEL_SERVICE_NAME           = "agent-tasker-aws-nova"
+      OTEL_TRACES_EXPORTER        = var.otel_exporter_otlp_endpoint == null ? "none" : "otlp"
+      POWERTOOLS_SERVICE_NAME     = "agent-aws-nova"
+      POWERTOOLS_TRACE_ENABLED    = "true"
     }
   }
 

--- a/infra/agent-aws-nova/variables.tf
+++ b/infra/agent-aws-nova/variables.tf
@@ -54,3 +54,16 @@ variable "bedrock_execute_model_id" {
   type        = string
   default     = "amazon.nova-pro-v1:0"
 }
+
+variable "otel_exporter_otlp_endpoint" {
+  description = "Optional Grafana Cloud OTLP endpoint (for example https://otlp-gateway-prod-us-central-0.grafana.net/otlp). When null, Lambda sets OTEL_TRACES_EXPORTER=none so local/dev deploys do not emit traces."
+  type        = string
+  default     = null
+}
+
+variable "otel_exporter_otlp_headers" {
+  description = "Optional OTLP headers for Grafana Cloud, usually Authorization=Basic <base64(instance_id:token)>. Stored in Terraform state; prefer environment-specific encrypted state."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/infra/agent-azure-gpt/container_app.tf
+++ b/infra/agent-azure-gpt/container_app.tf
@@ -31,6 +31,11 @@ resource "azurerm_container_app" "agent" {
     value = coalesce(var.azure_openai_api_key, "replace-me")
   }
 
+  secret {
+    name  = "otel-exporter-otlp-headers"
+    value = coalesce(var.otel_exporter_otlp_headers, "")
+  }
+
   ingress {
     external_enabled = true
     target_port      = var.agent_port
@@ -95,6 +100,26 @@ resource "azurerm_container_app" "agent" {
       env {
         name  = "KEY_VAULT_URI"
         value = azurerm_key_vault.agent.vault_uri
+      }
+
+      env {
+        name  = "OTEL_SERVICE_NAME"
+        value = "agent-tasker-azure-gpt"
+      }
+
+      env {
+        name  = "OTEL_TRACES_EXPORTER"
+        value = var.otel_exporter_otlp_endpoint == null ? "none" : "otlp"
+      }
+
+      env {
+        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+        value = coalesce(var.otel_exporter_otlp_endpoint, "")
+      }
+
+      env {
+        name        = "OTEL_EXPORTER_OTLP_HEADERS"
+        secret_name = "otel-exporter-otlp-headers"
       }
     }
   }

--- a/infra/agent-azure-gpt/variables.tf
+++ b/infra/agent-azure-gpt/variables.tf
@@ -121,3 +121,16 @@ variable "azure_openai_api_key" {
   default     = null
   sensitive   = true
 }
+
+variable "otel_exporter_otlp_endpoint" {
+  description = "Optional Grafana Cloud OTLP endpoint (for example https://otlp-gateway-prod-us-central-0.grafana.net/otlp). When null, Container Apps sets OTEL_TRACES_EXPORTER=none so local/dev deploys do not emit traces."
+  type        = string
+  default     = null
+}
+
+variable "otel_exporter_otlp_headers" {
+  description = "Optional OTLP headers for Grafana Cloud, usually Authorization=Basic <base64(instance_id:token)>. Stored in Terraform state; prefer environment-specific encrypted state."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/infra/agent-gcp-gemini/cloud_run.tf
+++ b/infra/agent-gcp-gemini/cloud_run.tf
@@ -99,6 +99,22 @@ resource "google_cloud_run_v2_service" "agent" {
         name  = "JWKS_URL"
         value = var.jwks_url
       }
+      env {
+        name  = "OTEL_SERVICE_NAME"
+        value = "agent-tasker-gcp-gemini"
+      }
+      env {
+        name  = "OTEL_TRACES_EXPORTER"
+        value = var.otel_exporter_otlp_endpoint == null ? "none" : "otlp"
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+        value = coalesce(var.otel_exporter_otlp_endpoint, "")
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_HEADERS"
+        value = coalesce(var.otel_exporter_otlp_headers, "")
+      }
     }
   }
 

--- a/infra/agent-gcp-gemini/variables.tf
+++ b/infra/agent-gcp-gemini/variables.tf
@@ -70,3 +70,16 @@ variable "jwks_url" {
   description = "Coordinator JWKS URL (output `jwks_public_url` from infra/coordinator) the agent fetches public keys from."
   type        = string
 }
+
+variable "otel_exporter_otlp_endpoint" {
+  description = "Optional Grafana Cloud OTLP endpoint (for example https://otlp-gateway-prod-us-central-0.grafana.net/otlp). When null, Cloud Run sets OTEL_TRACES_EXPORTER=none so local/dev deploys do not emit traces."
+  type        = string
+  default     = null
+}
+
+variable "otel_exporter_otlp_headers" {
+  description = "Optional OTLP headers for Grafana Cloud, usually Authorization=Basic <base64(instance_id:token)>. Stored in Terraform state; prefer environment-specific encrypted state."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/infra/coordinator/cloud_run.tf
+++ b/infra/coordinator/cloud_run.tf
@@ -89,6 +89,22 @@ resource "google_cloud_run_v2_service" "coordinator" {
         name  = "JWKS_BUCKET"
         value = google_storage_bucket.jwks.name
       }
+      env {
+        name  = "OTEL_SERVICE_NAME"
+        value = "agent-tasker-coordinator"
+      }
+      env {
+        name  = "OTEL_TRACES_EXPORTER"
+        value = var.otel_exporter_otlp_endpoint == null ? "none" : "otlp"
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+        value = coalesce(var.otel_exporter_otlp_endpoint, "")
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_HEADERS"
+        value = coalesce(var.otel_exporter_otlp_headers, "")
+      }
     }
   }
 

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -85,6 +85,19 @@ variable "coordinator_delete_protection" {
   default     = false
 }
 
+variable "otel_exporter_otlp_endpoint" {
+  description = "Optional Grafana Cloud OTLP endpoint (for example https://otlp-gateway-prod-us-central-0.grafana.net/otlp). When null, Cloud Run sets OTEL_TRACES_EXPORTER=none so local/dev deploys do not emit traces."
+  type        = string
+  default     = null
+}
+
+variable "otel_exporter_otlp_headers" {
+  description = "Optional OTLP headers for Grafana Cloud, usually Authorization=Basic <base64(instance_id:token)>. Stored in Terraform state; prefer environment-specific encrypted state."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
 variable "pricing_refresh_schedule" {
   description = "Cron expression (Etc/UTC) for the daily pricing-refresh job. Default 04:00 UTC — overnight in the Americas, mid-morning in EU, low coordinator traffic everywhere."
   type        = string


### PR DESCRIPTION
## Summary
- add optional Grafana Cloud OTLP endpoint/header variables to coordinator and agent Terraform stacks
- wire OTEL_SERVICE_NAME, OTEL_TRACES_EXPORTER, OTEL_EXPORTER_OTLP_ENDPOINT, and OTEL_EXPORTER_OTLP_HEADERS into Cloud Run, Lambda, and Azure Container Apps
- keep traces disabled by default when no endpoint is configured
- document the Grafana Cloud values operators need to provide

Closes #75

## Tests
- terraform fmt -check infra/coordinator infra/agent-gcp-gemini infra/agent-aws-nova infra/agent-azure-gpt
- terraform -chdir=infra/agent-azure-gpt validate
- pnpm typecheck
- pnpm exec prettier --check docs/observability.md

Note: local terraform validate for GCP/AWS modules could not load existing local provider plugins from .terraform/providers; CI uses a clean provider install.