### PR TITLE
Add optional cloud budget alarms

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,6 +27,16 @@ The coordinator Terraform creates a Cloud Monitoring policy for pricing-refresh 
 
 It also creates a JWKS rotation health policy that alerts when the public `jwks.json` object has not been updated in 32 days. Set `jwks_rotation_alert_notification_channels` to route that alert.
 
+## Cost Budget Alarms
+
+Terraform modules keep monthly budget alarms disabled by default. Enable them per environment with `cost_budget_monthly_usd` and notification targets:
+
+- `infra/coordinator`: set `billing_account_id`, `cost_budget_monthly_usd`, and optionally `cost_budget_alert_notification_channels` for a project-scoped GCP Cloud Billing budget.
+- `infra/agent-aws-nova`: set `cost_budget_monthly_usd` and `cost_budget_alert_emails` for AWS Budgets notifications.
+- `infra/agent-azure-gpt`: set `cost_budget_monthly_usd`, `cost_budget_start_date`, and `cost_budget_alert_emails` for an Azure Cost Management budget scoped to the agent resource group.
+
+Use low dev caps first. Budget alerts can lag vendor billing ingestion, so they are a backstop, not a real-time kill switch.
+
 ## Dashboards
 
 Import dashboard JSON from `docs/grafana/dashboards/` into Grafana Cloud:

--- a/infra/agent-aws-nova/budget.tf
+++ b/infra/agent-aws-nova/budget.tf
@@ -1,0 +1,21 @@
+resource "aws_budgets_budget" "agent" {
+  count = var.cost_budget_monthly_usd == null ? 0 : 1
+
+  name         = "${local.agent_name}-budget"
+  budget_type  = "COST"
+  limit_amount = tostring(var.cost_budget_monthly_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  dynamic "notification" {
+    for_each = var.cost_budget_threshold_percents
+
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = notification.value
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "ACTUAL"
+      subscriber_email_addresses = var.cost_budget_alert_emails
+    }
+  }
+}

--- a/infra/agent-aws-nova/variables.tf
+++ b/infra/agent-aws-nova/variables.tf
@@ -67,3 +67,36 @@ variable "otel_exporter_otlp_headers" {
   default     = null
   sensitive   = true
 }
+
+variable "cost_budget_monthly_usd" {
+  description = "Optional monthly AWS budget amount in whole USD. Leave null to skip budget creation."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.cost_budget_monthly_usd == null || var.cost_budget_monthly_usd > 0 && floor(var.cost_budget_monthly_usd) == var.cost_budget_monthly_usd
+    error_message = "cost_budget_monthly_usd must be a positive whole-dollar amount when set."
+  }
+}
+
+variable "cost_budget_threshold_percents" {
+  description = "Budget alert thresholds as whole percentages of monthly budget."
+  type        = list(number)
+  default     = [50, 80, 100]
+
+  validation {
+    condition     = length(var.cost_budget_threshold_percents) > 0 && alltrue([for p in var.cost_budget_threshold_percents : p > 0])
+    error_message = "cost_budget_threshold_percents must contain at least one positive threshold."
+  }
+}
+
+variable "cost_budget_alert_emails" {
+  description = "Email addresses that receive AWS Budget notifications. Required when cost_budget_monthly_usd is set."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = var.cost_budget_monthly_usd == null || length(var.cost_budget_alert_emails) > 0
+    error_message = "cost_budget_alert_emails must contain at least one email when cost_budget_monthly_usd is set."
+  }
+}

--- a/infra/agent-azure-gpt/budget.tf
+++ b/infra/agent-azure-gpt/budget.tf
@@ -1,0 +1,24 @@
+resource "azurerm_consumption_budget_resource_group" "agent" {
+  count = var.cost_budget_monthly_usd == null ? 0 : 1
+
+  name              = "${local.name_prefix}-azure-gpt-budget"
+  resource_group_id = data.azurerm_resource_group.agent.id
+  amount            = var.cost_budget_monthly_usd
+  time_grain        = "Monthly"
+
+  time_period {
+    start_date = var.cost_budget_start_date
+  }
+
+  dynamic "notification" {
+    for_each = var.cost_budget_threshold_percents
+
+    content {
+      enabled        = true
+      threshold      = notification.value
+      operator       = "GreaterThan"
+      threshold_type = "Actual"
+      contact_emails = var.cost_budget_alert_emails
+    }
+  }
+}

--- a/infra/agent-azure-gpt/variables.tf
+++ b/infra/agent-azure-gpt/variables.tf
@@ -134,3 +134,47 @@ variable "otel_exporter_otlp_headers" {
   default     = null
   sensitive   = true
 }
+
+variable "cost_budget_monthly_usd" {
+  description = "Optional monthly Azure budget amount in whole USD. Leave null to skip budget creation."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.cost_budget_monthly_usd == null || var.cost_budget_monthly_usd > 0 && floor(var.cost_budget_monthly_usd) == var.cost_budget_monthly_usd
+    error_message = "cost_budget_monthly_usd must be a positive whole-dollar amount when set."
+  }
+}
+
+variable "cost_budget_start_date" {
+  description = "Budget start date in RFC3339 format. Required when cost_budget_monthly_usd is set; Azure requires this to be a valid budget period boundary."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.cost_budget_monthly_usd == null || var.cost_budget_start_date != null
+    error_message = "cost_budget_start_date is required when cost_budget_monthly_usd is set."
+  }
+}
+
+variable "cost_budget_threshold_percents" {
+  description = "Budget alert thresholds as whole percentages of monthly budget."
+  type        = list(number)
+  default     = [50, 80, 100]
+
+  validation {
+    condition     = length(var.cost_budget_threshold_percents) > 0 && alltrue([for p in var.cost_budget_threshold_percents : p > 0])
+    error_message = "cost_budget_threshold_percents must contain at least one positive threshold."
+  }
+}
+
+variable "cost_budget_alert_emails" {
+  description = "Email addresses that receive Azure Cost Management budget notifications. Required when cost_budget_monthly_usd is set."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = var.cost_budget_monthly_usd == null || length(var.cost_budget_alert_emails) > 0
+    error_message = "cost_budget_alert_emails must contain at least one email when cost_budget_monthly_usd is set."
+  }
+}

--- a/infra/coordinator/budget.tf
+++ b/infra/coordinator/budget.tf
@@ -1,0 +1,43 @@
+data "google_project" "current" {
+  count = var.cost_budget_monthly_usd == null || var.billing_account_id == null ? 0 : 1
+
+  project_id = var.project_id
+}
+
+data "google_billing_account" "current" {
+  count = var.cost_budget_monthly_usd == null || var.billing_account_id == null ? 0 : 1
+
+  billing_account = var.billing_account_id
+}
+
+resource "google_billing_budget" "project" {
+  count = var.cost_budget_monthly_usd == null || var.billing_account_id == null ? 0 : 1
+
+  billing_account = data.google_billing_account.current[0].id
+  display_name    = "${local.name_prefix}-gcp-budget"
+
+  budget_filter {
+    projects = ["projects/${data.google_project.current[0].number}"]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = tostring(var.cost_budget_monthly_usd)
+    }
+  }
+
+  dynamic "threshold_rules" {
+    for_each = var.cost_budget_threshold_percents
+
+    content {
+      threshold_percent = threshold_rules.value / 100
+      spend_basis       = "CURRENT_SPEND"
+    }
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = var.cost_budget_alert_notification_channels
+    disable_default_iam_recipients   = length(var.cost_budget_alert_notification_channels) > 0
+  }
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -121,3 +121,42 @@ variable "jwks_rotation_alert_notification_channels" {
   type        = list(string)
   default     = []
 }
+
+variable "billing_account_id" {
+  description = "Optional GCP billing account ID used to create a project-scoped Cloud Billing budget. Leave null to skip budget creation."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.cost_budget_monthly_usd == null || var.billing_account_id != null
+    error_message = "billing_account_id is required when cost_budget_monthly_usd is set."
+  }
+}
+
+variable "cost_budget_monthly_usd" {
+  description = "Optional monthly GCP budget amount in whole USD. Leave null to skip budget creation."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.cost_budget_monthly_usd == null || var.cost_budget_monthly_usd > 0 && floor(var.cost_budget_monthly_usd) == var.cost_budget_monthly_usd
+    error_message = "cost_budget_monthly_usd must be a positive whole-dollar amount when set."
+  }
+}
+
+variable "cost_budget_threshold_percents" {
+  description = "Budget alert thresholds as whole percentages of monthly budget."
+  type        = list(number)
+  default     = [50, 80, 100]
+
+  validation {
+    condition     = length(var.cost_budget_threshold_percents) > 0 && alltrue([for p in var.cost_budget_threshold_percents : p > 0])
+    error_message = "cost_budget_threshold_percents must contain at least one positive threshold."
+  }
+}
+
+variable "cost_budget_alert_notification_channels" {
+  description = "Cloud Monitoring notification channel resource names to attach to the GCP billing budget. If empty, Billing uses default IAM recipients."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- add optional GCP Cloud Billing budget for the coordinator project
- add optional AWS Budgets alarms for the Nova agent account
- add optional Azure Cost Management budget for the GPT agent resource group
- document how to enable per-cloud monthly budget alarms

Closes #84.

## Validation
- pnpm format
- terraform -chdir=infra/coordinator validate
- terraform -chdir=infra/agent-aws-nova validate
- terraform -chdir=infra/agent-azure-gpt validate