### PR TITLE
Add GCP orchestrator bid estimator

### DIFF
--- a/agent/gcp-orchestrator/package.json
+++ b/agent/gcp-orchestrator/package.json
@@ -14,8 +14,10 @@
   "dependencies": {
     "@agent-tasker/agent": "workspace:*",
     "@agent-tasker/protocol": "workspace:*",
+    "@google-cloud/vertexai": "^1.12.0",
     "@hono/node-server": "^2.0.3",
     "hono": "^4.12.21",
-    "jose": "^6.2.3"
+    "jose": "^6.2.3",
+    "zod": "^3.25.76"
   }
 }

--- a/agent/gcp-orchestrator/src/app.ts
+++ b/agent/gcp-orchestrator/src/app.ts
@@ -1,5 +1,10 @@
 import { Hono } from "hono";
-import { AnnounceRequestSchema, ExecuteRequestSchema, type NoBid } from "@agent-tasker/protocol";
+import {
+  AnnounceRequestSchema,
+  ExecuteRequestSchema,
+  isNoBid,
+  type PricingEntry,
+} from "@agent-tasker/protocol";
 import {
   getTokenClaims,
   requireTaskToken,
@@ -7,10 +12,14 @@ import {
   type TaskTokenVerifier,
 } from "@agent-tasker/agent";
 import { AGENT_ID } from "./index.js";
+import { handleBid } from "./bid/handler.js";
+import type { BidEstimator } from "./bid/estimator.js";
 import { executeViaGaep, type GaepRuntimeClient } from "./runtime.js";
 
 export interface CreateAppOptions {
   verifier: TaskTokenVerifier;
+  estimator: BidEstimator;
+  pricing: PricingEntry;
   runtime: GaepRuntimeClient;
 }
 
@@ -37,14 +46,17 @@ export function createApp(opts: CreateAppOptions) {
     const result = await withAgentSpan(
       "agent.bid",
       { task_id: parsed.data.task_id, agent_id: AGENT_ID, phase: "bid" },
-      async (span): Promise<NoBid> => {
-        span.setAttribute("no_bid_reason", "capability");
-        return {
-          task_id: parsed.data.task_id,
-          agent_id: AGENT_ID,
-          status: "no_bid",
-          reason: "capability",
-        };
+      async (span) => {
+        const bidResult = await handleBid(parsed.data, {
+          estimator: opts.estimator,
+          pricing: opts.pricing,
+        });
+        if (isNoBid(bidResult)) {
+          span.setAttribute("no_bid_reason", bidResult.reason);
+        } else {
+          span.setAttributes({ tier: bidResult.tier, bid_usd: bidResult.bid_usd });
+        }
+        return bidResult;
       },
     );
     return c.json(result);

--- a/agent/gcp-orchestrator/src/bid/estimator.ts
+++ b/agent/gcp-orchestrator/src/bid/estimator.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import { VertexAI, type GenerativeModel } from "@google-cloud/vertexai";
+import type { TaskSpec } from "@agent-tasker/protocol";
+
+export interface OrchestratorTokenEstimate {
+  input_tokens: number;
+  output_tokens: number;
+  steps: number;
+  tool_calls: number;
+}
+
+export interface BidEstimator {
+  estimate(spec: TaskSpec): Promise<OrchestratorTokenEstimate>;
+}
+
+export interface GenerativeJsonClient {
+  generateJson(prompt: string): Promise<unknown>;
+}
+
+const EstimateResultSchema = z.object({
+  est_steps: z.number().int().positive(),
+  est_tool_calls: z.number().int().nonnegative(),
+  est_input_tokens_per_step: z.number().int().nonnegative(),
+  est_output_tokens_per_step: z.number().int().nonnegative(),
+  est_tool_call_input_tokens: z.number().int().nonnegative(),
+  est_platform_overhead_output_token_equivalent: z.number().int().nonnegative().default(0),
+});
+
+const ESTIMATE_RESPONSE_SCHEMA = {
+  type: "object",
+  properties: {
+    est_steps: { type: "integer", minimum: 1 },
+    est_tool_calls: { type: "integer", minimum: 0 },
+    est_input_tokens_per_step: { type: "integer", minimum: 0 },
+    est_output_tokens_per_step: { type: "integer", minimum: 0 },
+    est_tool_call_input_tokens: { type: "integer", minimum: 0 },
+    est_platform_overhead_output_token_equivalent: { type: "integer", minimum: 0 },
+  },
+  required: [
+    "est_steps",
+    "est_tool_calls",
+    "est_input_tokens_per_step",
+    "est_output_tokens_per_step",
+    "est_tool_call_input_tokens",
+  ],
+} as const;
+
+function buildPrompt(spec: TaskSpec): string {
+  return `You estimate cost for a Gemini Enterprise Agent Platform orchestrator.
+
+The executor is a multi-step GAEP runtime over Gemini 2.5 Pro plus registered tools.
+Estimate the likely number of reasoning/tool steps and token usage. Do not solve the task.
+
+Task prompt:
+---
+${spec.prompt}
+---
+${spec.min_tier ? `Minimum tier requested by client: ${spec.min_tier}\n` : ""}${
+    spec.attachments?.length
+      ? `Attachments: ${spec.attachments.length} (referenced by content hash; tools may need to fetch them)\n`
+      : ""
+  }
+Return JSON with conservative integer estimates:
+- est_steps: total GAEP reasoning steps, minimum 1
+- est_tool_calls: total tool invocations across the run
+- est_input_tokens_per_step: average input tokens per GAEP step
+- est_output_tokens_per_step: average output tokens per GAEP step
+- est_tool_call_input_tokens: extra input tokens per tool call for tool results/context
+- est_platform_overhead_output_token_equivalent: optional GAEP platform overhead expressed as output-token-equivalent units`;
+}
+
+export class OrchestratorBidEstimator implements BidEstimator {
+  constructor(private readonly client: GenerativeJsonClient) {}
+
+  async estimate(spec: TaskSpec): Promise<OrchestratorTokenEstimate> {
+    const raw = await this.client.generateJson(buildPrompt(spec));
+    const parsed = EstimateResultSchema.parse(raw);
+    return {
+      steps: parsed.est_steps,
+      tool_calls: parsed.est_tool_calls,
+      input_tokens:
+        parsed.est_steps * parsed.est_input_tokens_per_step +
+        parsed.est_tool_calls * parsed.est_tool_call_input_tokens,
+      output_tokens:
+        parsed.est_steps * parsed.est_output_tokens_per_step +
+        parsed.est_platform_overhead_output_token_equivalent,
+    };
+  }
+}
+
+export interface VertexJsonClientOptions {
+  project: string;
+  location: string;
+  model: string;
+}
+
+export function createVertexJsonClient(opts: VertexJsonClientOptions): GenerativeJsonClient {
+  const vertex = new VertexAI({ project: opts.project, location: opts.location });
+  const model: GenerativeModel = vertex.getGenerativeModel({ model: opts.model });
+
+  return {
+    async generateJson(prompt: string): Promise<unknown> {
+      const result = await model.generateContent({
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+        generationConfig: {
+          responseMimeType: "application/json",
+          // @ts-expect-error responseSchema typing in the Vertex SDK is
+          // loose; we pass our concrete object literal directly.
+          responseSchema: ESTIMATE_RESPONSE_SCHEMA,
+        },
+      });
+      const candidate = result.response.candidates?.[0];
+      const text = candidate?.content?.parts?.[0]?.text;
+      if (!text) throw new Error("Vertex AI Gemini Flash returned no text");
+      return JSON.parse(text);
+    },
+  };
+}

--- a/agent/gcp-orchestrator/src/bid/handler.ts
+++ b/agent/gcp-orchestrator/src/bid/handler.ts
@@ -1,0 +1,59 @@
+import {
+  computeBidUsd,
+  type AnnounceRequest,
+  type Bid,
+  type BidResponse,
+  type PricingEntry,
+} from "@agent-tasker/protocol";
+import { AGENT_ID } from "../index.js";
+import type { BidEstimator } from "./estimator.js";
+
+export const EXECUTION_MODEL_ID = "gemini-2-5-pro";
+export const EXECUTION_MODEL_FAMILY = "gemini" as const;
+export const EXECUTION_TIER = "frontier" as const;
+
+const BID_TTL_MS = 60_000;
+
+export interface BidHandlerDeps {
+  estimator: BidEstimator;
+  pricing: PricingEntry;
+  now?: () => Date;
+  sign?: (taskId: string) => string;
+}
+
+export async function handleBid(req: AnnounceRequest, deps: BidHandlerDeps): Promise<BidResponse> {
+  const now = deps.now?.() ?? new Date();
+  try {
+    const estimate = await deps.estimator.estimate(req.spec);
+    const bidUsd = computeBidUsd({
+      est_input_tokens: estimate.input_tokens,
+      est_output_tokens: estimate.output_tokens,
+      price_in_usd_per_mtoken: deps.pricing.price_in_usd_per_mtoken,
+      price_out_usd_per_mtoken: deps.pricing.price_out_usd_per_mtoken,
+    });
+
+    const bid: Bid = {
+      task_id: req.task_id,
+      agent_id: AGENT_ID,
+      tier: EXECUTION_TIER,
+      model_family: EXECUTION_MODEL_FAMILY,
+      model_id: EXECUTION_MODEL_ID,
+      est_input_tokens: estimate.input_tokens,
+      est_output_tokens: estimate.output_tokens,
+      price_in_usd_per_mtoken: deps.pricing.price_in_usd_per_mtoken,
+      price_out_usd_per_mtoken: deps.pricing.price_out_usd_per_mtoken,
+      bid_usd: bidUsd,
+      expires_at: new Date(now.getTime() + BID_TTL_MS).toISOString(),
+      signature: deps.sign?.(req.task_id) ?? "stub-signature",
+    };
+    return bid;
+  } catch (err) {
+    void err;
+    return {
+      task_id: req.task_id,
+      agent_id: AGENT_ID,
+      status: "no_bid",
+      reason: "internal_error",
+    };
+  }
+}

--- a/agent/gcp-orchestrator/src/bid/index.ts
+++ b/agent/gcp-orchestrator/src/bid/index.ts
@@ -1,0 +1,2 @@
+export * from "./estimator.js";
+export * from "./handler.js";

--- a/agent/gcp-orchestrator/src/index.ts
+++ b/agent/gcp-orchestrator/src/index.ts
@@ -11,4 +11,5 @@ export function startTelemetry(env?: NodeJS.ProcessEnv): AgentTelemetryHandle | 
 }
 
 export * from "./app.js";
+export * from "./bid/index.js";
 export * from "./runtime.js";

--- a/agent/gcp-orchestrator/src/server.ts
+++ b/agent/gcp-orchestrator/src/server.ts
@@ -1,17 +1,22 @@
 import { serve } from "@hono/node-server";
 import { createRemoteJWKSet } from "jose";
 import { createTaskTokenVerifier } from "@agent-tasker/agent";
+import { FALLBACK_PRICING } from "@agent-tasker/protocol";
 import { AGENT_ID, startTelemetry } from "./index.js";
 import { createApp } from "./app.js";
+import { OrchestratorBidEstimator, createVertexJsonClient } from "./bid/estimator.js";
 import { createGaepRuntimeClient } from "./runtime.js";
 
 const telemetry = startTelemetry();
 const port = Number(process.env["PORT"] ?? 8080);
+const projectId = process.env["GCP_PROJECT_ID"];
+const location = process.env["GCP_LOCATION"] ?? "us-central1";
 const jwksUrl = process.env["JWKS_URL"];
 const gaepAgentResourceName = process.env["GAEP_AGENT_RESOURCE_NAME"];
+const bidModel = process.env["BID_MODEL"] ?? "gemini-2.5-flash";
 
-if (!jwksUrl) {
-  console.error("JWKS_URL env var is required");
+if (!projectId || !jwksUrl) {
+  console.error("GCP_PROJECT_ID and JWKS_URL env vars are required");
   process.exit(1);
 }
 
@@ -20,8 +25,18 @@ const verifier = createTaskTokenVerifier({
   expectedAudience: AGENT_ID,
 });
 
+const pricing = FALLBACK_PRICING["gemini-2-5-pro"];
+if (!pricing) {
+  console.error("missing FALLBACK_PRICING entry for gemini-2-5-pro");
+  process.exit(1);
+}
+
+const estimator = new OrchestratorBidEstimator(
+  createVertexJsonClient({ project: projectId, location, model: bidModel }),
+);
+
 const runtime = createGaepRuntimeClient({ agentResourceName: gaepAgentResourceName });
-const app = createApp({ verifier, runtime });
+const app = createApp({ verifier, estimator, pricing, runtime });
 
 serve({ fetch: app.fetch, port }, (info) => {
   console.log(`${AGENT_ID} agent listening on :${info.port}`);

--- a/agent/gcp-orchestrator/test/app.test.ts
+++ b/agent/gcp-orchestrator/test/app.test.ts
@@ -10,8 +10,14 @@ import {
 } from "jose";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createTaskTokenVerifier } from "@agent-tasker/agent";
-import { COORDINATOR_ISSUER, TOKEN_TTL_SECONDS, type JwtPhase } from "@agent-tasker/protocol";
+import {
+  COORDINATOR_ISSUER,
+  FALLBACK_PRICING,
+  TOKEN_TTL_SECONDS,
+  type JwtPhase,
+} from "@agent-tasker/protocol";
 import { createApp } from "../src/app.js";
+import type { BidEstimator } from "../src/bid/estimator.js";
 import type { GaepRuntimeClient } from "../src/runtime.js";
 
 const KID = "test-kid";
@@ -66,7 +72,17 @@ beforeEach(() => {
       };
     },
   };
-  app = createApp({ verifier, runtime });
+  const estimator: BidEstimator = {
+    async estimate() {
+      return { input_tokens: 12_000, output_tokens: 2_000, steps: 3, tool_calls: 2 };
+    },
+  };
+  app = createApp({
+    verifier,
+    estimator,
+    pricing: FALLBACK_PRICING["gemini-2-5-pro"]!,
+    runtime,
+  });
 });
 
 describe("GET /health", () => {
@@ -78,7 +94,7 @@ describe("GET /health", () => {
 });
 
 describe("POST /bid", () => {
-  it("returns no_bid until the orchestrator estimator lands", async () => {
+  it("returns a Bid for a valid request", async () => {
     const t = await token({ taskId: "task-bid-1", phase: "bid" });
     const res = await app.request("/bid", {
       method: "POST",
@@ -87,12 +103,16 @@ describe("POST /bid", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
-      task_id: "task-bid-1",
-      agent_id: "gcp-orchestrator",
-      status: "no_bid",
-      reason: "capability",
-    });
+    const body = (await res.json()) as {
+      agent_id: string;
+      bid_usd: number;
+      tier: string;
+      est_input_tokens: number;
+    };
+    expect(body.agent_id).toBe("gcp-orchestrator");
+    expect(body.tier).toBe("frontier");
+    expect(body.est_input_tokens).toBe(12_000);
+    expect(body.bid_usd).toBeGreaterThan(0);
   });
 
   it("rejects missing bearer with 401", async () => {

--- a/agent/gcp-orchestrator/test/bid/estimator.test.ts
+++ b/agent/gcp-orchestrator/test/bid/estimator.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { OrchestratorBidEstimator, type GenerativeJsonClient } from "../../src/bid/estimator.js";
+
+describe("OrchestratorBidEstimator", () => {
+  it("folds steps, tool calls, and platform overhead into token totals", async () => {
+    const client: GenerativeJsonClient = {
+      async generateJson() {
+        return {
+          est_steps: 4,
+          est_tool_calls: 3,
+          est_input_tokens_per_step: 1200,
+          est_output_tokens_per_step: 350,
+          est_tool_call_input_tokens: 800,
+          est_platform_overhead_output_token_equivalent: 250,
+        };
+      },
+    };
+
+    const estimate = await new OrchestratorBidEstimator(client).estimate({
+      prompt: "fetch docs, compare options, summarize",
+      attachments: [{ content_hash: "sha256:abc", byte_size: 1234 }],
+    });
+
+    expect(estimate).toEqual({
+      steps: 4,
+      tool_calls: 3,
+      input_tokens: 7200,
+      output_tokens: 1650,
+    });
+  });
+
+  it("rejects malformed estimates", async () => {
+    const client: GenerativeJsonClient = {
+      async generateJson() {
+        return {
+          est_steps: 0,
+          est_tool_calls: -1,
+          est_input_tokens_per_step: 100,
+          est_output_tokens_per_step: 100,
+          est_tool_call_input_tokens: 0,
+        };
+      },
+    };
+
+    await expect(new OrchestratorBidEstimator(client).estimate({ prompt: "x" })).rejects.toThrow();
+  });
+});

--- a/agent/gcp-orchestrator/test/bid/handler.test.ts
+++ b/agent/gcp-orchestrator/test/bid/handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { AnnounceRequest, PricingEntry } from "@agent-tasker/protocol";
+import { handleBid } from "../../src/bid/handler.js";
+import type { BidEstimator } from "../../src/bid/estimator.js";
+
+const SPEC: AnnounceRequest["spec"] = { prompt: "research three pages then summarize" };
+
+const PRICING: PricingEntry = {
+  model_id: "gemini-2-5-pro",
+  price_in_usd_per_mtoken: 1.25,
+  price_out_usd_per_mtoken: 10.0,
+  effective_date: "2026-05-15",
+};
+
+function stubEstimator(input_tokens: number, output_tokens: number): BidEstimator {
+  return {
+    async estimate() {
+      return { input_tokens, output_tokens, steps: 3, tool_calls: 2 };
+    },
+  };
+}
+
+function throwingEstimator(message: string): BidEstimator {
+  return {
+    async estimate() {
+      throw new Error(message);
+    },
+  };
+}
+
+describe("handleBid", () => {
+  it("returns a frontier Gemini bid from the orchestrator estimate", async () => {
+    const fixed = new Date("2026-05-21T12:00:00Z");
+    const res = await handleBid(
+      { task_id: "task-1", spec: SPEC },
+      {
+        estimator: stubEstimator(15_000, 2_500),
+        pricing: PRICING,
+        now: () => fixed,
+      },
+    );
+
+    if ("status" in res) throw new Error(`expected bid, got no_bid: ${res.reason}`);
+
+    expect(res.task_id).toBe("task-1");
+    expect(res.agent_id).toBe("gcp-orchestrator");
+    expect(res.tier).toBe("frontier");
+    expect(res.model_family).toBe("gemini");
+    expect(res.model_id).toBe("gemini-2-5-pro");
+    expect(res.est_input_tokens).toBe(15_000);
+    expect(res.est_output_tokens).toBe(2_500);
+    expect(res.price_in_usd_per_mtoken).toBe(1.25);
+    expect(res.price_out_usd_per_mtoken).toBe(10.0);
+    expect(res.bid_usd).toBeCloseTo(0.04375, 10);
+    expect(res.expires_at).toBe("2026-05-21T12:01:00.000Z");
+    expect(res.signature).toBe("stub-signature");
+  });
+
+  it("uses a custom signer when provided", async () => {
+    const res = await handleBid(
+      { task_id: "task-sign", spec: SPEC },
+      {
+        estimator: stubEstimator(100, 50),
+        pricing: PRICING,
+        sign: (id) => `signed:${id}`,
+      },
+    );
+    if ("status" in res) throw new Error("expected bid");
+    expect(res.signature).toBe("signed:task-sign");
+  });
+
+  it("declines with internal_error when the estimator throws", async () => {
+    const res = await handleBid(
+      { task_id: "task-fail", spec: SPEC },
+      {
+        estimator: throwingEstimator("Vertex unavailable"),
+        pricing: PRICING,
+      },
+    );
+    if (!("status" in res)) throw new Error("expected no_bid");
+    expect(res.status).toBe("no_bid");
+    expect(res.reason).toBe("internal_error");
+    expect(res.agent_id).toBe("gcp-orchestrator");
+    expect(res.task_id).toBe("task-fail");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@agent-tasker/protocol':
         specifier: workspace:*
         version: link:../../protocol
+      '@google-cloud/vertexai':
+        specifier: ^1.12.0
+        version: 1.12.0
       '@hono/node-server':
         specifier: ^2.0.3
         version: 2.0.3(hono@4.12.21)
@@ -143,6 +146,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   coordinator:
     dependencies:


### PR DESCRIPTION
## Summary
- add the GCP/Orchestrator bid estimator backed by a single Vertex Gemini Flash JSON call
- estimate GAEP steps, tool calls, per-step tokens, tool-result tokens, and platform overhead converted to output-token-equivalent units
- wire /bid to return frontier Gemini bid envelopes using shared pricing and keep estimator failures as no_bid internal_error
- add bid handler, estimator, and app coverage

## Validation
- pnpm --filter @agent-tasker/agent-gcp-orchestrator test
- pnpm --filter @agent-tasker/agent-gcp-orchestrator typecheck
- pnpm --filter @agent-tasker/agent-gcp-orchestrator build
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... typecheck
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... test
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... build

Closes #93