### PR TITLE
Add optional BigQuery ledger export

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -37,6 +37,24 @@ Terraform modules keep monthly budget alarms disabled by default. Enable them pe
 
 Use low dev caps first. Budget alerts can lag vendor billing ingestion, so they are a backstop, not a real-time kill switch.
 
+## BigQuery Ledger Export
+
+`infra/coordinator` can optionally export the Firestore ledger into BigQuery analytical tables. Enable it with:
+
+```hcl
+ledger_bigquery_export_enabled = true
+ledger_bigquery_dataset_id     = "agent_tasker_ledger"
+ledger_bigquery_location       = "US"
+```
+
+The scheduled exporter scans task documents updated in the last `ledger_bigquery_export_lookback_hours` hours and writes:
+
+- `ledger_tasks`
+- `ledger_bids`
+- `ledger_results`
+
+Rows include flattened columns for common filters plus JSON payload columns for replay/debugging. The exporter uses BigQuery streaming insert IDs, so reruns over the same lookback window are idempotent enough for scheduled retry behavior.
+
 ## Dashboards
 
 Import dashboard JSON from `docs/grafana/dashboards/` into Grafana Cloud:

--- a/infra/coordinator/functions/ledger-export/index.js
+++ b/infra/coordinator/functions/ledger-export/index.js
@@ -1,0 +1,98 @@
+import { BigQuery } from "@google-cloud/bigquery";
+import { Firestore } from "@google-cloud/firestore";
+import { bidRow, resultRow, taskRow } from "./transform.js";
+
+const DEFAULT_LOOKBACK_HOURS = 24;
+
+function log(level, msg, extra) {
+  console.log(JSON.stringify({ severity: level, msg, ts: new Date().toISOString(), ...extra }));
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} env var is required`);
+  return value;
+}
+
+function cutoffDate() {
+  const hours = Number(process.env.EXPORT_LOOKBACK_HOURS ?? DEFAULT_LOOKBACK_HOURS);
+  return new Date(Date.now() - hours * 60 * 60 * 1000);
+}
+
+async function loadLedgerRows(firestore, cutoff) {
+  const tasks = [];
+  const bids = [];
+  const results = [];
+  const query = await firestore
+    .collection("tasks")
+    .where("updated_at", ">=", cutoff.toISOString())
+    .get();
+
+  for (const taskDoc of query.docs) {
+    const task = taskDoc.data();
+    tasks.push(taskRow(task));
+
+    const [bidSnap, resultSnap] = await Promise.all([
+      taskDoc.ref.collection("bids").get(),
+      taskDoc.ref.collection("results").get(),
+    ]);
+
+    for (const bidDoc of bidSnap.docs) bids.push(bidRow(bidDoc.data()));
+    for (const resultDoc of resultSnap.docs) results.push(resultRow(resultDoc.data()));
+  }
+
+  return { tasks, bids, results };
+}
+
+async function insertRows(dataset, table, rows, insertId) {
+  if (rows.length === 0) return 0;
+  await dataset.table(table).insert(
+    rows.map((row) => ({
+      insertId: insertId(row),
+      json: row,
+    })),
+    { raw: true },
+  );
+  return rows.length;
+}
+
+export async function runLedgerExport({
+  firestore,
+  bigquery,
+  datasetId,
+  cutoff = cutoffDate(),
+} = {}) {
+  const db = firestore ?? new Firestore({ projectId: requiredEnv("GCP_PROJECT_ID") });
+  const bq = bigquery ?? new BigQuery({ projectId: requiredEnv("GCP_PROJECT_ID") });
+  const dataset = bq.dataset(datasetId ?? requiredEnv("BIGQUERY_DATASET"));
+  const rows = await loadLedgerRows(db, cutoff);
+
+  const exported = {
+    tasks: await insertRows(dataset, "ledger_tasks", rows.tasks, (row) => row.task_id),
+    bids: await insertRows(
+      dataset,
+      "ledger_bids",
+      rows.bids,
+      (row) => `${row.task_id}:${row.agent_id}:${row.timestamp}`,
+    ),
+    results: await insertRows(
+      dataset,
+      "ledger_results",
+      rows.results,
+      (row) => `${row.task_id}:${row.agent_id}:${row.timestamp}`,
+    ),
+  };
+
+  log("INFO", "ledger-export: done", { cutoff: cutoff.toISOString(), exported });
+  return exported;
+}
+
+export const exportLedger = async (_req, res) => {
+  try {
+    const exported = await runLedgerExport();
+    res.status(200).json({ ok: true, exported });
+  } catch (err) {
+    log("ERROR", "ledger-export: failed", { error: err.message });
+    res.status(500).json({ ok: false, error: err.message });
+  }
+};

--- a/infra/coordinator/functions/ledger-export/package.json
+++ b/infra/coordinator/functions/ledger-export/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@agent-tasker/ledger-export",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Scheduled Firestore ledger export to BigQuery analytical tables.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "engines": {
+    "node": "22"
+  },
+  "dependencies": {
+    "@google-cloud/bigquery": "^8.1.1",
+    "@google-cloud/firestore": "^8.6.0"
+  }
+}

--- a/infra/coordinator/functions/ledger-export/transform.js
+++ b/infra/coordinator/functions/ledger-export/transform.js
@@ -1,0 +1,57 @@
+export function taskRow(task) {
+  const spec = task.spec ?? {};
+  const result = task.result ?? null;
+  return stripUndefined({
+    task_id: task.task_id,
+    status: task.status,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+    winner_agent_id: task.winner_agent_id,
+    auction_price_usd: task.auction_price_usd,
+    winning_bid_usd: task.winning_bid_usd,
+    prompt: spec.prompt,
+    min_tier: spec.min_tier,
+    output: result?.output,
+    actual_input_tokens: result?.actual_usage?.input_tokens,
+    actual_output_tokens: result?.actual_usage?.output_tokens,
+    spec_json: spec,
+    result_json: result,
+  });
+}
+
+export function bidRow(bid) {
+  const response = bid.response ?? {};
+  return stripUndefined({
+    task_id: bid.task_id,
+    agent_id: bid.agent_id,
+    timestamp: bid.timestamp,
+    response_kind: bid.response_kind,
+    tier: response.tier,
+    model_family: response.model_family,
+    model_id: response.model_id,
+    bid_usd: response.bid_usd,
+    est_input_tokens: response.est_input_tokens,
+    est_output_tokens: response.est_output_tokens,
+    no_bid_reason: bid.no_bid_reason,
+    response_json: response,
+    pricing_snapshot_json: bid.pricing_snapshot ?? [],
+  });
+}
+
+export function resultRow(result) {
+  return stripUndefined({
+    task_id: result.task_id,
+    agent_id: result.agent_id,
+    timestamp: result.timestamp,
+    actual_input_tokens: result.actual_input_tokens,
+    actual_output_tokens: result.actual_output_tokens,
+    actual_step_count: result.actual_step_count,
+    actual_tool_call_count: result.actual_tool_call_count,
+    result_json: result.result,
+    step_trace_json: result.step_trace,
+  });
+}
+
+export function stripUndefined(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined));
+}

--- a/infra/coordinator/functions/ledger-export/transform.test.js
+++ b/infra/coordinator/functions/ledger-export/transform.test.js
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { bidRow, resultRow, taskRow } from "./transform.js";
+
+test("taskRow flattens client-facing fields and keeps JSON payloads", () => {
+  assert.deepEqual(
+    taskRow({
+      task_id: "task-1",
+      status: "completed",
+      created_at: "2026-05-26T00:00:00.000Z",
+      updated_at: "2026-05-26T00:01:00.000Z",
+      winner_agent_id: "gcp-gemini",
+      auction_price_usd: 0.04,
+      winning_bid_usd: 0.02,
+      spec: { prompt: "summarize", min_tier: "frontier" },
+      result: {
+        output: "done",
+        actual_usage: { input_tokens: 1000, output_tokens: 200 },
+      },
+    }),
+    {
+      task_id: "task-1",
+      status: "completed",
+      created_at: "2026-05-26T00:00:00.000Z",
+      updated_at: "2026-05-26T00:01:00.000Z",
+      winner_agent_id: "gcp-gemini",
+      auction_price_usd: 0.04,
+      winning_bid_usd: 0.02,
+      prompt: "summarize",
+      min_tier: "frontier",
+      output: "done",
+      actual_input_tokens: 1000,
+      actual_output_tokens: 200,
+      spec_json: { prompt: "summarize", min_tier: "frontier" },
+      result_json: {
+        output: "done",
+        actual_usage: { input_tokens: 1000, output_tokens: 200 },
+      },
+    },
+  );
+});
+
+test("bidRow handles bids and no_bid rows", () => {
+  assert.equal(
+    bidRow({
+      task_id: "task-1",
+      agent_id: "aws-nova",
+      timestamp: "2026-05-26T00:00:01.000Z",
+      response_kind: "no_bid",
+      no_bid_reason: "capability",
+      response: { status: "no_bid", reason: "capability" },
+    }).no_bid_reason,
+    "capability",
+  );
+
+  assert.deepEqual(
+    bidRow({
+      task_id: "task-1",
+      agent_id: "gcp-gemini",
+      timestamp: "2026-05-26T00:00:01.000Z",
+      response_kind: "bid",
+      response: {
+        tier: "frontier",
+        model_family: "gemini",
+        model_id: "gemini-2-5-pro",
+        bid_usd: 0.02,
+        est_input_tokens: 1000,
+        est_output_tokens: 200,
+      },
+      pricing_snapshot: [{ model_id: "gemini-2-5-pro" }],
+    }),
+    {
+      task_id: "task-1",
+      agent_id: "gcp-gemini",
+      timestamp: "2026-05-26T00:00:01.000Z",
+      response_kind: "bid",
+      tier: "frontier",
+      model_family: "gemini",
+      model_id: "gemini-2-5-pro",
+      bid_usd: 0.02,
+      est_input_tokens: 1000,
+      est_output_tokens: 200,
+      response_json: {
+        tier: "frontier",
+        model_family: "gemini",
+        model_id: "gemini-2-5-pro",
+        bid_usd: 0.02,
+        est_input_tokens: 1000,
+        est_output_tokens: 200,
+      },
+      pricing_snapshot_json: [{ model_id: "gemini-2-5-pro" }],
+    },
+  );
+});
+
+test("resultRow flattens GAEP step trace counters", () => {
+  assert.deepEqual(
+    resultRow({
+      task_id: "task-1",
+      agent_id: "gcp-orchestrator",
+      timestamp: "2026-05-26T00:00:02.000Z",
+      actual_input_tokens: 1200,
+      actual_output_tokens: 300,
+      actual_step_count: 3,
+      actual_tool_call_count: 2,
+      result: { output: "done" },
+      step_trace: { total_steps: 3, tool_call_count: 2, steps: [] },
+    }),
+    {
+      task_id: "task-1",
+      agent_id: "gcp-orchestrator",
+      timestamp: "2026-05-26T00:00:02.000Z",
+      actual_input_tokens: 1200,
+      actual_output_tokens: 300,
+      actual_step_count: 3,
+      actual_tool_call_count: 2,
+      result_json: { output: "done" },
+      step_trace_json: { total_steps: 3, tool_call_count: 2, steps: [] },
+    },
+  );
+});

--- a/infra/coordinator/ledger_export.tf
+++ b/infra/coordinator/ledger_export.tf
@@ -1,0 +1,234 @@
+resource "google_bigquery_dataset" "ledger_export" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project    = var.project_id
+  dataset_id = var.ledger_bigquery_dataset_id
+  location   = var.ledger_bigquery_location
+
+  description                 = "Analytical export of the agent-tasker Firestore ledger"
+  delete_contents_on_destroy  = false
+  default_table_expiration_ms = var.ledger_bigquery_table_expiration_days == null ? null : var.ledger_bigquery_table_expiration_days * 24 * 60 * 60 * 1000
+}
+
+resource "google_bigquery_table" "ledger_tasks" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.ledger_export[0].dataset_id
+  table_id   = "ledger_tasks"
+
+  deletion_protection = var.ledger_bigquery_table_delete_protection
+
+  schema = jsonencode([
+    { name = "task_id", type = "STRING", mode = "REQUIRED" },
+    { name = "status", type = "STRING", mode = "REQUIRED" },
+    { name = "created_at", type = "TIMESTAMP" },
+    { name = "updated_at", type = "TIMESTAMP" },
+    { name = "winner_agent_id", type = "STRING" },
+    { name = "auction_price_usd", type = "FLOAT" },
+    { name = "winning_bid_usd", type = "FLOAT" },
+    { name = "prompt", type = "STRING" },
+    { name = "min_tier", type = "STRING" },
+    { name = "output", type = "STRING" },
+    { name = "actual_input_tokens", type = "INTEGER" },
+    { name = "actual_output_tokens", type = "INTEGER" },
+    { name = "spec_json", type = "JSON" },
+    { name = "result_json", type = "JSON" },
+  ])
+}
+
+resource "google_bigquery_table" "ledger_bids" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.ledger_export[0].dataset_id
+  table_id   = "ledger_bids"
+
+  deletion_protection = var.ledger_bigquery_table_delete_protection
+
+  schema = jsonencode([
+    { name = "task_id", type = "STRING", mode = "REQUIRED" },
+    { name = "agent_id", type = "STRING", mode = "REQUIRED" },
+    { name = "timestamp", type = "TIMESTAMP" },
+    { name = "response_kind", type = "STRING" },
+    { name = "tier", type = "STRING" },
+    { name = "model_family", type = "STRING" },
+    { name = "model_id", type = "STRING" },
+    { name = "bid_usd", type = "FLOAT" },
+    { name = "est_input_tokens", type = "INTEGER" },
+    { name = "est_output_tokens", type = "INTEGER" },
+    { name = "no_bid_reason", type = "STRING" },
+    { name = "response_json", type = "JSON" },
+    { name = "pricing_snapshot_json", type = "JSON" },
+  ])
+}
+
+resource "google_bigquery_table" "ledger_results" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.ledger_export[0].dataset_id
+  table_id   = "ledger_results"
+
+  deletion_protection = var.ledger_bigquery_table_delete_protection
+
+  schema = jsonencode([
+    { name = "task_id", type = "STRING", mode = "REQUIRED" },
+    { name = "agent_id", type = "STRING", mode = "REQUIRED" },
+    { name = "timestamp", type = "TIMESTAMP" },
+    { name = "actual_input_tokens", type = "INTEGER" },
+    { name = "actual_output_tokens", type = "INTEGER" },
+    { name = "actual_step_count", type = "INTEGER" },
+    { name = "actual_tool_call_count", type = "INTEGER" },
+    { name = "result_json", type = "JSON" },
+    { name = "step_trace_json", type = "JSON" },
+  ])
+}
+
+data "archive_file" "ledger_export_source" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  type        = "zip"
+  source_dir  = "${path.module}/functions/ledger-export"
+  output_path = "${path.module}/functions/.dist/ledger-export.zip"
+}
+
+resource "google_storage_bucket_object" "ledger_export_source" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  name   = "ledger-export-${data.archive_file.ledger_export_source[0].output_md5}.zip"
+  bucket = google_storage_bucket.functions_source.name
+  source = data.archive_file.ledger_export_source[0].output_path
+}
+
+resource "google_service_account" "ledger_export_runtime" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project      = var.project_id
+  account_id   = "${local.name_prefix}-ledger-export"
+  display_name = "Ledger-export function runtime SA"
+  description  = "Identity for scheduled Firestore ledger exports to BigQuery"
+}
+
+resource "google_project_iam_member" "ledger_export_firestore" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/datastore.viewer"
+  member  = "serviceAccount:${google_service_account.ledger_export_runtime[0].email}"
+}
+
+resource "google_project_iam_member" "ledger_export_bigquery_job_user" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.ledger_export_runtime[0].email}"
+}
+
+resource "google_bigquery_dataset_iam_member" "ledger_export_bigquery_writer" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.ledger_export[0].dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${google_service_account.ledger_export_runtime[0].email}"
+}
+
+resource "google_project_iam_member" "ledger_export_logs" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.ledger_export_runtime[0].email}"
+}
+
+resource "google_service_account" "ledger_export_scheduler" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project      = var.project_id
+  account_id   = "${local.name_prefix}-ledger-sched"
+  display_name = "Ledger-export scheduler SA"
+  description  = "Identity Cloud Scheduler assumes when invoking the ledger-export function"
+}
+
+resource "google_cloudfunctions2_function" "ledger_export" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project  = var.project_id
+  location = var.region
+  name     = "${local.name_prefix}-ledger-export"
+
+  build_config {
+    runtime     = "nodejs22"
+    entry_point = "exportLedger"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions_source.name
+        object = google_storage_bucket_object.ledger_export_source[0].name
+      }
+    }
+  }
+
+  service_config {
+    service_account_email = google_service_account.ledger_export_runtime[0].email
+
+    available_memory   = "512Mi"
+    timeout_seconds    = 540
+    max_instance_count = 1
+    min_instance_count = 0
+    ingress_settings   = "ALLOW_ALL"
+
+    environment_variables = {
+      GCP_PROJECT_ID        = var.project_id
+      BIGQUERY_DATASET      = google_bigquery_dataset.ledger_export[0].dataset_id
+      EXPORT_LOOKBACK_HOURS = tostring(var.ledger_bigquery_export_lookback_hours)
+    }
+  }
+
+  depends_on = [
+    google_bigquery_dataset_iam_member.ledger_export_bigquery_writer,
+    google_project_iam_member.ledger_export_bigquery_job_user,
+    google_project_iam_member.ledger_export_firestore,
+    google_project_iam_member.ledger_export_logs,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "ledger_export_scheduler_invoker" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project  = var.project_id
+  location = var.region
+  name     = google_cloudfunctions2_function.ledger_export[0].name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.ledger_export_scheduler[0].email}"
+}
+
+resource "google_cloud_scheduler_job" "ledger_export" {
+  count = var.ledger_bigquery_export_enabled ? 1 : 0
+
+  project = var.project_id
+  region  = var.region
+  name    = "${local.name_prefix}-ledger-export"
+
+  schedule  = var.ledger_bigquery_export_schedule
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = google_cloudfunctions2_function.ledger_export[0].service_config[0].uri
+    http_method = "POST"
+
+    oidc_token {
+      service_account_email = google_service_account.ledger_export_scheduler[0].email
+      audience              = google_cloudfunctions2_function.ledger_export[0].service_config[0].uri
+    }
+  }
+
+  retry_config {
+    retry_count          = 1
+    max_retry_duration   = "600s"
+    min_backoff_duration = "60s"
+    max_backoff_duration = "300s"
+    max_doublings        = 2
+  }
+}

--- a/infra/coordinator/variables.tf
+++ b/infra/coordinator/variables.tf
@@ -160,3 +160,60 @@ variable "cost_budget_alert_notification_channels" {
   type        = list(string)
   default     = []
 }
+
+variable "ledger_bigquery_export_enabled" {
+  description = "Whether to provision scheduled Firestore ledger export into BigQuery analytical tables."
+  type        = bool
+  default     = false
+}
+
+variable "ledger_bigquery_dataset_id" {
+  description = "BigQuery dataset ID for exported ledger tables."
+  type        = string
+  default     = "agent_tasker_ledger"
+
+  validation {
+    condition     = can(regex("^[A-Za-z_][A-Za-z0-9_]*$", var.ledger_bigquery_dataset_id)) && length(var.ledger_bigquery_dataset_id) <= 1024
+    error_message = "ledger_bigquery_dataset_id must be a valid BigQuery dataset ID."
+  }
+}
+
+variable "ledger_bigquery_location" {
+  description = "BigQuery dataset location for ledger exports."
+  type        = string
+  default     = "US"
+}
+
+variable "ledger_bigquery_table_delete_protection" {
+  description = "Whether BigQuery table deletion protection is enabled for ledger export tables."
+  type        = bool
+  default     = true
+}
+
+variable "ledger_bigquery_table_expiration_days" {
+  description = "Optional default table expiration in days for the ledger export dataset. Leave null to keep analytical tables indefinitely."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.ledger_bigquery_table_expiration_days == null || var.ledger_bigquery_table_expiration_days > 0
+    error_message = "ledger_bigquery_table_expiration_days must be positive when set."
+  }
+}
+
+variable "ledger_bigquery_export_schedule" {
+  description = "Cron expression (Etc/UTC) for scheduled Firestore ledger export to BigQuery."
+  type        = string
+  default     = "30 4 * * *"
+}
+
+variable "ledger_bigquery_export_lookback_hours" {
+  description = "How many hours of recently updated task documents each scheduled ledger export scans."
+  type        = number
+  default     = 24
+
+  validation {
+    condition     = var.ledger_bigquery_export_lookback_hours > 0
+    error_message = "ledger_bigquery_export_lookback_hours must be positive."
+  }
+}


### PR DESCRIPTION
## Summary
- add an opt-in scheduled ledger export Cloud Function for Firestore → BigQuery
- provision BigQuery dataset/tables plus least-privilege runtime and scheduler service accounts
- normalize task, bid, and result rows with flattened analysis columns and JSON replay payloads
- document how to enable the export

Closes #83.

## Validation
- node --test infra/coordinator/functions/ledger-export/transform.test.js
- terraform -chdir=infra/coordinator validate
- pnpm format