### PR TITLE
Add JWKS rotation health alert

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -25,6 +25,8 @@ When `otel_exporter_otlp_endpoint` is unset, Terraform sets `OTEL_TRACES_EXPORTE
 
 The coordinator Terraform creates a Cloud Monitoring policy for pricing-refresh ERROR logs. Set `pricing_refresh_alert_notification_channels` to Cloud Monitoring notification channel resource names to page on failures; leave it empty to create the policy without notifications while bootstrapping.
 
+It also creates a JWKS rotation health policy that alerts when the public `jwks.json` object has not been updated in 32 days. Set `jwks_rotation_alert_notification_channels` to route that alert.
+
 ## Dashboards
 
 Import dashboard JSON from `docs/grafana/dashboards/` into Grafana Cloud:

--- a/infra/coordinator/jwks_monitoring.tf
+++ b/infra/coordinator/jwks_monitoring.tf
@@ -1,0 +1,42 @@
+# JWKS rotation health alerting. The coordinator publishes `jwks.json` to a
+# public GCS bucket when keys are generated or rotated. This policy alerts if
+# that object has not been updated recently enough to prove the publishing path
+# still works.
+
+resource "google_monitoring_alert_policy" "jwks_stale" {
+  project      = var.project_id
+  display_name = "${local.name_prefix} JWKS publish stale"
+  combiner     = "OR"
+  enabled      = true
+
+  notification_channels = var.jwks_rotation_alert_notification_channels
+
+  documentation {
+    mime_type = "text/markdown"
+    content   = <<-EOT
+      `jwks.json` in bucket `${google_storage_bucket.jwks.name}` has not been updated in the last 32 days.
+
+      Check the coordinator JWKS publish/rotation path before rotating signing keys. Agents cache the public key set and rely on this object to verify coordinator-signed task JWTs.
+    EOT
+  }
+
+  conditions {
+    display_name = "JWKS object update count is zero"
+
+    condition_threshold {
+      filter          = "metric.type=\"storage.googleapis.com/api/request_count\" resource.type=\"gcs_bucket\" resource.label.bucket_name=\"${google_storage_bucket.jwks.name}\" metric.label.method=\"storage.objects.update\""
+      comparison      = "COMPARISON_LT"
+      threshold_value = 1
+      duration        = "0s"
+
+      aggregations {
+        alignment_period   = "2764800s" # 32 days
+        per_series_aligner = "ALIGN_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -115,3 +115,9 @@ variable "pricing_refresh_alert_notification_channels" {
   type        = list(string)
   default     = []
 }
+
+variable "jwks_rotation_alert_notification_channels" {
+  description = "Optional Cloud Monitoring notification channel resource names for JWKS rotation health alerts. Leave empty to create the policy without notifications while bootstrapping."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- add a Cloud Monitoring policy for stale JWKS publication health
- expose optional notification channel IDs for JWKS alerts
- document the JWKS rotation alert wiring alongside existing observability notes

Closes #80

## Checks
- terraform fmt -check infra/coordinator
- pnpm exec prettier --check docs/observability.md

Note: local terraform validate is blocked by the existing local provider schema/plugin loading issue; GitHub CI validates Terraform from a clean runner.