### PR TITLE
Deliver signed task completion callbacks

### DIFF
--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -16,7 +16,9 @@ import {
 import { SpanStatusCode, trace, type Attributes, type Span } from "@opentelemetry/api";
 import type { LedgerStore } from "../ledger/store.js";
 import { recordAgentBidLatency, recordBidRoundLatency } from "../observability/market-metrics.js";
+import type { TaskRecord } from "../ledger/types.js";
 import type { AuctionRunner } from "./runner.js";
+import { deliverCompletionWebhook, type WebhookSigner } from "./webhook-delivery.js";
 
 // Minimal real AuctionRunner that drives `bidding → awarded → executing →
 // (completed | failed)` for one task via real HTTP fan-out to each agent.
@@ -63,6 +65,10 @@ export interface HttpAuctionRunnerOptions {
   bidExtensionMs?: number;
   bidTimeoutMs?: number;
   executeTimeoutMs?: number;
+  callbackMaxAttempts?: number;
+  callbackInitialBackoffMs?: number;
+  callbackSleep?: (ms: number) => Promise<void>;
+  webhookSigner?: WebhookSigner;
   // Override for tests; defaults to the global `fetch` available in Node 22+.
   fetch?: typeof fetch;
   // Hook so callers can observe runs / surface errors. The runner itself
@@ -197,7 +203,8 @@ export class HttpAuctionRunner implements AuctionRunner {
           actual_usd: actualUsd,
           mape: actualUsd > 0 ? Math.abs(award.winningBidUsd - actualUsd) / actualUsd : 0,
         });
-        await this.opts.store.completeTask({ taskId, result });
+        const completed = await this.opts.store.completeTask({ taskId, result });
+        await this.deliverCallback(completed);
         return;
       } catch (err) {
         failures.push(`winner ${award.winner.agent_id} failed /execute: ${(err as Error).message}`);
@@ -419,6 +426,36 @@ export class HttpAuctionRunner implements AuctionRunner {
       }),
     };
     (this.opts.egressRecorder ?? DEFAULT_AGENT_EGRESS_RECORDER)(event);
+  }
+
+  private async deliverCallback(task: TaskRecord): Promise<void> {
+    if (!task.spec.callback_url) return;
+    if (!this.opts.webhookSigner) {
+      this.opts.onError?.(
+        task.task_id,
+        new Error("callback_url provided but no webhook signer is configured"),
+      );
+      return;
+    }
+
+    const result = await deliverCompletionWebhook({
+      task,
+      signer: this.opts.webhookSigner,
+      fetch: this.opts.fetch ?? fetch,
+      ...(this.opts.callbackMaxAttempts !== undefined
+        ? { maxAttempts: this.opts.callbackMaxAttempts }
+        : {}),
+      ...(this.opts.callbackInitialBackoffMs !== undefined
+        ? { initialBackoffMs: this.opts.callbackInitialBackoffMs }
+        : {}),
+      ...(this.opts.callbackSleep ? { sleep: this.opts.callbackSleep } : {}),
+    });
+    if (!result.ok) {
+      this.opts.onError?.(
+        task.task_id,
+        new Error(`callback delivery failed after ${result.attempts} attempts: ${result.error}`),
+      );
+    }
   }
 }
 

--- a/coordinator/src/auction/webhook-delivery.ts
+++ b/coordinator/src/auction/webhook-delivery.ts
@@ -1,0 +1,88 @@
+import type { TaskId } from "@agent-tasker/protocol";
+import type { TaskRecord } from "../ledger/types.js";
+
+export interface WebhookSigner {
+  sign(args: { taskId: TaskId; callbackUrl: string }): Promise<string>;
+}
+
+export interface WebhookDeliveryOptions {
+  task: TaskRecord;
+  signer: WebhookSigner;
+  fetch: typeof fetch;
+  maxAttempts?: number;
+  initialBackoffMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface WebhookDeliveryResult {
+  ok: boolean;
+  attempts: number;
+  status?: number;
+  error?: string;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_INITIAL_BACKOFF_MS = 250;
+
+export async function deliverCompletionWebhook(
+  opts: WebhookDeliveryOptions,
+): Promise<WebhookDeliveryResult> {
+  const callbackUrl = opts.task.spec.callback_url;
+  if (!callbackUrl) return { ok: true, attempts: 0 };
+
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const initialBackoffMs = opts.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
+  const sleep = opts.sleep ?? defaultSleep;
+  const token = await opts.signer.sign({ taskId: opts.task.task_id, callbackUrl });
+  const body = JSON.stringify(completionPayload(opts.task));
+  const idempotencyKey = `task:${opts.task.task_id}:completed`;
+
+  let lastFailure: WebhookDeliveryResult = { ok: false, attempts: 0 };
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const res = await opts.fetch(callbackUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+          "idempotency-key": idempotencyKey,
+          "x-agent-tasker-event": "task.completed",
+        },
+        body,
+      });
+      if (res.ok) return { ok: true, attempts: attempt, status: res.status };
+      lastFailure = {
+        ok: false,
+        attempts: attempt,
+        status: res.status,
+        error: `callback returned ${res.status}`,
+      };
+    } catch (err) {
+      lastFailure = {
+        ok: false,
+        attempts: attempt,
+        error: err instanceof Error ? err.message : "callback delivery failed",
+      };
+    }
+
+    if (attempt < maxAttempts) {
+      await sleep(initialBackoffMs * 2 ** (attempt - 1));
+    }
+  }
+
+  return lastFailure;
+}
+
+function completionPayload(task: TaskRecord) {
+  return {
+    task_id: task.task_id,
+    status: task.status,
+    winner_agent_id: task.winner_agent_id,
+    auction_price_usd: task.auction_price_usd,
+    result: task.result,
+  };
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/coordinator/src/jwt/sign.ts
+++ b/coordinator/src/jwt/sign.ts
@@ -20,6 +20,13 @@ export interface SignTaskTokenArgs {
   now?: () => Date;
 }
 
+export interface SignWebhookTokenArgs {
+  taskId: TaskId;
+  callbackUrl: string;
+  ttlSeconds?: number;
+  now?: () => Date;
+}
+
 // Mint a single-use, single-phase task token. Each call to `/announce`,
 // `/award`, `/execute`, `/reject` should mint a fresh token; tokens are
 // scoped to one (task, agent, phase) tuple.
@@ -40,6 +47,28 @@ export async function signTaskToken(
     .setIssuer(COORDINATOR_ISSUER)
     .setSubject(COORDINATOR_ISSUER)
     .setAudience(args.agentId)
+    .setIssuedAt(issuedAt)
+    .setExpirationTime(issuedAt + ttl)
+    .sign(privateKey);
+}
+
+export async function signWebhookToken(
+  keyProvider: KeyProvider,
+  args: SignWebhookTokenArgs,
+): Promise<string> {
+  const key = await keyProvider.getActiveKey();
+  const privateKey = await importPKCS8(key.privateKeyPem, "RS256");
+  const issuedAt = Math.floor((args.now?.() ?? new Date()).getTime() / 1000);
+  const ttl = args.ttlSeconds ?? TOKEN_TTL_SECONDS;
+
+  return new SignJWT({
+    task_id: args.taskId,
+    event: "task.completed",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: key.kid, typ: "JWT" })
+    .setIssuer(COORDINATOR_ISSUER)
+    .setSubject(COORDINATOR_ISSUER)
+    .setAudience(args.callbackUrl)
     .setIssuedAt(issuedAt)
     .setExpirationTime(issuedAt + ttl)
     .sign(privateKey);

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -1,3 +1,5 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type {
   AgentId,
@@ -19,6 +21,7 @@ import {
   cloudLegForAgent,
   estimateHttpRequestBytes,
 } from "../../src/auction/http-runner.js";
+import type { WebhookSigner } from "../../src/auction/webhook-delivery.js";
 import { startFakeAgent, type FakeAgent } from "./fake-agent.js";
 
 const PRICING_SNAPSHOT: PricingEntry[] = [
@@ -41,6 +44,14 @@ const stubSigner: TaskTokenSigner = {
   },
 };
 
+const signedWebhookTokens: Array<{ taskId: TaskId; callbackUrl: string }> = [];
+const stubWebhookSigner: WebhookSigner = {
+  async sign({ taskId, callbackUrl }) {
+    signedWebhookTokens.push({ taskId, callbackUrl });
+    return `stub-webhook-token.${taskId}`;
+  },
+};
+
 function bidFor(agentId: AgentId, bidUsd: number, taskId: string, tier: Tier = "frontier"): Bid {
   return {
     task_id: taskId,
@@ -60,15 +71,19 @@ function bidFor(agentId: AgentId, bidUsd: number, taskId: string, tier: Tier = "
 
 let store: InMemoryLedgerStore;
 let agents: FakeAgent[];
+let callbackServers: Server[];
 
 beforeEach(() => {
   signedTokens.length = 0;
+  signedWebhookTokens.length = 0;
   store = new InMemoryLedgerStore();
   agents = [];
+  callbackServers = [];
 });
 
 afterEach(async () => {
   await Promise.all(agents.map((a) => a.stop()));
+  await Promise.all(callbackServers.map((s) => closeServer(s)));
 });
 
 async function startAuction(opts: {
@@ -79,6 +94,11 @@ async function startAuction(opts: {
   bidTimeoutMs?: number;
   spec?: TaskSpec;
   egressRecorder?: (event: AgentEgressEvent) => void;
+  webhookSigner?: WebhookSigner;
+  callbackMaxAttempts?: number;
+  callbackInitialBackoffMs?: number;
+  callbackSleep?: (ms: number) => Promise<void>;
+  onError?: (taskId: TaskId, err: unknown) => void;
 }): Promise<HttpAuctionRunner> {
   await store.createTask({
     taskId: opts.taskId,
@@ -92,6 +112,15 @@ async function startAuction(opts: {
     ...(opts.accuracyByAgent !== undefined ? { accuracyByAgent: opts.accuracyByAgent } : {}),
     ...(opts.tieBreakRandom !== undefined ? { tieBreakRandom: opts.tieBreakRandom } : {}),
     ...(opts.bidTimeoutMs !== undefined ? { bidTimeoutMs: opts.bidTimeoutMs } : {}),
+    ...(opts.webhookSigner !== undefined ? { webhookSigner: opts.webhookSigner } : {}),
+    ...(opts.callbackMaxAttempts !== undefined
+      ? { callbackMaxAttempts: opts.callbackMaxAttempts }
+      : {}),
+    ...(opts.callbackInitialBackoffMs !== undefined
+      ? { callbackInitialBackoffMs: opts.callbackInitialBackoffMs }
+      : {}),
+    ...(opts.callbackSleep !== undefined ? { callbackSleep: opts.callbackSleep } : {}),
+    ...(opts.onError !== undefined ? { onError: opts.onError } : {}),
     egressRecorder: opts.egressRecorder ?? (() => {}),
   });
   runner.start(opts.taskId);
@@ -145,6 +174,89 @@ describe("HttpAuctionRunner", () => {
     expect(gemini.executeCalls).toBe(1);
     expect(nova.bidCalls).toBe(1);
     expect(nova.executeCalls).toBe(0);
+  });
+
+  it("delivers signed completion callbacks with a stable idempotency key", async () => {
+    const taskId = "task-callback";
+    const deliveries: CallbackRequest[] = [];
+    const callback = await startCallbackServer(async (req, body) => {
+      deliveries.push(toCallbackRequest(req, body));
+      return { status: 204 };
+    });
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "gcp-gemini",
+        output: "gemini did it",
+        actual_usage: { input_tokens: 4100, output_tokens: 950 },
+      }),
+    });
+    agents.push(gemini);
+
+    await startAuction({
+      taskId,
+      endpoints: [{ agentId: "gcp-gemini", baseUrl: gemini.url }],
+      spec: { prompt: "summarize the transcript", callback_url: callback.url },
+      webhookSigner: stubWebhookSigner,
+    });
+
+    expect(signedWebhookTokens).toEqual([{ taskId, callbackUrl: callback.url }]);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      authorization: `Bearer stub-webhook-token.${taskId}`,
+      idempotencyKey: `task:${taskId}:completed`,
+      event: "task.completed",
+      body: {
+        task_id: taskId,
+        status: "completed",
+        winner_agent_id: "gcp-gemini",
+        auction_price_usd: 0.02,
+        result: {
+          task_id: taskId,
+          agent_id: "gcp-gemini",
+          output: "gemini did it",
+          actual_usage: { input_tokens: 4100, output_tokens: 950 },
+        },
+      },
+    });
+  });
+
+  it("retries callback delivery with the same idempotency key", async () => {
+    const taskId = "task-callback-retry";
+    const deliveries: CallbackRequest[] = [];
+    const callback = await startCallbackServer(async (req, body) => {
+      deliveries.push(toCallbackRequest(req, body));
+      return { status: deliveries.length < 3 ? 500 : 204 };
+    });
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "gcp-gemini",
+        output: "gemini did it",
+        actual_usage: { input_tokens: 4100, output_tokens: 950 },
+      }),
+    });
+    agents.push(gemini);
+
+    await startAuction({
+      taskId,
+      endpoints: [{ agentId: "gcp-gemini", baseUrl: gemini.url }],
+      spec: { prompt: "summarize the transcript", callback_url: callback.url },
+      webhookSigner: stubWebhookSigner,
+      callbackInitialBackoffMs: 1,
+      callbackSleep: async () => {},
+    });
+
+    expect(deliveries).toHaveLength(3);
+    expect(new Set(deliveries.map((d) => d.idempotencyKey))).toEqual(
+      new Set([`task:${taskId}:completed`]),
+    );
+    const task = await store.getTask(taskId);
+    expect(task?.status).toBe("completed");
   });
 
   it("single bidder: degenerate Vickrey price equals the winner's own bid", async () => {
@@ -570,3 +682,64 @@ describe("HttpAuctionRunner", () => {
     expect(cloudLegForAgent("azure-gpt")).toBe("azure");
   });
 });
+
+interface CallbackRequest {
+  authorization: string | undefined;
+  idempotencyKey: string | undefined;
+  event: string | undefined;
+  body: unknown;
+}
+
+async function startCallbackServer(
+  handler: (
+    req: IncomingMessage,
+    body: unknown,
+  ) => Promise<{ status: number; body?: unknown }> | { status: number; body?: unknown },
+): Promise<{ url: string }> {
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const bodyText = await readRequestBody(req);
+    const body = bodyText ? JSON.parse(bodyText) : null;
+    const response = await handler(req, body);
+    res.statusCode = response.status;
+    if (response.body !== undefined) {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(response.body));
+      return;
+    }
+    res.end();
+  });
+  callbackServers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo | null;
+  if (!address || typeof address === "string") {
+    throw new Error("callback server failed to bind");
+  }
+  return { url: `http://127.0.0.1:${address.port}/callback` };
+}
+
+function toCallbackRequest(req: IncomingMessage, body: unknown): CallbackRequest {
+  return {
+    authorization: req.headers.authorization,
+    idempotencyKey: headerValue(req.headers["idempotency-key"]),
+    event: headerValue(req.headers["x-agent-tasker-event"]),
+    body,
+  };
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}

--- a/coordinator/test/jwt/sign.test.ts
+++ b/coordinator/test/jwt/sign.test.ts
@@ -5,7 +5,12 @@ import {
   TOKEN_TTL_SECONDS,
   TaskTokenClaimsSchema,
 } from "@agent-tasker/protocol";
-import { StaticKeyProvider, signTaskToken, type SigningKey } from "../../src/jwt/index.js";
+import {
+  StaticKeyProvider,
+  signTaskToken,
+  signWebhookToken,
+  type SigningKey,
+} from "../../src/jwt/index.js";
 
 const KID = "test-kid-1";
 
@@ -121,5 +126,29 @@ describe("signTaskToken", () => {
 
     const { protectedHeader } = await verify(jwt, "gcp-gemini");
     expect(protectedHeader.kid).toBe(KID);
+  });
+});
+
+describe("signWebhookToken", () => {
+  it("uses the callback URL as the audience and marks the completed event", async () => {
+    const callbackUrl = "https://client.example.com/callback";
+    const jwt = await signWebhookToken(provider, {
+      taskId: "task-callback",
+      callbackUrl,
+      ttlSeconds: 120,
+    });
+
+    const { payload, protectedHeader } = await verify(jwt, callbackUrl);
+
+    expect(protectedHeader.alg).toBe("RS256");
+    expect(protectedHeader.kid).toBe(KID);
+    expect(payload).toMatchObject({
+      iss: COORDINATOR_ISSUER,
+      sub: COORDINATOR_ISSUER,
+      aud: callbackUrl,
+      task_id: "task-callback",
+      event: "task.completed",
+    });
+    expect(Number(payload.exp) - Number(payload.iat)).toBe(120);
   });
 });


### PR DESCRIPTION
## Summary
- add signed completion webhook delivery for task callback_url
- retry callback POSTs with exponential backoff and a stable idempotency key
- add webhook JWT signing and runner integration coverage

Closes #82.

## Validation
- pnpm --filter @agent-tasker/coordinator test -- http-runner sign
- pnpm --filter @agent-tasker/coordinator typecheck
- pnpm --filter @agent-tasker/coordinator build