### PR TITLE
Add MAPE drift dashboard metrics

### DIFF
--- a/coordinator/src/ledger/firestore-store.ts
+++ b/coordinator/src/ledger/firestore-store.ts
@@ -39,8 +39,10 @@ import {
   applyWinRateWinUpdate,
 } from "./win-rates.js";
 import {
+  recordBidAccuracySample,
   recordBidDeltas,
   recordWin,
+  type AgentBidAccuracyMetric,
   type AgentTierMetricDelta,
 } from "../observability/market-metrics.js";
 
@@ -202,11 +204,16 @@ export class FirestoreLedgerStore implements LedgerStore {
         updated_at: nowIso(input.now),
         result: input.result,
       };
-      const winMetric = await this.writeSettlementRollups(tx, next);
+      const settlementMetrics = await this.writeSettlementRollups(tx, next);
       tx.set(ref, stripUndefined(next));
-      return { record: next, winMetric };
+      return { record: next, settlementMetrics };
     });
-    if (result.winMetric) recordWin(result.winMetric.agentId, result.winMetric.tier);
+    if (result.settlementMetrics?.win) {
+      recordWin(result.settlementMetrics.win.agentId, result.settlementMetrics.win.tier);
+    }
+    if (result.settlementMetrics?.accuracy) {
+      recordBidAccuracySample(result.settlementMetrics.accuracy);
+    }
     return result.record;
   }
 
@@ -302,7 +309,7 @@ export class FirestoreLedgerStore implements LedgerStore {
   private async writeSettlementRollups(
     tx: Transaction,
     task: TaskRecord,
-  ): Promise<AgentTierMetricDelta | undefined> {
+  ): Promise<SettlementMetricDeltas | undefined> {
     if (!task.winner_agent_id || !task.result) return undefined;
 
     const bidSnap = await tx.get(
@@ -318,6 +325,7 @@ export class FirestoreLedgerStore implements LedgerStore {
     const previousWinRateRollupSnap = await tx.get(winRateRollupRef);
 
     const sample = computeBidAccuracySample(bidRecord.response, task.result);
+    let accuracyMetric: AgentBidAccuracyMetric | undefined;
     if (sample) {
       const previousMapeRollup = previousMapeRollupSnap.exists
         ? AgentMapeRollupSchema.parse(previousMapeRollupSnap.data())
@@ -333,6 +341,11 @@ export class FirestoreLedgerStore implements LedgerStore {
           }),
         ),
       );
+      accuracyMetric = {
+        agentId: bidRecord.response.agent_id,
+        tier: bidRecord.response.tier,
+        sample,
+      };
     }
 
     const previousWinRateRollup = previousWinRateRollupSnap.exists
@@ -347,10 +360,15 @@ export class FirestoreLedgerStore implements LedgerStore {
         }),
       ),
     );
-    return {
+    const win = {
       agentId: bidRecord.response.agent_id,
       tier: bidRecord.response.tier,
       delta: 1,
+    };
+    if (!accuracyMetric) return { win };
+    return {
+      win,
+      accuracy: accuracyMetric,
     };
   }
 
@@ -409,6 +427,11 @@ function bidMetricDeltas(
 
 interface FirestoreError {
   code?: number;
+}
+
+interface SettlementMetricDeltas {
+  win: AgentTierMetricDelta;
+  accuracy?: AgentBidAccuracyMetric;
 }
 
 // gRPC code 6 = ALREADY_EXISTS — thrown by DocumentReference#create when the

--- a/coordinator/src/ledger/in-memory-store.ts
+++ b/coordinator/src/ledger/in-memory-store.ts
@@ -28,8 +28,10 @@ import {
   applyWinRateWinUpdate,
 } from "./win-rates.js";
 import {
+  recordBidAccuracySample,
   recordBidDeltas,
   recordWin,
+  type AgentBidAccuracyMetric,
   type AgentTierMetricDelta,
 } from "../observability/market-metrics.js";
 
@@ -179,9 +181,13 @@ export class InMemoryLedgerStore implements LedgerStore {
       result: input.result,
     };
     this.tasks.set(input.taskId, next);
-    this.writeMapeRollup(next, input.result);
-    const winMetric = this.writeWinRateWinRollup(next);
-    if (winMetric) recordWin(winMetric.agentId, winMetric.tier);
+    const settlementMetrics = this.writeSettlementRollups(next, input.result);
+    if (settlementMetrics?.win) {
+      recordWin(settlementMetrics.win.agentId, settlementMetrics.win.tier);
+    }
+    if (settlementMetrics?.accuracy) {
+      recordBidAccuracySample(settlementMetrics.accuracy);
+    }
     return clone(next);
   }
 
@@ -206,13 +212,16 @@ export class InMemoryLedgerStore implements LedgerStore {
     return clone(next);
   }
 
-  private writeMapeRollup(task: TaskRecord, result: TaskRecord["result"]): void {
-    if (!task.winner_agent_id || !result) return;
+  private writeMapeRollup(
+    task: TaskRecord,
+    result: TaskRecord["result"],
+  ): AgentBidAccuracyMetric | undefined {
+    if (!task.winner_agent_id || !result) return undefined;
     const bidRecord = this.bids.get(bidKey(task.task_id, task.winner_agent_id));
-    if (!bidRecord || isNoBid(bidRecord.response)) return;
+    if (!bidRecord || isNoBid(bidRecord.response)) return undefined;
 
     const sample = computeBidAccuracySample(bidRecord.response, result);
-    if (!sample) return;
+    if (!sample) return undefined;
 
     const previous = this.mapeRollups.get(task.winner_agent_id) ?? null;
     this.mapeRollups.set(
@@ -224,6 +233,22 @@ export class InMemoryLedgerStore implements LedgerStore {
         sample,
       }),
     );
+    return {
+      agentId: bidRecord.response.agent_id,
+      tier: bidRecord.response.tier,
+      sample,
+    };
+  }
+
+  private writeSettlementRollups(
+    task: TaskRecord,
+    result: TaskRecord["result"],
+  ): SettlementMetricDeltas | undefined {
+    const accuracy = this.writeMapeRollup(task, result);
+    const win = this.writeWinRateWinRollup(task);
+    if (!win) return undefined;
+    if (!accuracy) return { win };
+    return { win, accuracy };
   }
 
   private writeDeclineRollup(previous: BidRecord | undefined, next: BidRecord): void {
@@ -326,4 +351,9 @@ function bidMetricDeltas(
     });
   }
   return deltas;
+}
+
+interface SettlementMetricDeltas {
+  win: AgentTierMetricDelta;
+  accuracy?: AgentBidAccuracyMetric;
 }

--- a/coordinator/src/observability/market-metrics.ts
+++ b/coordinator/src/observability/market-metrics.ts
@@ -1,9 +1,14 @@
-import { metrics, type UpDownCounter } from "@opentelemetry/api";
+import { metrics, type Counter, type Histogram, type UpDownCounter } from "@opentelemetry/api";
 import type { AgentId, Tier } from "@agent-tasker/protocol";
+import type { BidAccuracySample } from "../ledger/mape.js";
 
 interface MarketMetricInstruments {
   bids: UpDownCounter;
   wins: UpDownCounter;
+  bidAccuracySamples: Counter;
+  bidAbsolutePercentageErrorSum: Counter;
+  bidSignedPercentageErrorSum: UpDownCounter;
+  bidAbsolutePercentageError: Histogram;
 }
 
 let instruments: MarketMetricInstruments | undefined;
@@ -12,6 +17,12 @@ export interface AgentTierMetricDelta {
   agentId: AgentId;
   tier: Tier;
   delta: number;
+}
+
+export interface AgentBidAccuracyMetric {
+  agentId: AgentId;
+  tier: Tier;
+  sample: BidAccuracySample;
 }
 
 export function recordBidDeltas(deltas: readonly AgentTierMetricDelta[]): void {
@@ -23,6 +34,23 @@ export function recordBidDeltas(deltas: readonly AgentTierMetricDelta[]): void {
       tier: delta.tier,
     });
   }
+}
+
+export function recordBidAccuracySample(metric: AgentBidAccuracyMetric): void {
+  const {
+    bidAccuracySamples,
+    bidAbsolutePercentageError,
+    bidAbsolutePercentageErrorSum,
+    bidSignedPercentageErrorSum,
+  } = getInstruments();
+  const attributes = {
+    agent_id: metric.agentId,
+    tier: metric.tier,
+  };
+  bidAccuracySamples.add(1, attributes);
+  bidAbsolutePercentageError.record(metric.sample.absolutePercentageError, attributes);
+  bidAbsolutePercentageErrorSum.add(metric.sample.absolutePercentageError, attributes);
+  bidSignedPercentageErrorSum.add(metric.sample.signedPercentageError, attributes);
 }
 
 export function recordWin(agentId: AgentId, tier: Tier): void {
@@ -45,6 +73,32 @@ function getInstruments(): MarketMetricInstruments {
       description: "Current count of settled winning tasks by agent and tier.",
       unit: "{win}",
     }),
+    bidAccuracySamples: meter.createCounter("agent_tasker_bid_accuracy_samples", {
+      description: "Count of settled tasks with bid accuracy samples.",
+      unit: "{sample}",
+    }),
+    bidAbsolutePercentageErrorSum: meter.createCounter(
+      "agent_tasker_bid_absolute_percentage_error_sum",
+      {
+        description: "Cumulative absolute percentage error for settled winning bids.",
+        unit: "1",
+      },
+    ),
+    bidSignedPercentageErrorSum: meter.createUpDownCounter(
+      "agent_tasker_bid_signed_percentage_error_sum",
+      {
+        description:
+          "Cumulative signed percentage error for settled winning bids; positive means actual cost exceeded the bid.",
+        unit: "1",
+      },
+    ),
+    bidAbsolutePercentageError: meter.createHistogram(
+      "agent_tasker_bid_absolute_percentage_error",
+      {
+        description: "Distribution of absolute percentage error for settled winning bids.",
+        unit: "1",
+      },
+    ),
   };
   return instruments;
 }

--- a/docs/grafana/dashboards/agent-mape-drift.json
+++ b/docs/grafana/dashboards/agent-mape-drift.json
@@ -1,0 +1,412 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 25
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 14,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (agent_id) (rate(agent_tasker_bid_absolute_percentage_error_sum[$__rate_interval])) / clamp_min(sum by (agent_id) (rate(agent_tasker_bid_accuracy_samples[$__rate_interval])), 0.001)",
+          "legendFormat": "{{agent_id}} MAPE",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MAPE Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 14,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (agent_id) (increase(agent_tasker_bid_accuracy_samples[$__range]))",
+          "legendFormat": "{{agent_id}} samples",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Settled Accuracy Samples",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (agent_id) (rate(agent_tasker_bid_signed_percentage_error_sum[$__rate_interval])) / clamp_min(sum by (agent_id) (rate(agent_tasker_bid_accuracy_samples[$__rate_interval])), 0.001)",
+          "legendFormat": "{{agent_id}} signed drift",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Signed Bid Drift",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * histogram_quantile(0.95, sum by (agent_id, le) (rate(agent_tasker_bid_absolute_percentage_error_bucket[$__rate_interval])))",
+          "legendFormat": "{{agent_id}} p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Absolute Percentage Error",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["agent-tasker", "market", "phase-1"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus/Mimir",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Agent Tasker / MAPE Drift",
+  "uid": "agent-tasker-mape-drift",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -26,3 +26,4 @@ When `otel_exporter_otlp_endpoint` is unset, Terraform sets `OTEL_TRACES_EXPORTE
 Import dashboard JSON from `docs/grafana/dashboards/` into Grafana Cloud:
 
 - `agent-win-rate.json` tracks bid counts, settled wins, and win rate per agent/tier from the coordinator OTLP metrics `agent_tasker_agent_bids` and `agent_tasker_agent_wins`.
+- `agent-mape-drift.json` tracks MAPE, p95 absolute percentage error, and signed bid drift from coordinator OTLP metrics emitted when winning tasks settle.


### PR DESCRIPTION
## Summary
- emit coordinator OTLP metrics for settled bid accuracy samples, absolute error, signed drift, and absolute-error distribution
- keep metric emission outside Firestore transaction retries while reusing the existing ledger settlement rollup path
- add Grafana dashboard JSON for MAPE, p95 absolute percentage error, signed drift, and sample count

Closes #77

## Checks
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm exec prettier --check docs/observability.md docs/grafana/dashboards/agent-mape-drift.json coordinator/src/observability/market-metrics.ts coordinator/src/ledger/firestore-store.ts coordinator/src/ledger/in-memory-store.ts