### PR TITLE
Add GCP orchestrator initial tool surface

### DIFF
--- a/agent/gcp-orchestrator/src/index.ts
+++ b/agent/gcp-orchestrator/src/index.ts
@@ -13,3 +13,4 @@ export function startTelemetry(env?: NodeJS.ProcessEnv): AgentTelemetryHandle | 
 export * from "./app.js";
 export * from "./bid/index.js";
 export * from "./runtime.js";
+export * from "./tools.js";

--- a/agent/gcp-orchestrator/src/runtime.ts
+++ b/agent/gcp-orchestrator/src/runtime.ts
@@ -1,5 +1,10 @@
 import type { ExecuteRequest, Result, StepTrace } from "@agent-tasker/protocol";
 import { AGENT_ID } from "./index.js";
+import {
+  INITIAL_TOOL_SURFACE,
+  buildToolSurfacePreamble,
+  type OrchestratorToolDefinition,
+} from "./tools.js";
 
 export interface GaepRuntimeResult {
   output: string;
@@ -17,6 +22,7 @@ export interface GaepRuntimeClientOptions {
   accessTokenProvider?: AccessTokenProvider;
   fetch?: typeof fetch;
   apiEndpoint?: string;
+  tools?: readonly OrchestratorToolDefinition[];
 }
 
 export type AccessTokenProvider = () => Promise<string>;
@@ -26,6 +32,7 @@ export function createGaepRuntimeClient(opts: GaepRuntimeClientOptions): GaepRun
   const fetchImpl = opts.fetch ?? fetch;
   const accessTokenProvider = opts.accessTokenProvider ?? fetchMetadataAccessToken;
   const apiEndpoint = opts.apiEndpoint ?? "https://discoveryengine.googleapis.com/v1";
+  const tools = opts.tools ?? INITIAL_TOOL_SURFACE;
 
   return {
     async execute(req: ExecuteRequest): Promise<GaepRuntimeResult> {
@@ -42,6 +49,11 @@ export function createGaepRuntimeClient(opts: GaepRuntimeClientOptions): GaepRun
         body: JSON.stringify({
           query: { text: req.spec.prompt },
           userPseudoId: `agent-tasker-${req.task_id}`,
+          answerGenerationSpec: {
+            promptSpec: {
+              preamble: buildToolSurfacePreamble(tools),
+            },
+          },
         }),
       });
       if (!response.ok) {

--- a/agent/gcp-orchestrator/src/tools.ts
+++ b/agent/gcp-orchestrator/src/tools.ts
@@ -1,0 +1,65 @@
+export interface OrchestratorToolDefinition {
+  id: string;
+  display_name: string;
+  purpose: string;
+  input_contract: string;
+  guardrails: readonly string[];
+}
+
+export const INITIAL_TOOL_SURFACE: readonly OrchestratorToolDefinition[] = [
+  {
+    id: "readonly_http_fetch",
+    display_name: "Read-only HTTP fetch",
+    purpose: "Fetch public HTTP(S) resources needed to answer the task.",
+    input_contract: "url: HTTPS URL; method: GET or HEAD; max_bytes: optional byte cap",
+    guardrails: [
+      "Only GET and HEAD are allowed.",
+      "Do not send credentials, cookies, secrets, or task JWTs to fetched URLs.",
+      "Prefer signed attachment URLs supplied by the coordinator over arbitrary URLs.",
+      "Stop after the configured byte cap and summarize partial content explicitly.",
+    ],
+  },
+  {
+    id: "search_retrieval",
+    display_name: "Search and retrieval",
+    purpose: "Retrieve relevant public or configured corpus snippets before synthesis.",
+    input_contract: "query: natural-language search query; max_results: bounded integer",
+    guardrails: [
+      "Use when the task requires current or external facts.",
+      "Cite retrieved source titles or URLs in the answer when available.",
+      "Do not expand the search scope beyond the task request.",
+    ],
+  },
+  {
+    id: "code_eval_sandbox",
+    display_name: "Code evaluation sandbox",
+    purpose: "Run small deterministic snippets to inspect data or verify calculations.",
+    input_contract: "language: supported runtime; code: short snippet; timeout_ms: bounded integer",
+    guardrails: [
+      "No network access from evaluated code.",
+      "No filesystem writes outside the sandbox workspace.",
+      "Use only for deterministic calculation, parsing, or validation steps.",
+      "Respect CPU, memory, and wall-clock limits.",
+    ],
+  },
+] as const;
+
+export function buildToolSurfacePreamble(
+  tools: readonly OrchestratorToolDefinition[] = INITIAL_TOOL_SURFACE,
+): string {
+  const renderedTools = tools
+    .map(
+      (tool) =>
+        `- ${tool.id} (${tool.display_name}): ${tool.purpose}\n  Input: ${
+          tool.input_contract
+        }\n  Guardrails: ${tool.guardrails.join(" ")}`,
+    )
+    .join("\n");
+
+  return `You are the GCP/Orchestrator agent for Agent Tasker. Use only the registered GAEP tools listed below, and only when they materially improve the answer.
+
+Registered tool surface:
+${renderedTools}
+
+Keep the plan narrow. Prefer the fewest tool calls that can complete the task, and include enough final context for audit replay.`;
+}

--- a/agent/gcp-orchestrator/test/runtime.test.ts
+++ b/agent/gcp-orchestrator/test/runtime.test.ts
@@ -139,6 +139,11 @@ describe("createGaepRuntimeClient", () => {
     expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
       query: { text: "summarize this" },
       userPseudoId: "agent-tasker-task-123",
+      answerGenerationSpec: {
+        promptSpec: {
+          preamble: expect.stringContaining("readonly_http_fetch"),
+        },
+      },
     });
   });
 });

--- a/agent/gcp-orchestrator/test/tools.test.ts
+++ b/agent/gcp-orchestrator/test/tools.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { INITIAL_TOOL_SURFACE, buildToolSurfacePreamble } from "../src/tools.js";
+
+describe("INITIAL_TOOL_SURFACE", () => {
+  it("keeps the Phase 1 orchestrator surface narrow and auditable", () => {
+    expect(INITIAL_TOOL_SURFACE.map((tool) => tool.id)).toEqual([
+      "readonly_http_fetch",
+      "search_retrieval",
+      "code_eval_sandbox",
+    ]);
+    expect(INITIAL_TOOL_SURFACE).toHaveLength(3);
+    expect(INITIAL_TOOL_SURFACE[0]?.guardrails).toContain("Only GET and HEAD are allowed.");
+    expect(INITIAL_TOOL_SURFACE[2]?.guardrails).toContain("No network access from evaluated code.");
+  });
+});
+
+describe("buildToolSurfacePreamble", () => {
+  it("renders tool ids, contracts, and guardrails for the GAEP request", () => {
+    const preamble = buildToolSurfacePreamble();
+
+    expect(preamble).toContain("readonly_http_fetch");
+    expect(preamble).toContain("search_retrieval");
+    expect(preamble).toContain("code_eval_sandbox");
+    expect(preamble).toContain("Do not send credentials");
+    expect(preamble).toContain("Prefer the fewest tool calls");
+  });
+});


### PR DESCRIPTION
## Summary
- define the initial GAEP tool surface for the orchestrator: read-only HTTP fetch, search/retrieval, and code-eval sandbox
- render the tool ids, input contracts, and guardrails into the Answer API preamble
- export the tool surface and add coverage for the manifest and request wiring

## Validation
- pnpm --filter @agent-tasker/agent-gcp-orchestrator test
- pnpm --filter @agent-tasker/agent-gcp-orchestrator typecheck
- pnpm --filter @agent-tasker/agent-gcp-orchestrator build

Closes #95