### PR TITLE
Add pricing refresh failure alert

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -21,6 +21,10 @@ When `otel_exporter_otlp_endpoint` is unset, Terraform sets `OTEL_TRACES_EXPORTE
 
 `otel_exporter_otlp_headers` is marked sensitive, but it is still stored in Terraform state. Keep state in encrypted, access-controlled backends and rotate the Grafana token if state access changes.
 
+## Alerts
+
+The coordinator Terraform creates a Cloud Monitoring policy for pricing-refresh ERROR logs. Set `pricing_refresh_alert_notification_channels` to Cloud Monitoring notification channel resource names to page on failures; leave it empty to create the policy without notifications while bootstrapping.
+
 ## Dashboards
 
 Import dashboard JSON from `docs/grafana/dashboards/` into Grafana Cloud:

--- a/infra/coordinator/pricing_monitoring.tf
+++ b/infra/coordinator/pricing_monitoring.tf
@@ -1,0 +1,73 @@
+# Logs-based alerting for the daily pricing-refresh job. The function uses
+# structured logs with `msg` values prefixed by `pricing-refresh:`; any ERROR
+# there means the pricing snapshot path degraded to fallback, partial writes,
+# or a full no-write failure.
+
+resource "google_logging_metric" "pricing_refresh_errors" {
+  project = var.project_id
+  name    = "${local.name_prefix}-pricing-refresh-errors"
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="${google_cloudfunctions2_function.pricing_refresh.name}"
+    jsonPayload.msg:"pricing-refresh:"
+    (severity>=ERROR OR jsonPayload.severity="ERROR")
+  EOT
+
+  label_extractors = {
+    message = "EXTRACT(jsonPayload.msg)"
+  }
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    unit         = "1"
+    display_name = "Pricing refresh errors"
+
+    labels {
+      key         = "message"
+      value_type  = "STRING"
+      description = "Structured pricing-refresh log message."
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "pricing_refresh_errors" {
+  project      = var.project_id
+  display_name = "${local.name_prefix} pricing-refresh errors"
+  combiner     = "OR"
+  enabled      = true
+
+  notification_channels = var.pricing_refresh_alert_notification_channels
+
+  documentation {
+    mime_type = "text/markdown"
+    content   = <<-EOT
+      The daily pricing-refresh function emitted at least one ERROR log.
+
+      Check Cloud Run / Cloud Functions logs for `${google_cloudfunctions2_function.pricing_refresh.name}` and verify the latest Firestore `pricing/{model_id}` documents still point at a fresh snapshot. Vendor fetch failures use fallback prices; write failures leave the affected model on last-known-good.
+    EOT
+  }
+
+  conditions {
+    display_name = "Pricing refresh emitted errors"
+
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.pricing_refresh_errors.name}\" resource.type=\"cloud_run_revision\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields      = ["metric.label.message"]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -109,3 +109,9 @@ variable "pricing_refresh_delete_protection" {
   type        = bool
   default     = false
 }
+
+variable "pricing_refresh_alert_notification_channels" {
+  description = "Optional Cloud Monitoring notification channel resource names for pricing-refresh failure alerts. Leave empty to create the policy without paging until channels are provisioned."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- add a logs-based metric for pricing-refresh ERROR logs
- add a Cloud Monitoring alert policy for pricing-refresh failures/degraded refreshes
- expose optional notification channel IDs via Terraform and document the alert wiring

Closes #79

## Checks
- terraform fmt -check infra/coordinator
- pnpm exec prettier --check docs/observability.md

Note: local terraform validate is blocked by the existing local provider schema/plugin loading issue; GitHub CI validates Terraform from a clean runner.