### PR TITLE
Add GCP orchestrator Cloud Run shim

### DIFF
--- a/agent/gcp-orchestrator/.dockerignore
+++ b/agent/gcp-orchestrator/.dockerignore
@@ -1,0 +1,10 @@
+**/node_modules/
+**/dist/
+**/.terraform/
+**/*.tsbuildinfo
+.git/
+.github/
+.husky/
+docs/
+*.md
+.DS_Store

--- a/agent/gcp-orchestrator/Dockerfile
+++ b/agent/gcp-orchestrator/Dockerfile
@@ -1,0 +1,31 @@
+# Multi-stage build for the GCP/Orchestrator agent.
+#
+# Build from the repo root:
+#   docker build -f agent/gcp-orchestrator/Dockerfile -t gcp-orchestrator:dev .
+#
+# Push to Artifact Registry (image repo from the Terraform output):
+#   gcloud auth configure-docker LOCATION-docker.pkg.dev
+#   docker tag gcp-orchestrator:dev LOCATION-docker.pkg.dev/PROJECT/REPO/gcp-orchestrator:TAG
+#   docker push LOCATION-docker.pkg.dev/PROJECT/REPO/gcp-orchestrator:TAG
+
+FROM node:22-alpine AS build
+RUN corepack enable
+WORKDIR /workspace
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY protocol/ ./protocol/
+COPY agent/ ./agent/
+COPY coordinator/ ./coordinator/
+COPY infra/ ./infra/
+COPY eval/ ./eval/
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter '@agent-tasker/agent-gcp-orchestrator...' build
+RUN pnpm --filter @agent-tasker/agent-gcp-orchestrator deploy --prod /app
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=build /app ./
+ENV NODE_ENV=production
+ENV PORT=8080
+EXPOSE 8080
+USER node
+CMD ["node", "dist/server.js"]

--- a/agent/gcp-orchestrator/package.json
+++ b/agent/gcp-orchestrator/package.json
@@ -6,12 +6,16 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
     "@agent-tasker/agent": "workspace:*",
-    "@agent-tasker/protocol": "workspace:*"
+    "@agent-tasker/protocol": "workspace:*",
+    "@hono/node-server": "^2.0.3",
+    "hono": "^4.12.21",
+    "jose": "^6.2.3"
   }
 }

--- a/agent/gcp-orchestrator/src/app.ts
+++ b/agent/gcp-orchestrator/src/app.ts
@@ -1,0 +1,92 @@
+import { Hono } from "hono";
+import { AnnounceRequestSchema, ExecuteRequestSchema, type NoBid } from "@agent-tasker/protocol";
+import {
+  getTokenClaims,
+  requireTaskToken,
+  withAgentSpan,
+  type TaskTokenVerifier,
+} from "@agent-tasker/agent";
+import { AGENT_ID } from "./index.js";
+import { executeViaGaep, type GaepRuntimeClient } from "./runtime.js";
+
+export interface CreateAppOptions {
+  verifier: TaskTokenVerifier;
+  runtime: GaepRuntimeClient;
+}
+
+export function createApp(opts: CreateAppOptions) {
+  const app = new Hono();
+
+  app.get("/health", (c) => c.json({ ok: true, agent_id: AGENT_ID }));
+
+  app.post("/bid", requireTaskToken(opts.verifier, "bid"), async (c) => {
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    const parsed = AnnounceRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: { code: "invalid_request", message: "bad announce body" } }, 400);
+    }
+
+    const claims = getTokenClaims(c);
+    if (claims.task_id !== parsed.data.task_id) {
+      return c.json(
+        { error: { code: "unauthorized", message: "token task_id does not match body" } },
+        401,
+      );
+    }
+
+    const result = await withAgentSpan(
+      "agent.bid",
+      { task_id: parsed.data.task_id, agent_id: AGENT_ID, phase: "bid" },
+      async (span): Promise<NoBid> => {
+        span.setAttribute("no_bid_reason", "capability");
+        return {
+          task_id: parsed.data.task_id,
+          agent_id: AGENT_ID,
+          status: "no_bid",
+          reason: "capability",
+        };
+      },
+    );
+    return c.json(result);
+  });
+
+  app.post("/execute", requireTaskToken(opts.verifier, "execute"), async (c) => {
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    const parsed = ExecuteRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: { code: "invalid_request", message: "bad execute body" } }, 400);
+    }
+
+    const claims = getTokenClaims(c);
+    if (claims.task_id !== parsed.data.task_id) {
+      return c.json(
+        { error: { code: "unauthorized", message: "token task_id does not match body" } },
+        401,
+      );
+    }
+
+    const result = await withAgentSpan(
+      "agent.execute",
+      { task_id: parsed.data.task_id, agent_id: AGENT_ID, phase: "execute" },
+      async (span) => {
+        const executeResult = await executeViaGaep(parsed.data, opts.runtime);
+        span.setAttributes({
+          input_tokens: executeResult.actual_usage.input_tokens,
+          output_tokens: executeResult.actual_usage.output_tokens,
+        });
+        return executeResult;
+      },
+    );
+    return c.json(result);
+  });
+
+  app.onError((err, c) => {
+    console.error("gcp-orchestrator unhandled error", err);
+    return c.json(
+      { error: { code: "internal_error", message: "agent failed to handle request" } },
+      500,
+    );
+  });
+
+  return app;
+}

--- a/agent/gcp-orchestrator/src/index.ts
+++ b/agent/gcp-orchestrator/src/index.ts
@@ -9,3 +9,6 @@ export function startTelemetry(env?: NodeJS.ProcessEnv): AgentTelemetryHandle | 
     ...(env ? { env } : {}),
   });
 }
+
+export * from "./app.js";
+export * from "./runtime.js";

--- a/agent/gcp-orchestrator/src/runtime.ts
+++ b/agent/gcp-orchestrator/src/runtime.ts
@@ -1,0 +1,47 @@
+import type { ExecuteRequest, Result } from "@agent-tasker/protocol";
+import { AGENT_ID } from "./index.js";
+
+export interface GaepRuntimeResult {
+  output: string;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+export interface GaepRuntimeClient {
+  execute(req: ExecuteRequest): Promise<GaepRuntimeResult>;
+}
+
+export interface GaepRuntimeClientOptions {
+  agentResourceName: string | undefined;
+}
+
+export function createGaepRuntimeClient(opts: GaepRuntimeClientOptions): GaepRuntimeClient {
+  const agentResourceName = opts.agentResourceName?.trim();
+
+  return {
+    async execute(): Promise<GaepRuntimeResult> {
+      if (!agentResourceName) {
+        throw new Error("GAEP agent resource name is required before execution can run");
+      }
+      throw new Error(
+        `GAEP runtime client for ${agentResourceName} is not implemented yet; issue #94 wires the Gemini Enterprise execution call`,
+      );
+    },
+  };
+}
+
+export async function executeViaGaep(
+  req: ExecuteRequest,
+  client: GaepRuntimeClient,
+): Promise<Result> {
+  const result = await client.execute(req);
+  return {
+    task_id: req.task_id,
+    agent_id: AGENT_ID,
+    output: result.output,
+    actual_usage: {
+      input_tokens: result.input_tokens,
+      output_tokens: result.output_tokens,
+    },
+  };
+}

--- a/agent/gcp-orchestrator/src/server.ts
+++ b/agent/gcp-orchestrator/src/server.ts
@@ -1,0 +1,34 @@
+import { serve } from "@hono/node-server";
+import { createRemoteJWKSet } from "jose";
+import { createTaskTokenVerifier } from "@agent-tasker/agent";
+import { AGENT_ID, startTelemetry } from "./index.js";
+import { createApp } from "./app.js";
+import { createGaepRuntimeClient } from "./runtime.js";
+
+const telemetry = startTelemetry();
+const port = Number(process.env["PORT"] ?? 8080);
+const jwksUrl = process.env["JWKS_URL"];
+const gaepAgentResourceName = process.env["GAEP_AGENT_RESOURCE_NAME"];
+
+if (!jwksUrl) {
+  console.error("JWKS_URL env var is required");
+  process.exit(1);
+}
+
+const verifier = createTaskTokenVerifier({
+  getKey: createRemoteJWKSet(new URL(jwksUrl), { cacheMaxAge: 10 * 60_000 }),
+  expectedAudience: AGENT_ID,
+});
+
+const runtime = createGaepRuntimeClient({ agentResourceName: gaepAgentResourceName });
+const app = createApp({ verifier, runtime });
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`${AGENT_ID} agent listening on :${info.port}`);
+});
+
+process.once("SIGTERM", () => {
+  void telemetry?.shutdown().finally(() => {
+    process.exit(0);
+  });
+});

--- a/agent/gcp-orchestrator/test/app.test.ts
+++ b/agent/gcp-orchestrator/test/app.test.ts
@@ -1,0 +1,168 @@
+import { Hono } from "hono";
+import {
+  SignJWT,
+  createLocalJWKSet,
+  exportJWK,
+  exportPKCS8,
+  generateKeyPair,
+  importPKCS8,
+  type JWK,
+} from "jose";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTaskTokenVerifier } from "@agent-tasker/agent";
+import { COORDINATOR_ISSUER, TOKEN_TTL_SECONDS, type JwtPhase } from "@agent-tasker/protocol";
+import { createApp } from "../src/app.js";
+import type { GaepRuntimeClient } from "../src/runtime.js";
+
+const KID = "test-kid";
+const AUDIENCE = "gcp-orchestrator" as const;
+
+let privateKeyPem: string;
+let publicJwk: JWK;
+let app: Hono;
+let executeCalls = 0;
+
+async function token(opts: {
+  taskId?: string;
+  phase?: JwtPhase;
+  audience?: string;
+  now?: Date;
+}): Promise<string> {
+  const key = await importPKCS8(privateKeyPem, "RS256");
+  const iat = Math.floor((opts.now ?? new Date()).getTime() / 1000);
+  return new SignJWT({
+    task_id: opts.taskId ?? "task-1",
+    phase: opts.phase ?? "bid",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: KID, typ: "JWT" })
+    .setIssuer(COORDINATOR_ISSUER)
+    .setSubject(COORDINATOR_ISSUER)
+    .setAudience(opts.audience ?? AUDIENCE)
+    .setIssuedAt(iat)
+    .setExpirationTime(iat + TOKEN_TTL_SECONDS)
+    .sign(key);
+}
+
+beforeAll(async () => {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  privateKeyPem = await exportPKCS8(privateKey);
+  publicJwk = await exportJWK(publicKey);
+  publicJwk.kid = KID;
+});
+
+beforeEach(() => {
+  executeCalls = 0;
+  const verifier = createTaskTokenVerifier({
+    getKey: createLocalJWKSet({ keys: [publicJwk] }),
+    expectedAudience: AUDIENCE,
+  });
+  const runtime: GaepRuntimeClient = {
+    async execute(req) {
+      executeCalls += 1;
+      return {
+        output: `orchestrated: ${req.spec.prompt}`,
+        input_tokens: 7000,
+        output_tokens: 1200,
+      };
+    },
+  };
+  app = createApp({ verifier, runtime });
+});
+
+describe("GET /health", () => {
+  it("returns ok without auth", async () => {
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, agent_id: "gcp-orchestrator" });
+  });
+});
+
+describe("POST /bid", () => {
+  it("returns no_bid until the orchestrator estimator lands", async () => {
+    const t = await token({ taskId: "task-bid-1", phase: "bid" });
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-bid-1", spec: { prompt: "plan work" } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      task_id: "task-bid-1",
+      agent_id: "gcp-orchestrator",
+      status: "no_bid",
+      reason: "capability",
+    });
+  });
+
+  it("rejects missing bearer with 401", async () => {
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task_id: "task-1", spec: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects execute-phase token on /bid with 401", async () => {
+    const t = await token({ phase: "execute" });
+    const res = await app.request("/bid", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-1", spec: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /execute", () => {
+  it("routes valid execute requests into the GAEP runtime adapter", async () => {
+    const t = await token({ taskId: "task-exec-1", phase: "execute" });
+    const res = await app.request("/execute", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-exec-1", spec: { prompt: "do the thing" } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(executeCalls).toBe(1);
+    expect(await res.json()).toEqual({
+      task_id: "task-exec-1",
+      agent_id: "gcp-orchestrator",
+      output: "orchestrated: do the thing",
+      actual_usage: { input_tokens: 7000, output_tokens: 1200 },
+    });
+  });
+
+  it("rejects bid-phase token on /execute with 401", async () => {
+    const t = await token({ phase: "bid" });
+    const res = await app.request("/execute", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-1", spec: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects mismatched task_id between JWT and body with 401", async () => {
+    const t = await token({ taskId: "task-token", phase: "execute" });
+    const res = await app.request("/execute", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-different", spec: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(401);
+    expect(executeCalls).toBe(0);
+  });
+
+  it("returns 400 on malformed body", async () => {
+    const t = await token({ phase: "execute" });
+    const res = await app.request("/execute", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${t}` },
+      body: JSON.stringify({ task_id: "task-1" }),
+    });
+    expect(res.status).toBe(400);
+    expect(executeCalls).toBe(0);
+  });
+});

--- a/agent/gcp-orchestrator/tsconfig.build.json
+++ b/agent/gcp-orchestrator/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/agent/gcp-orchestrator/tsconfig.json
+++ b/agent/gcp-orchestrator/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,15 @@ importers:
       '@agent-tasker/protocol':
         specifier: workspace:*
         version: link:../../protocol
+      '@hono/node-server':
+        specifier: ^2.0.3
+        version: 2.0.3(hono@4.12.21)
+      hono:
+        specifier: ^4.12.21
+        version: 4.12.21
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
 
   coordinator:
     dependencies:


### PR DESCRIPTION
## Summary
- add a Hono Cloud Run shim for the GCP/Orchestrator agent with /health, /bid, and /execute
- enforce coordinator JWT phase checks and task_id/body matching before bid or execute handling
- route /execute through a GAEP runtime adapter abstraction, with the concrete Gemini Enterprise call left for #94
- add Dockerfile, build config, package deps, and shim tests

## Validation
- pnpm --filter @agent-tasker/agent-gcp-orchestrator test
- pnpm --filter @agent-tasker/agent-gcp-orchestrator typecheck
- pnpm --filter @agent-tasker/agent-gcp-orchestrator build
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... build
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... test
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... typecheck

Closes #91