### PR TITLE
Add GCP orchestrator GAEP execute client

### DIFF
--- a/agent/gcp-orchestrator/src/runtime.ts
+++ b/agent/gcp-orchestrator/src/runtime.ts
@@ -1,10 +1,11 @@
-import type { ExecuteRequest, Result } from "@agent-tasker/protocol";
+import type { ExecuteRequest, Result, StepTrace } from "@agent-tasker/protocol";
 import { AGENT_ID } from "./index.js";
 
 export interface GaepRuntimeResult {
   output: string;
   input_tokens: number;
   output_tokens: number;
+  step_trace?: StepTrace;
 }
 
 export interface GaepRuntimeClient {
@@ -13,19 +14,41 @@ export interface GaepRuntimeClient {
 
 export interface GaepRuntimeClientOptions {
   agentResourceName: string | undefined;
+  accessTokenProvider?: AccessTokenProvider;
+  fetch?: typeof fetch;
+  apiEndpoint?: string;
 }
+
+export type AccessTokenProvider = () => Promise<string>;
 
 export function createGaepRuntimeClient(opts: GaepRuntimeClientOptions): GaepRuntimeClient {
   const agentResourceName = opts.agentResourceName?.trim();
+  const fetchImpl = opts.fetch ?? fetch;
+  const accessTokenProvider = opts.accessTokenProvider ?? fetchMetadataAccessToken;
+  const apiEndpoint = opts.apiEndpoint ?? "https://discoveryengine.googleapis.com/v1";
 
   return {
-    async execute(): Promise<GaepRuntimeResult> {
+    async execute(req: ExecuteRequest): Promise<GaepRuntimeResult> {
       if (!agentResourceName) {
         throw new Error("GAEP agent resource name is required before execution can run");
       }
-      throw new Error(
-        `GAEP runtime client for ${agentResourceName} is not implemented yet; issue #94 wires the Gemini Enterprise execution call`,
-      );
+      const accessToken = await accessTokenProvider();
+      const response = await fetchImpl(buildAnswerUrl(apiEndpoint, agentResourceName), {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          query: { text: req.spec.prompt },
+          userPseudoId: `agent-tasker-${req.task_id}`,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`GAEP answer call failed with HTTP ${response.status}`);
+      }
+      const body = (await response.json()) as unknown;
+      return parseGaepAnswerResponse(body, req.spec.prompt);
     },
   };
 }
@@ -43,5 +66,132 @@ export async function executeViaGaep(
       input_tokens: result.input_tokens,
       output_tokens: result.output_tokens,
     },
+    ...(result.step_trace ? { step_trace: result.step_trace } : {}),
   };
+}
+
+export function buildAnswerUrl(apiEndpoint: string, agentResourceName: string): string {
+  const base = apiEndpoint.replace(/\/$/, "");
+  const servingConfig = agentResourceName.includes("/servingConfigs/")
+    ? agentResourceName
+    : `${agentResourceName.replace(/\/$/, "")}/servingConfigs/default_search`;
+  return `${base}/${servingConfig}:answer`;
+}
+
+export async function fetchMetadataAccessToken(): Promise<string> {
+  const response = await fetch(
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+    { headers: { "metadata-flavor": "Google" } },
+  );
+  if (!response.ok) {
+    throw new Error(`metadata token fetch failed with HTTP ${response.status}`);
+  }
+  const body = (await response.json()) as { access_token?: unknown };
+  if (typeof body.access_token !== "string" || body.access_token.length === 0) {
+    throw new Error("metadata token response missing access_token");
+  }
+  return body.access_token;
+}
+
+export function parseGaepAnswerResponse(body: unknown, prompt: string): GaepRuntimeResult {
+  const record = asRecord(body);
+  const answer = asRecord(record["answer"]);
+  const output = stringValue(answer["answerText"]) ?? stringValue(record["answerText"]);
+  if (output === undefined) {
+    throw new Error("GAEP answer response missing answer.answerText");
+  }
+
+  const stepTrace = parseStepTrace(answer["steps"]);
+  const usage = parseUsage(record, answer, prompt, output);
+  return {
+    output,
+    input_tokens: usage.input_tokens,
+    output_tokens: usage.output_tokens,
+    ...(stepTrace ? { step_trace: stepTrace } : {}),
+  };
+}
+
+function parseStepTrace(rawSteps: unknown): StepTrace | undefined {
+  if (!Array.isArray(rawSteps)) return undefined;
+
+  const steps = rawSteps.map((rawStep, index) => {
+    const step = asRecord(rawStep);
+    const actions = Array.isArray(step["actions"]) ? step["actions"] : [];
+    return {
+      index,
+      ...(stringValue(step["state"]) ? { state: stringValue(step["state"]) } : {}),
+      ...(stringValue(step["description"])
+        ? { description: stringValue(step["description"]) }
+        : {}),
+      actions: actions.map(parseStepAction),
+    };
+  });
+
+  return {
+    total_steps: steps.length,
+    tool_call_count: steps.reduce((count, step) => count + step.actions.length, 0),
+    steps,
+  };
+}
+
+function parseStepAction(rawAction: unknown): StepTrace["steps"][number]["actions"][number] {
+  const action = asRecord(rawAction);
+  const searchAction = asRecord(action["searchAction"]);
+  const observation = asRecord(action["observation"]);
+  const searchResults = Array.isArray(observation["searchResults"])
+    ? observation["searchResults"]
+    : [];
+  const firstResult = asRecord(searchResults[0]);
+  const snippetInfo = Array.isArray(firstResult["snippetInfo"]) ? firstResult["snippetInfo"] : [];
+  const firstSnippet = asRecord(snippetInfo[0]);
+  return {
+    tool: searchAction["query"] === undefined ? "gaep_action" : "search",
+    ...(stringValue(searchAction["query"]) ? { query: stringValue(searchAction["query"]) } : {}),
+    ...(stringValue(firstSnippet["snippet"])
+      ? { observation: stringValue(firstSnippet["snippet"]) }
+      : {}),
+  };
+}
+
+function parseUsage(
+  response: Record<string, unknown>,
+  answer: Record<string, unknown>,
+  prompt: string,
+  output: string,
+): { input_tokens: number; output_tokens: number } {
+  const answerUsage = asRecord(answer["usageMetadata"]);
+  const responseUsage = asRecord(response["usageMetadata"]);
+  const usage = Object.keys(answerUsage).length > 0 ? answerUsage : responseUsage;
+  // The Answer API examples omit usage metadata, so keep settlement moving
+  // with a deterministic fallback until GAEP exposes exact token counts.
+  const input =
+    numberValue(usage?.["promptTokenCount"]) ??
+    numberValue(usage?.["inputTokenCount"]) ??
+    estimateTokens(prompt);
+  const outputTokens =
+    numberValue(usage?.["candidatesTokenCount"]) ??
+    numberValue(usage?.["outputTokenCount"]) ??
+    numberValue(usage?.["answerTokenCount"]) ??
+    estimateTokens(output);
+  return { input_tokens: input, output_tokens: outputTokens };
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(new TextEncoder().encode(text).byteLength / 4));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : undefined;
 }

--- a/agent/gcp-orchestrator/test/app.test.ts
+++ b/agent/gcp-orchestrator/test/app.test.ts
@@ -69,6 +69,18 @@ beforeEach(() => {
         output: `orchestrated: ${req.spec.prompt}`,
         input_tokens: 7000,
         output_tokens: 1200,
+        step_trace: {
+          total_steps: 1,
+          tool_call_count: 1,
+          steps: [
+            {
+              index: 0,
+              state: "SUCCEEDED",
+              description: "Search and answer.",
+              actions: [{ tool: "search", query: "do the thing" }],
+            },
+          ],
+        },
       };
     },
   };
@@ -151,6 +163,18 @@ describe("POST /execute", () => {
       agent_id: "gcp-orchestrator",
       output: "orchestrated: do the thing",
       actual_usage: { input_tokens: 7000, output_tokens: 1200 },
+      step_trace: {
+        total_steps: 1,
+        tool_call_count: 1,
+        steps: [
+          {
+            index: 0,
+            state: "SUCCEEDED",
+            description: "Search and answer.",
+            actions: [{ tool: "search", query: "do the thing" }],
+          },
+        ],
+      },
     });
   });
 

--- a/agent/gcp-orchestrator/test/runtime.test.ts
+++ b/agent/gcp-orchestrator/test/runtime.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAnswerUrl,
+  createGaepRuntimeClient,
+  parseGaepAnswerResponse,
+} from "../src/runtime.js";
+
+describe("buildAnswerUrl", () => {
+  it("targets default_search for an engine resource", () => {
+    expect(
+      buildAnswerUrl(
+        "https://discoveryengine.googleapis.com/v1",
+        "projects/p/locations/global/collections/default_collection/engines/app",
+      ),
+    ).toBe(
+      "https://discoveryengine.googleapis.com/v1/projects/p/locations/global/collections/default_collection/engines/app/servingConfigs/default_search:answer",
+    );
+  });
+
+  it("accepts a fully-qualified serving config resource", () => {
+    expect(
+      buildAnswerUrl(
+        "https://example.test/v1/",
+        "projects/p/locations/global/collections/default_collection/engines/app/servingConfigs/custom",
+      ),
+    ).toBe(
+      "https://example.test/v1/projects/p/locations/global/collections/default_collection/engines/app/servingConfigs/custom:answer",
+    );
+  });
+});
+
+describe("parseGaepAnswerResponse", () => {
+  it("extracts answer text, usage, and a compact step trace", () => {
+    const result = parseGaepAnswerResponse(
+      {
+        answer: {
+          answerText: "Use Cloud Run for the shim.",
+          usageMetadata: { promptTokenCount: 42, candidatesTokenCount: 7 },
+          steps: [
+            {
+              state: "SUCCEEDED",
+              description: "Rephrase the query and search.",
+              actions: [
+                {
+                  searchAction: { query: "Cloud Run service shim" },
+                  observation: {
+                    searchResults: [
+                      {
+                        snippetInfo: [{ snippet: "Cloud Run can host containers." }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Which runtime?",
+    );
+
+    expect(result).toEqual({
+      output: "Use Cloud Run for the shim.",
+      input_tokens: 42,
+      output_tokens: 7,
+      step_trace: {
+        total_steps: 1,
+        tool_call_count: 1,
+        steps: [
+          {
+            index: 0,
+            state: "SUCCEEDED",
+            description: "Rephrase the query and search.",
+            actions: [
+              {
+                tool: "search",
+                query: "Cloud Run service shim",
+                observation: "Cloud Run can host containers.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it("falls back to deterministic token estimates when the API omits usage metadata", () => {
+    const result = parseGaepAnswerResponse(
+      {
+        answer: {
+          answerText: "abcd efgh",
+          steps: [],
+        },
+      },
+      "abcd",
+    );
+
+    expect(result.input_tokens).toBe(1);
+    expect(result.output_tokens).toBe(3);
+    expect(result.step_trace).toEqual({ total_steps: 0, tool_call_count: 0, steps: [] });
+  });
+});
+
+describe("createGaepRuntimeClient", () => {
+  it("calls the Discovery Engine answer endpoint with a coordinator task prompt", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const client = createGaepRuntimeClient({
+      agentResourceName: "projects/p/locations/global/collections/default_collection/engines/app",
+      accessTokenProvider: async () => "token-1",
+      apiEndpoint: "https://example.test/v1",
+      fetch: async (url, init) => {
+        calls.push({ url: String(url), init: init ?? {} });
+        return new Response(
+          JSON.stringify({
+            answer: {
+              answerText: "done",
+              usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    const result = await client.execute({
+      task_id: "task-123",
+      spec: { prompt: "summarize this" },
+    });
+
+    expect(result.output).toBe("done");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(
+      "https://example.test/v1/projects/p/locations/global/collections/default_collection/engines/app/servingConfigs/default_search:answer",
+    );
+    expect(calls[0]?.init.headers).toMatchObject({
+      authorization: "Bearer token-1",
+      "content-type": "application/json",
+    });
+    expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
+      query: { text: "summarize this" },
+      userPseudoId: "agent-tasker-task-123",
+    });
+  });
+});

--- a/protocol/src/schemas.ts
+++ b/protocol/src/schemas.ts
@@ -100,12 +100,35 @@ export const ActualUsageSchema = z.object({
 });
 export type ActualUsage = z.infer<typeof ActualUsageSchema>;
 
+export const StepTraceActionSchema = z.object({
+  tool: z.string().min(1),
+  query: z.string().optional(),
+  observation: z.string().optional(),
+});
+export type StepTraceAction = z.infer<typeof StepTraceActionSchema>;
+
+export const StepTraceStepSchema = z.object({
+  index: NonNegInt,
+  state: z.string().optional(),
+  description: z.string().optional(),
+  actions: z.array(StepTraceActionSchema),
+});
+export type StepTraceStep = z.infer<typeof StepTraceStepSchema>;
+
+export const StepTraceSchema = z.object({
+  total_steps: NonNegInt,
+  tool_call_count: NonNegInt,
+  steps: z.array(StepTraceStepSchema),
+});
+export type StepTrace = z.infer<typeof StepTraceSchema>;
+
 // Result returned by the winner's /execute handler.
 export const ResultSchema = z.object({
   task_id: TaskIdSchema,
   agent_id: AgentIdSchema,
   output: z.string(),
   actual_usage: ActualUsageSchema,
+  step_trace: StepTraceSchema.optional(),
 });
 export type Result = z.infer<typeof ResultSchema>;
 


### PR DESCRIPTION
## Summary
- replace the placeholder GAEP runtime with a Discovery Engine Answer API client for Gemini Enterprise execution
- parse answer text, usage metadata, and compact step traces from GAEP answer responses
- extend the shared Result schema with optional step_trace so the coordinator preserves the execution trace for later ledger/MAPE decomposition
- add runtime tests for URL construction, response parsing, token fallback, and execute request shape

## Notes
- Gemini Enterprise docs show the Answer API at /servingConfigs/default_search:answer and response steps under answer.steps.
- The docs example does not include token usage metadata, so the runtime uses reported usage when present and a deterministic byte-based fallback when absent.

## Validation
- pnpm --filter @agent-tasker/agent-gcp-orchestrator test
- pnpm --filter @agent-tasker/agent-gcp-orchestrator typecheck
- pnpm --filter @agent-tasker/agent-gcp-orchestrator build
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... typecheck
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... test
- pnpm --filter @agent-tasker/agent-gcp-orchestrator... build

Closes #94