### PR TITLE
Add bid latency dashboard metrics

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -15,6 +15,7 @@ import {
 } from "@agent-tasker/protocol";
 import { SpanStatusCode, trace, type Attributes, type Span } from "@opentelemetry/api";
 import type { LedgerStore } from "../ledger/store.js";
+import { recordAgentBidLatency, recordBidRoundLatency } from "../observability/market-metrics.js";
 import type { AuctionRunner } from "./runner.js";
 
 // Minimal real AuctionRunner that drives `bidding → awarded → executing →
@@ -231,13 +232,14 @@ export class HttpAuctionRunner implements AuctionRunner {
     const pending = this.opts.agents.map((agent) => {
       const controller = new AbortController();
       const promise = (async (): Promise<BidResponse> => {
+        const startedAt = Date.now();
         try {
           const token = await this.opts.tokenSigner.sign({
             agentId: agent.agentId,
             taskId,
             phase: "bid",
           });
-          return await withSpan(
+          const response = await withSpan(
             "coordinator.agent.bid",
             { task_id: taskId, agent_id: agent.agentId, phase: "bid" },
             async (span) => {
@@ -275,9 +277,21 @@ export class HttpAuctionRunner implements AuctionRunner {
               return parsed.data;
             },
           );
+          recordAgentBidLatency({
+            agentId: agent.agentId,
+            response,
+            durationMs: Date.now() - startedAt,
+          });
+          return response;
         } catch (err) {
           const reason = err instanceof Error && err.name === "AbortError" ? "timeout" : "error";
-          return syntheticNoBid(taskId, agent.agentId, reason);
+          const response = syntheticNoBid(taskId, agent.agentId, reason);
+          recordAgentBidLatency({
+            agentId: agent.agentId,
+            response,
+            durationMs: Date.now() - startedAt,
+          });
+          return response;
         }
       })();
       return {
@@ -288,13 +302,21 @@ export class HttpAuctionRunner implements AuctionRunner {
     });
 
     try {
-      return await collectBidResponsesAdaptive({
+      const startedAt = Date.now();
+      const responses = await collectBidResponsesAdaptive({
         taskId,
         pending,
         totalTimeoutMs: this.opts.bidTimeoutMs ?? DEFAULT_BID_TIMEOUT_MS,
         initialWaitMs: this.opts.bidInitialWaitMs ?? DEFAULT_BID_INITIAL_WAIT_MS,
         extensionMs: this.opts.bidExtensionMs ?? DEFAULT_BID_EXTENSION_MS,
       });
+      recordBidRoundLatency({
+        durationMs: Date.now() - startedAt,
+        configuredAgentCount: pending.length,
+        responseCount: responses.length,
+        bidCount: responses.filter((response) => !isNoBid(response)).length,
+      });
+      return responses;
     } finally {
       for (const entry of pending) entry.abort();
     }

--- a/coordinator/src/observability/market-metrics.ts
+++ b/coordinator/src/observability/market-metrics.ts
@@ -1,5 +1,5 @@
 import { metrics, type Counter, type Histogram, type UpDownCounter } from "@opentelemetry/api";
-import type { AgentId, Tier } from "@agent-tasker/protocol";
+import { isNoBid, type AgentId, type BidResponse, type Tier } from "@agent-tasker/protocol";
 import type { BidAccuracySample } from "../ledger/mape.js";
 
 interface MarketMetricInstruments {
@@ -9,6 +9,8 @@ interface MarketMetricInstruments {
   bidAbsolutePercentageErrorSum: Counter;
   bidSignedPercentageErrorSum: UpDownCounter;
   bidAbsolutePercentageError: Histogram;
+  agentBidLatencyMs: Histogram;
+  bidRoundLatencyMs: Histogram;
 }
 
 let instruments: MarketMetricInstruments | undefined;
@@ -23,6 +25,19 @@ export interface AgentBidAccuracyMetric {
   agentId: AgentId;
   tier: Tier;
   sample: BidAccuracySample;
+}
+
+export interface AgentBidLatencyMetric {
+  agentId: AgentId;
+  response: BidResponse;
+  durationMs: number;
+}
+
+export interface BidRoundLatencyMetric {
+  durationMs: number;
+  configuredAgentCount: number;
+  responseCount: number;
+  bidCount: number;
 }
 
 export function recordBidDeltas(deltas: readonly AgentTierMetricDelta[]): void {
@@ -51,6 +66,22 @@ export function recordBidAccuracySample(metric: AgentBidAccuracyMetric): void {
   bidAbsolutePercentageError.record(metric.sample.absolutePercentageError, attributes);
   bidAbsolutePercentageErrorSum.add(metric.sample.absolutePercentageError, attributes);
   bidSignedPercentageErrorSum.add(metric.sample.signedPercentageError, attributes);
+}
+
+export function recordAgentBidLatency(metric: AgentBidLatencyMetric): void {
+  getInstruments().agentBidLatencyMs.record(metric.durationMs, {
+    agent_id: metric.agentId,
+    response_kind: isNoBid(metric.response) ? "no_bid" : "bid",
+    ...(isNoBid(metric.response) ? { no_bid_reason: metric.response.reason } : {}),
+  });
+}
+
+export function recordBidRoundLatency(metric: BidRoundLatencyMetric): void {
+  getInstruments().bidRoundLatencyMs.record(metric.durationMs, {
+    configured_agent_count: metric.configuredAgentCount,
+    response_count: metric.responseCount,
+    bid_count: metric.bidCount,
+  });
 }
 
 export function recordWin(agentId: AgentId, tier: Tier): void {
@@ -99,6 +130,14 @@ function getInstruments(): MarketMetricInstruments {
         unit: "1",
       },
     ),
+    agentBidLatencyMs: meter.createHistogram("agent_tasker_agent_bid_latency_ms", {
+      description: "Coordinator-observed latency for each agent /bid request.",
+      unit: "ms",
+    }),
+    bidRoundLatencyMs: meter.createHistogram("agent_tasker_bid_round_latency_ms", {
+      description: "Coordinator-observed latency for the full adaptive bid collection window.",
+      unit: "ms",
+    }),
   };
   return instruments;
 }

--- a/docs/grafana/dashboards/bid-latency.json
+++ b/docs/grafana/dashboards/bid-latency.json
@@ -1,0 +1,367 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 3000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (agent_id, le) (rate(agent_tasker_agent_bid_latency_ms_bucket[$__rate_interval])))",
+          "legendFormat": "{{agent_id}} p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (agent_id, le) (rate(agent_tasker_agent_bid_latency_ms_bucket[$__rate_interval])))",
+          "hide": false,
+          "legendFormat": "{{agent_id}} p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (agent_id, le) (rate(agent_tasker_agent_bid_latency_ms_bucket[$__rate_interval])))",
+          "legendFormat": "{{agent_id}} p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Per-Agent Bid Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2000
+              },
+              {
+                "color": "red",
+                "value": 5000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(agent_tasker_bid_round_latency_ms_bucket[$__rate_interval])))",
+          "legendFormat": "bid round p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(agent_tasker_bid_round_latency_ms_bucket[$__rate_interval])))",
+          "legendFormat": "bid round p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(agent_tasker_bid_round_latency_ms_bucket[$__rate_interval])))",
+          "legendFormat": "bid round p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Adaptive Bid-Round Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 14,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (agent_id, response_kind) (rate(agent_tasker_agent_bid_latency_ms_count[$__rate_interval]))",
+          "legendFormat": "{{agent_id}} / {{response_kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Bid Response Rate",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["agent-tasker", "market", "phase-1"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus/Mimir",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Agent Tasker / Bid Latency",
+  "uid": "agent-tasker-bid-latency",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,3 +27,4 @@ Import dashboard JSON from `docs/grafana/dashboards/` into Grafana Cloud:
 
 - `agent-win-rate.json` tracks bid counts, settled wins, and win rate per agent/tier from the coordinator OTLP metrics `agent_tasker_agent_bids` and `agent_tasker_agent_wins`.
 - `agent-mape-drift.json` tracks MAPE, p95 absolute percentage error, and signed bid drift from coordinator OTLP metrics emitted when winning tasks settle.
+- `bid-latency.json` tracks per-agent `/bid` latency and full adaptive bid-round latency p50/p95/p99.


### PR DESCRIPTION
## Summary
- emit coordinator histograms for each agent /bid round-trip and the full adaptive bid collection window
- tag agent latency by agent, response kind, and no_bid reason for quick concentration checks
- add Grafana dashboard JSON for bid latency p50/p95/p99 and response rate

Closes #78

## Checks
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm exec prettier --check docs/observability.md docs/grafana/dashboards/bid-latency.json coordinator/src/observability/market-metrics.ts coordinator/src/auction/http-runner.ts