### PR TITLE
Add GCP orchestrator Terraform stack

### DIFF
--- a/infra/agent-gcp-orchestrator/.terraform.lock.hcl
+++ b/infra/agent-gcp-orchestrator/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.10"
+  hashes = [
+    "h1:olAQvz+q7YBzOi5knYOVPG43mpbCPcwYjVKEKu6hRGs=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.10"
+  hashes = [
+    "h1:R3HPM/5pVitHLBxb1QiUzDU0lEUR2nA7aKzC54JWe0o=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/agent-gcp-orchestrator/artifact_registry.tf
+++ b/infra/agent-gcp-orchestrator/artifact_registry.tf
@@ -1,0 +1,7 @@
+resource "google_artifact_registry_repository" "agent" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = "${local.name_prefix}-gcp-orchestrator"
+  description   = "Container images for the GCP/Orchestrator agent"
+  format        = "DOCKER"
+}

--- a/infra/agent-gcp-orchestrator/backend.hcl.example
+++ b/infra/agent-gcp-orchestrator/backend.hcl.example
@@ -1,0 +1,9 @@
+# Copy to backend.hcl per environment and pass to:
+#   terraform init -backend-config=backend.hcl
+#
+# Reuses the GCS state bucket created during infra/project bootstrap.
+# Separate prefix from infra/coordinator/, infra/project/, and the direct
+# GCP/Gemini agent module so this stack stays independently managed.
+
+bucket = "agent-tasker-tfstate-CHANGEME"
+prefix = "agent-gcp-orchestrator/dev"

--- a/infra/agent-gcp-orchestrator/cloud_run.tf
+++ b/infra/agent-gcp-orchestrator/cloud_run.tf
@@ -1,0 +1,152 @@
+# Cloud Run service for the GCP/Orchestrator agent.
+#
+# Isolation model per AGENTS.md:
+# - Dedicated runtime SA, distinct from the GCP/Gemini direct-call agent.
+# - Vertex AI access is present for Gemini-backed bidding and orchestration,
+#   while Gemini Enterprise / GAEP execution roles are granted separately via
+#   `gaep_agent_execution_roles`.
+# - The runtime contract is GAEP-only for execution. Direct single-call Vertex
+#   execution is intentionally left to the GCP/Gemini stack.
+# - `roles/run.invoker` is granted ONLY to the coordinator runtime SA. Neither
+#   GCP agent can invoke the other, and clients cannot invoke either directly.
+#
+# Ingress is public (INGRESS_TRAFFIC_ALL): the IAM layer enforces
+# coordinator-only invocation, matching the GCP/Gemini service shape.
+
+resource "google_service_account" "agent_runtime" {
+  project      = var.project_id
+  account_id   = local.agent_service_account_id
+  display_name = "GCP/Orchestrator agent runtime SA"
+  description  = "Identity for the GCP/Orchestrator agent — GAEP runtime execution only"
+}
+
+resource "google_project_iam_member" "agent_vertex" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.agent_runtime.email}"
+
+  condition {
+    title       = "vertex_publishers_google_only"
+    description = "Restrict to Google's first-party model publishers (Gemini family)"
+    expression  = "resource.name.startsWith(\"projects/${var.project_id}/locations/${var.region}/publishers/google/\")"
+  }
+}
+
+resource "google_project_iam_member" "agent_gaep_execution" {
+  for_each = var.gaep_agent_execution_roles
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.agent_runtime.email}"
+}
+
+resource "google_project_iam_member" "agent_logs" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.agent_runtime.email}"
+}
+
+resource "google_cloud_run_v2_service" "agent" {
+  project  = var.project_id
+  location = var.region
+  name     = "${local.name_prefix}-gcp-orchestrator"
+
+  deletion_protection = var.agent_delete_protection
+
+  # Public DNS endpoint; the run.invoker IAM binding below is the gate.
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = google_service_account.agent_runtime.email
+    timeout         = "${var.agent_request_timeout_seconds}s"
+
+    scaling {
+      min_instance_count = var.agent_min_instances
+      max_instance_count = var.agent_max_instances
+    }
+
+    containers {
+      image = var.agent_image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        # The shim is thin; GAEP does the multi-step work. Keep idle CPU off
+        # for cost while preserving startup boost for cold bid rounds.
+        cpu_idle          = true
+        startup_cpu_boost = true
+
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      env {
+        name  = "AGENT_ID"
+        value = "gcp-orchestrator"
+      }
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "GCP_LOCATION"
+        value = var.region
+      }
+      env {
+        name  = "GAEP_AGENT_RESOURCE_NAME"
+        value = var.gaep_agent_resource_name
+      }
+      env {
+        name  = "JWKS_URL"
+        value = var.jwks_url
+      }
+      env {
+        name  = "OTEL_SERVICE_NAME"
+        value = "agent-tasker-gcp-orchestrator"
+      }
+      env {
+        name  = "OTEL_TRACES_EXPORTER"
+        value = var.otel_exporter_otlp_endpoint == null ? "none" : "otlp"
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+        value = coalesce(var.otel_exporter_otlp_endpoint, "")
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_HEADERS"
+        value = coalesce(var.otel_exporter_otlp_headers, "")
+      }
+    }
+  }
+
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+    ]
+  }
+
+  depends_on = [
+    google_project_iam_member.agent_vertex,
+    google_project_iam_member.agent_gaep_execution,
+    google_project_iam_member.agent_logs,
+  ]
+}
+
+# Coordinator runtime SA is the only principal that can invoke this service.
+resource "google_cloud_run_v2_service_iam_member" "coordinator_only_invoker" {
+  project  = google_cloud_run_v2_service.agent.project
+  location = google_cloud_run_v2_service.agent.location
+  name     = google_cloud_run_v2_service.agent.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${var.coordinator_service_account_email}"
+}

--- a/infra/agent-gcp-orchestrator/main.tf
+++ b/infra/agent-gcp-orchestrator/main.tf
@@ -1,0 +1,28 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+
+  default_labels = local.common_labels
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+
+  default_labels = local.common_labels
+}
+
+locals {
+  name_prefix = "${var.project}-${var.env}"
+  # Service account IDs cap at 30 chars, shorter than Cloud Run service names.
+  agent_service_account_id = "${substr(var.project, 0, 12)}-${substr(var.env, 0, 8)}-orch"
+
+  common_labels = merge(
+    {
+      project = var.project
+      env     = var.env
+      module  = "agent-gcp-orchestrator"
+    },
+    var.labels,
+  )
+}

--- a/infra/agent-gcp-orchestrator/outputs.tf
+++ b/infra/agent-gcp-orchestrator/outputs.tf
@@ -1,0 +1,14 @@
+output "agent_url" {
+  description = "Auto-generated Cloud Run URL for the GCP/Orchestrator agent. Coordinator's per-agent endpoint config points at this."
+  value       = google_cloud_run_v2_service.agent.uri
+}
+
+output "agent_service_account_email" {
+  description = "GCP/Orchestrator runtime SA. Useful for cross-module IAM checks (e.g. confirming this SA is *not* on the direct GCP/Gemini service)."
+  value       = google_service_account.agent_runtime.email
+}
+
+output "agent_image_repo" {
+  description = "Artifact Registry path CI/CD pushes GCP/Orchestrator agent images to. Format: LOCATION-docker.pkg.dev/PROJECT/REPO."
+  value       = "${google_artifact_registry_repository.agent.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.agent.repository_id}"
+}

--- a/infra/agent-gcp-orchestrator/variables.tf
+++ b/infra/agent-gcp-orchestrator/variables.tf
@@ -1,0 +1,99 @@
+variable "project_id" {
+  description = "GCP project ID. Must be bootstrapped via infra/project first."
+  type        = string
+}
+
+variable "project" {
+  description = "Project name prefix used in resource naming and labels."
+  type        = string
+  default     = "agent-tasker"
+}
+
+variable "env" {
+  description = "Environment name (e.g. dev, staging, prod). Used in resource names."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{1,16}$", var.env))
+    error_message = "env must be 1-16 chars of [a-z0-9-]."
+  }
+}
+
+variable "region" {
+  description = "GCP region for the agent's Cloud Run service. Must match the Vertex AI and Gemini Enterprise runtime location."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "labels" {
+  description = "Extra labels to merge onto every resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "agent_image" {
+  description = "Fully-qualified container image (LOCATION-docker.pkg.dev/PROJECT/REPO/gcp-orchestrator:TAG). Defaults to Google's hello placeholder so `terraform apply` succeeds on a fresh project before the real image is built and pushed."
+  type        = string
+  default     = "gcr.io/cloudrun/hello"
+}
+
+variable "agent_min_instances" {
+  description = "Minimum Cloud Run instances. Zero scales to nothing at idle; bump to 1 for prod-grade warm-start."
+  type        = number
+  default     = 0
+}
+
+variable "agent_max_instances" {
+  description = "Cloud Run autoscale cap. The orchestrator can run longer execute calls, but concurrency remains per-request."
+  type        = number
+  default     = 10
+}
+
+variable "agent_request_timeout_seconds" {
+  description = "Per-request timeout. GAEP-backed execution can take multiple tool-using steps, so this stack gets more headroom than direct Gemini."
+  type        = number
+  default     = 540
+}
+
+variable "agent_delete_protection" {
+  description = "Cloud Run service-level delete protection. False in dev for iteration; true in prod."
+  type        = bool
+  default     = false
+}
+
+variable "gaep_agent_execution_roles" {
+  description = "Additional project IAM roles required for the GCP/Orchestrator runtime to execute Gemini Enterprise / GAEP resources. Keep this separate from the direct GCP/Gemini SA and override if the GAEP app needs narrower or additional roles."
+  type        = set(string)
+  default = [
+    "roles/discoveryengine.agentspaceUser",
+  ]
+}
+
+variable "gaep_agent_resource_name" {
+  description = "Optional fully-qualified Gemini Enterprise / GAEP agent resource name. Left empty until the runtime app is created in the follow-up shim work."
+  type        = string
+  default     = ""
+}
+
+variable "coordinator_service_account_email" {
+  description = "Coordinator runtime SA email (output `coordinator_service_account_email` from infra/coordinator). The only principal granted `roles/run.invoker` on this agent."
+  type        = string
+}
+
+variable "jwks_url" {
+  description = "Coordinator JWKS URL (output `jwks_public_url` from infra/coordinator) the agent fetches public keys from."
+  type        = string
+}
+
+variable "otel_exporter_otlp_endpoint" {
+  description = "Optional Grafana Cloud OTLP endpoint (for example https://otlp-gateway-prod-us-central-0.grafana.net/otlp). When null, Cloud Run sets OTEL_TRACES_EXPORTER=none so local/dev deploys do not emit traces."
+  type        = string
+  default     = null
+}
+
+variable "otel_exporter_otlp_headers" {
+  description = "Optional OTLP headers for Grafana Cloud, usually Authorization=Basic <base64(instance_id:token)>. Stored in Terraform state; prefer environment-specific encrypted state."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/infra/agent-gcp-orchestrator/versions.tf
+++ b/infra/agent-gcp-orchestrator/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.10"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.10"
+    }
+  }
+
+  backend "gcs" {}
+}

--- a/infra/project/apis.tf
+++ b/infra/project/apis.tf
@@ -1,7 +1,6 @@
 # APIs required across the project. Phase 1 minimum plus the small set
 # already known to be needed downstream — enabling APIs is idempotent and
-# free; the cost of forgetting one is debugging time, not dollars. Add
-# GAEP-specific APIs here when the orchestrator stack lands (#90+).
+# free; the cost of forgetting one is debugging time, not dollars.
 locals {
   required_apis = toset([
     "aiplatform.googleapis.com",       # Vertex AI (Gemini direct + GAEP execution)
@@ -10,6 +9,7 @@ locals {
     "cloudfunctions.googleapis.com",   # pricing refresh function (#35)
     "cloudscheduler.googleapis.com",   # pricing refresh trigger (#35)
     "compute.googleapis.com",          # backbone for Cloud Run / external HTTPS LB
+    "discoveryengine.googleapis.com",  # Gemini Enterprise / GAEP orchestrator agent (#90)
     "firestore.googleapis.com",        # ledger + pricing collections (#20, #24)
     "iam.googleapis.com",              # SAs + IAM
     "iamcredentials.googleapis.com",   # SA impersonation (CI, local dev)


### PR DESCRIPTION
## Summary
- add an independent infra/agent-gcp-orchestrator Terraform module with its own Cloud Run service, runtime service account, Artifact Registry repo, and outputs
- grant coordinator-only Cloud Run invoker access, Vertex AI access, and configurable Gemini Enterprise / GAEP execution roles
- enable the Discovery Engine API in the project bootstrap module for Gemini Enterprise / GAEP

## Validation
- terraform fmt -check -recursive infra
- terraform -chdir=infra/agent-gcp-orchestrator init -backend=false
- terraform -chdir=infra/agent-gcp-orchestrator validate
- terraform -chdir=infra/project validate (blocked locally by provider plugin schema startup failure in the existing project module cache)

Closes #90