### PR TITLE
Persist GAEP step traces in ledger

### DIFF
--- a/coordinator/src/ledger/firestore-store.ts
+++ b/coordinator/src/ledger/firestore-store.ts
@@ -21,16 +21,19 @@ import type {
 } from "./store.js";
 import { applyDeclineRollupUpdate } from "./declines.js";
 import { applyBidAccuracySample, computeBidAccuracySample } from "./mape.js";
+import { buildResultRecord } from "./results.js";
 import {
   AgentDeclineRollupSchema,
   AgentMapeRollupSchema,
   AgentWinRateRollupSchema,
   BidRecordSchema,
+  ResultRecordSchema,
   TaskRecordSchema,
   type AgentDeclineRollup,
   type AgentMapeRollup,
   type AgentWinRateRollup,
   type BidRecord,
+  type ResultRecord,
   type TaskRecord,
 } from "./types.js";
 import {
@@ -128,6 +131,11 @@ export class FirestoreLedgerStore implements LedgerStore {
     return snap.docs.map((d) => BidRecordSchema.parse(d.data()));
   }
 
+  async listResults(taskId: TaskId): Promise<ResultRecord[]> {
+    const snap = await this.taskRef(taskId).collection("results").orderBy("timestamp", "asc").get();
+    return snap.docs.map((d) => ResultRecordSchema.parse(d.data()));
+  }
+
   async getAgentMapeRollup(agentId: AgentId): Promise<AgentMapeRollup | null> {
     const snap = await this.mapeRollupRef(agentId).get();
     if (!snap.exists) return null;
@@ -195,16 +203,25 @@ export class FirestoreLedgerStore implements LedgerStore {
         task.result &&
         task.result.output === input.result.output
       ) {
+        tx.set(
+          this.resultRef(input.taskId, task.result.agent_id),
+          stripUndefined(buildResultRecord(input.taskId, task.result, task.updated_at)),
+        );
         return { record: task };
       }
       this.requireTransition(input.taskId, task.status, "completed");
+      const completedAt = nowIso(input.now);
       const next: TaskRecord = {
         ...task,
         status: "completed",
-        updated_at: nowIso(input.now),
+        updated_at: completedAt,
         result: input.result,
       };
       const settlementMetrics = await this.writeSettlementRollups(tx, next);
+      tx.set(
+        this.resultRef(input.taskId, input.result.agent_id),
+        stripUndefined(buildResultRecord(input.taskId, input.result, completedAt)),
+      );
       tx.set(ref, stripUndefined(next));
       return { record: next, settlementMetrics };
     });
@@ -236,6 +253,10 @@ export class FirestoreLedgerStore implements LedgerStore {
 
   private taskRef(taskId: TaskId): DocumentReference {
     return this.tasksCollection.doc(taskId);
+  }
+
+  private resultRef(taskId: TaskId, agentId: AgentId): DocumentReference {
+    return this.taskRef(taskId).collection("results").doc(agentId);
   }
 
   private mapeRollupRef(agentId: AgentId): DocumentReference {

--- a/coordinator/src/ledger/in-memory-store.ts
+++ b/coordinator/src/ledger/in-memory-store.ts
@@ -15,11 +15,13 @@ import type {
 } from "./store.js";
 import { applyDeclineRollupUpdate } from "./declines.js";
 import { applyBidAccuracySample, computeBidAccuracySample } from "./mape.js";
+import { buildResultRecord } from "./results.js";
 import type {
   AgentDeclineRollup,
   AgentMapeRollup,
   AgentWinRateRollup,
   BidRecord,
+  ResultRecord,
   TaskRecord,
 } from "./types.js";
 import {
@@ -43,6 +45,7 @@ import {
 export class InMemoryLedgerStore implements LedgerStore {
   private readonly tasks = new Map<string, TaskRecord>();
   private readonly bids = new Map<string, BidRecord>();
+  private readonly results = new Map<string, ResultRecord>();
   private readonly mapeRollups = new Map<AgentId, AgentMapeRollup>();
   private readonly declineRollups = new Map<AgentId, AgentDeclineRollup>();
   private readonly winRateRollups = new Map<AgentId, AgentWinRateRollup>();
@@ -98,6 +101,16 @@ export class InMemoryLedgerStore implements LedgerStore {
     const prefix = `${taskId}:`;
     const out: BidRecord[] = [];
     for (const [key, record] of this.bids) {
+      if (key.startsWith(prefix)) out.push(clone(record));
+    }
+    out.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    return out;
+  }
+
+  async listResults(taskId: TaskId): Promise<ResultRecord[]> {
+    const prefix = `${taskId}:`;
+    const out: ResultRecord[] = [];
+    for (const [key, record] of this.results) {
       if (key.startsWith(prefix)) out.push(clone(record));
     }
     out.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
@@ -167,6 +180,7 @@ export class InMemoryLedgerStore implements LedgerStore {
     const task = this.requireTask(input.taskId);
 
     if (task.status === "completed" && task.result && task.result.output === input.result.output) {
+      this.writeResultRecord(input.taskId, task.result, task.updated_at);
       return clone(task);
     }
 
@@ -174,13 +188,15 @@ export class InMemoryLedgerStore implements LedgerStore {
       throw new InvalidTransitionError(input.taskId, task.status, "completed");
     }
 
+    const completedAt = nowIso(input.now);
     const next: TaskRecord = {
       ...task,
       status: "completed",
-      updated_at: nowIso(input.now),
+      updated_at: completedAt,
       result: input.result,
     };
     this.tasks.set(input.taskId, next);
+    this.writeResultRecord(input.taskId, input.result, completedAt);
     const settlementMetrics = this.writeSettlementRollups(next, input.result);
     if (settlementMetrics?.win) {
       recordWin(settlementMetrics.win.agentId, settlementMetrics.win.tier);
@@ -238,6 +254,14 @@ export class InMemoryLedgerStore implements LedgerStore {
       tier: bidRecord.response.tier,
       sample,
     };
+  }
+
+  private writeResultRecord(taskId: TaskId, result: TaskRecord["result"], timestamp: string): void {
+    if (!result) return;
+    this.results.set(
+      resultKey(taskId, result.agent_id),
+      buildResultRecord(taskId, result, timestamp),
+    );
   }
 
   private writeSettlementRollups(
@@ -317,6 +341,10 @@ export class InMemoryLedgerStore implements LedgerStore {
 }
 
 function bidKey(taskId: TaskId, agentId: string): string {
+  return `${taskId}:${agentId}`;
+}
+
+function resultKey(taskId: TaskId, agentId: string): string {
   return `${taskId}:${agentId}`;
 }
 

--- a/coordinator/src/ledger/results.ts
+++ b/coordinator/src/ledger/results.ts
@@ -1,0 +1,17 @@
+import type { Result, TaskId } from "@agent-tasker/protocol";
+import type { ResultRecord } from "./types.js";
+
+export function buildResultRecord(taskId: TaskId, result: Result, timestamp: string): ResultRecord {
+  return {
+    task_id: taskId,
+    agent_id: result.agent_id,
+    timestamp,
+    phase: "execute",
+    result,
+    step_trace: result.step_trace,
+    actual_input_tokens: result.actual_usage.input_tokens,
+    actual_output_tokens: result.actual_usage.output_tokens,
+    actual_step_count: result.step_trace?.total_steps ?? 0,
+    actual_tool_call_count: result.step_trace?.tool_call_count ?? 0,
+  };
+}

--- a/coordinator/src/ledger/store.ts
+++ b/coordinator/src/ledger/store.ts
@@ -12,6 +12,7 @@ import type {
   AgentMapeRollup,
   AgentWinRateRollup,
   BidRecord,
+  ResultRecord,
   TaskRecord,
 } from "./types.js";
 
@@ -43,6 +44,8 @@ export interface LedgerStore {
   recordBidResponse(input: RecordBidResponseInput): Promise<BidRecord>;
 
   listBids(taskId: TaskId): Promise<BidRecord[]>;
+
+  listResults(taskId: TaskId): Promise<ResultRecord[]>;
 
   getAgentMapeRollup(agentId: AgentId): Promise<AgentMapeRollup | null>;
 

--- a/coordinator/src/ledger/types.ts
+++ b/coordinator/src/ledger/types.ts
@@ -5,6 +5,7 @@ import {
   NoBidReasonSchema,
   PricingEntrySchema,
   ResultSchema,
+  StepTraceSchema,
   TaskIdSchema,
   TaskSpecSchema,
   TaskStatusSchema,
@@ -60,6 +61,24 @@ export const BidRecordSchema = z.object({
   pricing_snapshot: z.array(PricingEntrySchema),
 });
 export type BidRecord = z.infer<typeof BidRecordSchema>;
+
+// Per-agent execution result at tasks/{task_id}/results/{agent_id}. The task
+// root keeps the final client-facing result; this subcollection keeps the
+// analysis-friendly result record for MAPE decomposition and future
+// re-auction attempts.
+export const ResultRecordSchema = z.object({
+  task_id: TaskIdSchema,
+  agent_id: AgentIdSchema,
+  timestamp: Iso8601,
+  phase: z.literal("execute"),
+  result: ResultSchema,
+  step_trace: StepTraceSchema.optional(),
+  actual_input_tokens: z.number().int().nonnegative(),
+  actual_output_tokens: z.number().int().nonnegative(),
+  actual_step_count: z.number().int().nonnegative(),
+  actual_tool_call_count: z.number().int().nonnegative(),
+});
+export type ResultRecord = z.infer<typeof ResultRecordSchema>;
 
 // Per-agent rolling bid accuracy at agent_mape_rollups/{agent_id}. Updated
 // when a winning task settles so tie-breaking and later score-weighted

--- a/coordinator/test/integration/e2e-gcp-orchestrator.test.ts
+++ b/coordinator/test/integration/e2e-gcp-orchestrator.test.ts
@@ -152,6 +152,22 @@ describe("E2E: client → coordinator → GCP/Orchestrator → settle", () => {
       query: "orchestrator task context",
     });
 
+    const results = await store.listResults(created.task_id);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      task_id: created.task_id,
+      agent_id: "gcp-orchestrator",
+      phase: "execute",
+      actual_input_tokens: 9000,
+      actual_output_tokens: 2500,
+      actual_step_count: 2,
+      actual_tool_call_count: 1,
+    });
+    expect(results[0]?.step_trace?.steps[0]?.actions[0]).toMatchObject({
+      tool: "search",
+      query: "orchestrator task context",
+    });
+
     const bids = await store.listBids(created.task_id);
     expect(bids).toHaveLength(1);
     expect(bids[0]?.agent_id).toBe("gcp-orchestrator");

--- a/coordinator/test/ledger/in-memory-store.test.ts
+++ b/coordinator/test/ledger/in-memory-store.test.ts
@@ -65,6 +65,42 @@ function makeResult(agentId: AgentId, taskId = TASK_ID): Result {
   };
 }
 
+function makeResultWithStepTrace(agentId: AgentId, taskId = TASK_ID): Result {
+  return {
+    ...makeResult(agentId, taskId),
+    step_trace: {
+      total_steps: 3,
+      tool_call_count: 2,
+      steps: [
+        {
+          index: 0,
+          state: "SUCCEEDED",
+          description: "Fetch supporting source.",
+          actions: [
+            {
+              tool: "readonly_http_fetch",
+              query: "https://example.test/source",
+              observation: "source body",
+            },
+          ],
+        },
+        {
+          index: 1,
+          state: "SUCCEEDED",
+          description: "Run a small calculation.",
+          actions: [{ tool: "code_eval_sandbox", observation: "42" }],
+        },
+        {
+          index: 2,
+          state: "SUCCEEDED",
+          description: "Synthesize answer.",
+          actions: [],
+        },
+      ],
+    },
+  };
+}
+
 let store: InMemoryLedgerStore;
 
 beforeEach(() => {
@@ -449,6 +485,29 @@ describe("markExecuting / completeTask / failTask", () => {
     const record = await store.completeTask({ taskId: TASK_ID, result });
     expect(record.status).toBe("completed");
     expect(record.result).toEqual(result);
+  });
+
+  it("completeTask persists an analysis-friendly result record with step-trace counts", async () => {
+    await store.markExecuting(TASK_ID);
+    const completedAt = new Date("2026-05-20T12:00:00Z");
+    const result = makeResultWithStepTrace("gcp-gemini");
+
+    await store.completeTask({ taskId: TASK_ID, result, now: completedAt });
+
+    const results = await store.listResults(TASK_ID);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      task_id: TASK_ID,
+      agent_id: "gcp-gemini",
+      timestamp: completedAt.toISOString(),
+      phase: "execute",
+      result,
+      step_trace: result.step_trace,
+      actual_input_tokens: 4100,
+      actual_output_tokens: 950,
+      actual_step_count: 3,
+      actual_tool_call_count: 2,
+    });
   });
 
   it("completeTask updates the winner's rolling MAPE rollup", async () => {


### PR DESCRIPTION
## Summary
- add coordinator result records for tasks/{task_id}/results/{agent_id}
- persist step traces plus token/step/tool-call decomposition fields on task completion
- cover result-record persistence in ledger and GCP/Orchestrator E2E tests

Closes #99.

## Validation
- pnpm --filter @agent-tasker/coordinator test -- in-memory-store e2e-gcp-orchestrator
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm --filter @agent-tasker/coordinator build