### PR TITLE
Harden Phase 1: lock GCP agents to coordinator-only invoker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project status
 
-Greenfield. No code yet. This document is the design spec — a multi-cloud "agent market" where four LLM-backed agents receive a task description, each privately estimates the cost in normalized USD to complete it, submit sealed bids, and the lowest bidder wins and executes the work. Coordinator runs a Vickrey (second-price) auction; agent reputation will layer in once the ledger has ~100 settled tasks.
+**Phase 1 (GCP-only, 2-bidder auction) is built and deployed.** The coordinator,
+the GCP/Gemini direct agent, and the GCP/Orchestrator (GAEP) agent run on Cloud
+Run in project `agent-tasker-lcd` (us-central1), with the Firestore ledger, JWKS
+publishing, and the daily pricing-refresh Cloud Function live. CI builds the
+images and applies Terraform on every push to `main` via Workload Identity
+Federation. The GCP agents are locked to coordinator-only `roles/run.invoker`;
+the coordinator authenticates with a Google OIDC token in
+`X-Serverless-Authorization` (Cloud Run IAM) plus the per-task RS256 JWT in
+`Authorization` (verified by the agent). Phases 2 (AWS/Nova) and 3 (Azure/GPT)
+are implemented in-tree but undeployed — their CI deploy steps are gated on the
+`AWS_ROLE_ARN` / `AZURE_CLIENT_ID` secrets, which are unset. See the repo layout
+and build-order sections below for the per-component map; the design rationale
+throughout remains the reference for *why*.
+
+This system is a multi-cloud "agent market" where four LLM-backed agents receive a task description, each privately estimates the cost in normalized USD to complete it, submit sealed bids, and the lowest bidder wins and executes the work. Coordinator runs a Vickrey (second-price) auction; agent reputation will layer in once the ledger has ~100 settled tasks.
 
 The four agents are role-locked by design so the market spans both *runtime/capability profiles* and *cross-vendor model families*:
 
@@ -15,7 +29,7 @@ The four agents are role-locked by design so the market spans both *runtime/capa
 
 Two agents live in GCP (same Google model family under the hood, different runtimes, independent endpoints, independent bidders). AWS and Azure host one each. The system is GCP-centric by design — the coordinator lives on GCP, both same-cloud bidders are on Vertex AI/Gemini, and Gemini Enterprise Agent Platform powers the GCP/Orchestrator agent. The "two GCP bidders" thus contrast on **runtime/capability** (direct call vs orchestration); cross-vendor **family contrast** (Google vs Amazon vs OpenAI) sits across the cloud boundary in AWS/Nova and Azure/GPT.
 
-When code starts landing, update this file's commands/architecture sections to reflect what is actually built; keep the design rationale below as the reference for *why*.
+Keep the design rationale below as the reference for *why*; when behavior diverges from this spec, update the affected section rather than letting it drift.
 
 ## Goals & non-goals
 
@@ -215,6 +229,8 @@ Per-task tokens:
 - Signed per request — no token reuse across phases
 
 Each agent verifies tokens at the entrypoint (Cloud Run middleware / Lambda authorizer / Function middleware) by fetching JWKS once and caching for the rotation window. Key rotation: dual-publish in JWKS for the rotation window, switch active signing key, retire old after agents have refreshed.
+
+**Transport gate on GCP agents (in addition to the task JWT).** The GCP/Gemini and GCP/Orchestrator Cloud Run services grant `roles/run.invoker` only to the coordinator runtime service account — no `allUsers`. So before the task JWT is even seen, Cloud Run's IAM check must pass. The coordinator satisfies it by minting a Google-signed OIDC ID token from the metadata server (`aud` = the agent's Cloud Run service URL) and sending it in the **`X-Serverless-Authorization`** header. Cloud Run validates that header for the IAM check and forwards the `Authorization` header (the per-task RS256 JWT) to the container untouched, so the agent's JWT middleware is unchanged. This is a two-layer gate — Cloud Run invoker IAM, then app-level task-JWT verification — and the reason the agents can keep public ingress without being open to the world. AWS/Nova and Azure/GPT enforce auth via the task JWT at their own edge (Lambda authorizer / API Management); the `X-Serverless-Authorization` token is attached only for GCP-leg agents.
 
 ## Pricing data (scheduled refresh)
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,20 @@ Multi-cloud "agent market": four model-locked LLM agents privately estimate the 
 - **End-of-v1 security review:** [`docs/security-review-checklist.md`](./docs/security-review-checklist.md)
 - **Operator console:** [`operator-console/index.html`](./operator-console/index.html)
 
-Greenfield. Phase 1 (GCP-only, 2-bidder) is the active build target.
+## Status
+
+**Phase 1 (GCP-only, 2-bidder auction) is built and deployed** to project
+`agent-tasker-lcd` (us-central1): the coordinator, the GCP/Gemini direct agent,
+and the GCP/Orchestrator (GAEP) agent run on Cloud Run, with the Firestore
+ledger, JWKS publishing, and the daily pricing-refresh function live. CI builds
+the images and applies Terraform on every push to `main` via Workload Identity
+Federation.
+
+The GCP agents' Cloud Run services are locked to coordinator-only
+`roles/run.invoker`; the coordinator authenticates with a Google OIDC token in
+`X-Serverless-Authorization` (for Cloud Run IAM) plus the per-task RS256 JWT in
+`Authorization` (verified by the agent).
+
+Phases 2 (AWS/Nova) and 3 (Azure/GPT) are implemented in-tree — agent code,
+Terraform, and CI deploy steps — but not yet deployed: their CI steps are gated
+on the `AWS_ROLE_ARN` / `AZURE_CLIENT_ID` secrets, which are unset.

--- a/coordinator/src/auction/http-runner.ts
+++ b/coordinator/src/auction/http-runner.ts
@@ -18,6 +18,7 @@ import type { LedgerStore } from "../ledger/store.js";
 import { recordAgentBidLatency, recordBidRoundLatency } from "../observability/market-metrics.js";
 import type { TaskRecord } from "../ledger/types.js";
 import type { AuctionRunner } from "./runner.js";
+import type { IdTokenProvider } from "./id-token.js";
 import { deliverCompletionWebhook, type WebhookSigner } from "./webhook-delivery.js";
 
 // Minimal real AuctionRunner that drives `bidding → awarded → executing →
@@ -68,6 +69,14 @@ export interface HttpAuctionRunnerOptions {
   callbackInitialBackoffMs?: number;
   callbackSleep?: (ms: number) => Promise<void>;
   webhookSigner?: WebhookSigner;
+  // Mints Google OIDC ID tokens (keyed by audience = agent base URL) so the
+  // coordinator can invoke GCP agents whose Cloud Run services are locked to
+  // coordinator-only `roles/run.invoker`. The token is sent in
+  // `X-Serverless-Authorization`; Cloud Run validates it there and leaves the
+  // task JWT in `Authorization` untouched for the agent. Only consulted for
+  // GCP-leg agents; AWS/Azure agents enforce auth via the task JWT alone.
+  // Omit (e.g. local dev / tests) to call agents without an ID token.
+  idTokenProvider?: IdTokenProvider;
   // Override for tests; defaults to the global `fetch` available in Node 22+.
   fetch?: typeof fetch;
   // Hook so callers can observe runs / surface errors. The runner itself
@@ -245,6 +254,7 @@ export class HttpAuctionRunner implements AuctionRunner {
             taskId,
             phase: "bid",
           });
+          const headers = await this.buildAgentRequestHeaders(agent, token);
           const response = await withSpan(
             "coordinator.agent.bid",
             { task_id: taskId, agent_id: agent.agentId, phase: "bid" },
@@ -255,14 +265,11 @@ export class HttpAuctionRunner implements AuctionRunner {
                 phase: "bid",
                 url: `${agent.baseUrl}/bid`,
                 body,
-                bearerToken: token,
+                headers,
               });
               const res = await fetchImpl(`${agent.baseUrl}/bid`, {
                 method: "POST",
-                headers: {
-                  "content-type": "application/json",
-                  authorization: `Bearer ${token}`,
-                },
+                headers,
                 body,
                 signal: controller.signal,
               });
@@ -335,6 +342,7 @@ export class HttpAuctionRunner implements AuctionRunner {
       throw new Error(`winner ${agentId} not in agent registry`);
     }
     const token = await this.opts.tokenSigner.sign({ agentId, taskId, phase: "execute" });
+    const headers = await this.buildAgentRequestHeaders(agent, token);
     const timeoutMs = this.opts.executeTimeoutMs ?? DEFAULT_EXECUTE_TIMEOUT_MS;
     const fetchImpl = this.opts.fetch ?? fetch;
     const controller = new AbortController();
@@ -358,14 +366,11 @@ export class HttpAuctionRunner implements AuctionRunner {
             phase: "execute",
             url: `${agent.baseUrl}/execute`,
             body: requestBody,
-            bearerToken: token,
+            headers,
           });
           const executeResponse = await fetchImpl(`${agent.baseUrl}/execute`, {
             method: "POST",
-            headers: {
-              "content-type": "application/json",
-              authorization: `Bearer ${token}`,
-            },
+            headers,
             body: requestBody,
             signal: controller.signal,
           });
@@ -406,20 +411,40 @@ export class HttpAuctionRunner implements AuctionRunner {
     return accuracyByAgent;
   }
 
+  // Builds the request headers for an agent call. Always carries the per-task
+  // RS256 JWT in `Authorization` (verified by the agent). For GCP-leg agents,
+  // additionally attaches a Google OIDC ID token in `X-Serverless-Authorization`
+  // so Cloud Run's coordinator-only invoker IAM check passes; Cloud Run consumes
+  // that header and forwards `Authorization` to the container unchanged.
+  private async buildAgentRequestHeaders(
+    agent: AgentEndpoint,
+    taskToken: string,
+  ): Promise<Record<string, string>> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      authorization: `Bearer ${taskToken}`,
+    };
+    if (cloudLegForAgent(agent.agentId) === "gcp" && this.opts.idTokenProvider) {
+      const idToken = await this.opts.idTokenProvider(agent.baseUrl);
+      if (idToken) headers["x-serverless-authorization"] = `Bearer ${idToken}`;
+    }
+    return headers;
+  }
+
   private recordAgentEgress({
     taskId,
     agentId,
     phase,
     url,
     body,
-    bearerToken,
+    headers,
   }: {
     taskId: TaskId;
     agentId: AgentId;
     phase: JwtPhase;
     url: string;
     body: string;
-    bearerToken: string;
+    headers: Record<string, string>;
   }): void {
     const target = new URL(url);
     const cloudLeg = cloudLegForAgent(agentId);
@@ -433,10 +458,7 @@ export class HttpAuctionRunner implements AuctionRunner {
       bytes_out: estimateHttpRequestBytes({
         method: "POST",
         path: target.pathname,
-        headers: {
-          "content-type": "application/json",
-          authorization: `Bearer ${bearerToken}`,
-        },
+        headers,
         body,
       }),
     };

--- a/coordinator/src/auction/id-token.ts
+++ b/coordinator/src/auction/id-token.ts
@@ -1,0 +1,82 @@
+// Google OIDC ID-token provider for coordinator → agent calls.
+//
+// When a GCP agent's Cloud Run service is locked to coordinator-only
+// invocation (`roles/run.invoker` granted only to the coordinator SA), the
+// coordinator must present a Google-signed ID token so Cloud Run's IAM check
+// passes. We send that token in the `X-Serverless-Authorization` header — Cloud
+// Run validates it there and leaves the `Authorization` header (which carries
+// the per-task RS256 JWT the agent verifies) untouched for the container. That
+// avoids moving the task JWT off `Authorization` and keeps the agent-side auth
+// unchanged.
+//
+// Tokens are fetched from the GCP metadata server, which mints an ID token for
+// the coordinator's runtime service account with `aud` set to the receiving
+// service's URL. No extra dependency or IAM grant is needed — every Cloud Run
+// instance can mint identity tokens for its own service account.
+
+export type IdTokenProvider = (audience: string) => Promise<string | undefined>;
+
+const METADATA_IDENTITY_URL =
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity";
+
+// Refresh a little before the ~1h metadata-server token lifetime so a cached
+// token never expires mid-flight on a slow auction.
+const TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000;
+const ASSUMED_TOKEN_LIFETIME_MS = 60 * 60 * 1000;
+
+interface CachedToken {
+  token: string;
+  expiresAtMs: number;
+}
+
+export interface MetadataIdTokenProviderOptions {
+  // Override for tests; defaults to the global `fetch`.
+  fetch?: typeof fetch;
+  // Override the clock for tests.
+  now?: () => number;
+}
+
+// Builds an IdTokenProvider backed by the GCP metadata server, caching one
+// token per audience until shortly before it expires. Decodes the JWT `exp`
+// claim to size the cache window; falls back to a conservative assumed lifetime
+// if the token can't be parsed.
+export function createMetadataIdTokenProvider(
+  options: MetadataIdTokenProviderOptions = {},
+): IdTokenProvider {
+  const fetchImpl = options.fetch ?? fetch;
+  const now = options.now ?? Date.now;
+  const cache = new Map<string, CachedToken>();
+
+  return async (audience: string): Promise<string | undefined> => {
+    const cached = cache.get(audience);
+    if (cached && cached.expiresAtMs - TOKEN_REFRESH_SKEW_MS > now()) {
+      return cached.token;
+    }
+
+    const url = `${METADATA_IDENTITY_URL}?audience=${encodeURIComponent(audience)}&format=full`;
+    const res = await fetchImpl(url, { headers: { "Metadata-Flavor": "Google" } });
+    if (!res.ok) {
+      throw new Error(`metadata identity fetch failed: ${res.status}`);
+    }
+    const token = (await res.text()).trim();
+    cache.set(audience, { token, expiresAtMs: tokenExpiryMs(token, now) });
+    return token;
+  };
+}
+
+// Reads the `exp` claim (seconds since epoch) from a JWT without verifying it —
+// we only use it to decide when to refresh our own cache. Returns a conservative
+// fallback if the token is unparseable.
+function tokenExpiryMs(token: string, now: () => number): number {
+  const fallback = now() + ASSUMED_TOKEN_LIFETIME_MS;
+  const parts = token.split(".");
+  if (parts.length < 2) return fallback;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as {
+      exp?: number;
+    };
+    return typeof payload.exp === "number" ? payload.exp * 1000 : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/coordinator/src/auction/index.ts
+++ b/coordinator/src/auction/index.ts
@@ -1,3 +1,4 @@
 export * from "./state-machine.js";
 export * from "./runner.js";
 export * from "./http-runner.js";
+export * from "./id-token.js";

--- a/coordinator/src/server.ts
+++ b/coordinator/src/server.ts
@@ -8,6 +8,7 @@ import {
   type AgentEndpoint,
   type TaskTokenSigner,
 } from "./auction/http-runner.js";
+import { createMetadataIdTokenProvider, type IdTokenProvider } from "./auction/id-token.js";
 import { StubAuctionRunner } from "./auction/runner.js";
 import { FirestoreLedgerStore } from "./ledger/firestore-store.js";
 import { SecretManagerKeyProvider } from "./jwt/secret-manager-key-provider.js";
@@ -47,10 +48,23 @@ if (signingKeySecretName && gcpGeminiUrl && gcpOrchestratorUrl) {
     ...(awsNovaUrl ? [{ agentId: "aws-nova" as const, baseUrl: awsNovaUrl }] : []),
     ...(azureGptUrl ? [{ agentId: "azure-gpt" as const, baseUrl: azureGptUrl }] : []),
   ];
+  // GCP agent Cloud Run services are locked to coordinator-only `run.invoker`,
+  // so the coordinator must present a Google OIDC ID token (in
+  // `X-Serverless-Authorization`) on each call. The metadata-server provider
+  // only works on Cloud Run; `K_SERVICE` is set there but not in local dev,
+  // where agents are reached without GCP IAM in front of them.
+  let idTokenProvider: IdTokenProvider | undefined;
+  if (process.env["K_SERVICE"]) {
+    idTokenProvider = createMetadataIdTokenProvider();
+    console.log("metadata ID-token provider enabled for GCP agent invocation");
+  } else {
+    console.warn("K_SERVICE not set — skipping OIDC ID tokens (local/dev agent calls)");
+  }
   runner = new HttpAuctionRunner({
     store,
     agents,
     tokenSigner,
+    ...(idTokenProvider ? { idTokenProvider } : {}),
     pricingSnapshot: Object.values(FALLBACK_PRICING),
     // Vertex AI Flash responds in 2-5s; give the bid window room to collect
     // before the adaptive timeout closes. Phase 1 agents are on min-instances=0

--- a/coordinator/test/auction/id-token.test.ts
+++ b/coordinator/test/auction/id-token.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMetadataIdTokenProvider } from "../../src/auction/id-token.js";
+
+// Builds a JWT-shaped string whose payload carries the given `exp` (seconds).
+// The provider only base64url-decodes the payload to size its cache; the
+// signature is irrelevant here.
+function tokenWithExp(expSeconds: number, marker = "tok"): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds, marker })).toString("base64url");
+  return `${header}.${payload}.sig-${marker}`;
+}
+
+const AUDIENCE = "https://agent.example.run.app";
+
+describe("createMetadataIdTokenProvider", () => {
+  it("requests an ID token from the metadata server for the given audience", async () => {
+    const now = 1_000_000;
+    const fetchImpl = vi.fn(
+      async () => new Response(tokenWithExp(now / 1000 + 3600), { status: 200 }),
+    );
+
+    const provider = createMetadataIdTokenProvider({
+      fetch: fetchImpl as unknown as typeof fetch,
+      now: () => now,
+    });
+    const token = await provider(AUDIENCE);
+
+    expect(token).toBe(tokenWithExp(now / 1000 + 3600));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toContain("metadata.google.internal");
+    expect(url).toContain(`audience=${encodeURIComponent(AUDIENCE)}`);
+    expect((init as RequestInit).headers).toMatchObject({ "Metadata-Flavor": "Google" });
+  });
+
+  it("caches the token per audience until shortly before expiry", async () => {
+    let now = 1_000_000;
+    const expSeconds = now / 1000 + 3600; // expires in 1h
+    const fetchImpl = vi.fn(async () => new Response(tokenWithExp(expSeconds), { status: 200 }));
+    const provider = createMetadataIdTokenProvider({
+      fetch: fetchImpl as unknown as typeof fetch,
+      now: () => now,
+    });
+
+    await provider(AUDIENCE);
+    now += 30 * 60 * 1000; // +30m, still well before expiry
+    await provider(AUDIENCE);
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // served from cache
+
+    // Past expiry minus the refresh skew → refetch.
+    now += 30 * 60 * 1000; // now at the 1h mark
+    await provider(AUDIENCE);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps separate cache entries per audience", async () => {
+    const now = 1_000_000;
+    const fetchImpl = vi.fn(
+      async () => new Response(tokenWithExp(now / 1000 + 3600), { status: 200 }),
+    );
+    const provider = createMetadataIdTokenProvider({
+      fetch: fetchImpl as unknown as typeof fetch,
+      now: () => now,
+    });
+
+    await provider("https://a.run.app");
+    await provider("https://b.run.app");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when the metadata server returns a non-200", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 503 }));
+    const provider = createMetadataIdTokenProvider({
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(provider(AUDIENCE)).rejects.toThrow(/metadata identity fetch failed: 503/);
+  });
+});

--- a/coordinator/test/integration/fake-agent.ts
+++ b/coordinator/test/integration/fake-agent.ts
@@ -25,17 +25,26 @@ export interface FakeAgentOptions {
   onExecute?: (req: ExecuteRequest) => Result | Promise<Result>;
 }
 
+export interface CapturedRequest {
+  path: "/bid" | "/execute";
+  authorization: string | undefined;
+  serverlessAuthorization: string | undefined;
+}
+
 export interface FakeAgent {
   readonly agentId: AgentId;
   readonly url: string;
   bidCalls: number;
   executeCalls: number;
+  // Auth headers seen on each /bid and /execute request, in arrival order.
+  readonly requests: CapturedRequest[];
   stop(): Promise<void>;
 }
 
 export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent> {
   const agentId = opts.agentId;
   const state = { bidCalls: 0, executeCalls: 0 };
+  const requests: CapturedRequest[] = [];
 
   const onBid =
     opts.onBid ??
@@ -60,6 +69,7 @@ export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent>
 
   app.post("/bid", async (c) => {
     state.bidCalls += 1;
+    requests.push(captureRequest(c, "/bid"));
     const body = (await c.req.json()) as unknown;
     const parsed = AnnounceRequestSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: "invalid request" }, 400);
@@ -68,6 +78,7 @@ export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent>
 
   app.post("/execute", async (c) => {
     state.executeCalls += 1;
+    requests.push(captureRequest(c, "/execute"));
     const body = (await c.req.json()) as unknown;
     const parsed = ExecuteRequestSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: "invalid request" }, 400);
@@ -87,6 +98,7 @@ export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent>
   const agent: FakeAgent = {
     agentId,
     url,
+    requests,
     get bidCalls() {
       return state.bidCalls;
     },
@@ -101,4 +113,15 @@ export async function startFakeAgent(opts: FakeAgentOptions): Promise<FakeAgent>
   };
 
   return agent;
+}
+
+function captureRequest(
+  c: { req: { header(name: string): string | undefined } },
+  path: "/bid" | "/execute",
+): CapturedRequest {
+  return {
+    path,
+    authorization: c.req.header("authorization"),
+    serverlessAuthorization: c.req.header("x-serverless-authorization"),
+  };
 }

--- a/coordinator/test/integration/http-runner.test.ts
+++ b/coordinator/test/integration/http-runner.test.ts
@@ -98,6 +98,7 @@ async function startAuction(opts: {
   callbackMaxAttempts?: number;
   callbackInitialBackoffMs?: number;
   callbackSleep?: (ms: number) => Promise<void>;
+  idTokenProvider?: (audience: string) => Promise<string | undefined>;
   onError?: (taskId: TaskId, err: unknown) => void;
 }): Promise<HttpAuctionRunner> {
   await store.createTask({
@@ -120,6 +121,7 @@ async function startAuction(opts: {
       ? { callbackInitialBackoffMs: opts.callbackInitialBackoffMs }
       : {}),
     ...(opts.callbackSleep !== undefined ? { callbackSleep: opts.callbackSleep } : {}),
+    ...(opts.idTokenProvider !== undefined ? { idTokenProvider: opts.idTokenProvider } : {}),
     ...(opts.onError !== undefined ? { onError: opts.onError } : {}),
     egressRecorder: opts.egressRecorder ?? (() => {}),
   });
@@ -659,6 +661,56 @@ describe("HttpAuctionRunner", () => {
       ]),
     );
     expect(egressEvents.every((event) => event.bytes_out > 0)).toBe(true);
+  });
+
+  it("sends OIDC X-Serverless-Authorization to GCP agents only, task JWT to all", async () => {
+    const taskId = "task-oidc-invoker";
+    const audiences: string[] = [];
+    const gemini = await startFakeAgent({
+      agentId: "gcp-gemini",
+      onBid: (req) => bidFor("gcp-gemini", 0.02, req.task_id),
+      onExecute: (req) => ({
+        task_id: req.task_id,
+        agent_id: "gcp-gemini",
+        output: "gemini did it",
+        actual_usage: { input_tokens: 4000, output_tokens: 1000 },
+      }),
+    });
+    const nova = await startFakeAgent({
+      agentId: "aws-nova",
+      onBid: (req) => bidFor("aws-nova", 0.04, req.task_id),
+    });
+    agents.push(gemini, nova);
+
+    await startAuction({
+      taskId,
+      endpoints: [
+        { agentId: "gcp-gemini", baseUrl: gemini.url },
+        { agentId: "aws-nova", baseUrl: nova.url },
+      ],
+      idTokenProvider: async (audience) => {
+        audiences.push(audience);
+        return `id-token-for.${audience}`;
+      },
+    });
+
+    // GCP agent: Cloud Run IAM token in X-Serverless-Authorization, task JWT in
+    // Authorization. Both bid and execute requests carry it.
+    expect(gemini.requests.length).toBeGreaterThanOrEqual(2);
+    for (const req of gemini.requests) {
+      expect(req.authorization).toBe(
+        `Bearer stub-token.gcp-gemini.${req.path === "/bid" ? "bid" : "execute"}`,
+      );
+      expect(req.serverlessAuthorization).toBe(`Bearer id-token-for.${gemini.url}`);
+    }
+    // The ID token audience is the agent's base URL (Cloud Run service URL).
+    expect(audiences).toContain(gemini.url);
+
+    // Non-GCP agent: task JWT only; no OIDC token requested for its audience.
+    const novaBid = nova.requests.find((r) => r.path === "/bid");
+    expect(novaBid?.authorization).toBe("Bearer stub-token.aws-nova.bid");
+    expect(novaBid?.serverlessAuthorization).toBeUndefined();
+    expect(audiences).not.toContain(nova.url);
   });
 
   it("estimates request bytes with UTF-8 body and header length", () => {

--- a/docs/security-review-2026-06-19-phase1.md
+++ b/docs/security-review-2026-06-19-phase1.md
@@ -1,0 +1,119 @@
+# Phase 1 Security Review — Sign-off (2026-06-19)
+
+Records the end-of-v1 review for the **deployed Phase 1 (GCP-only, 2-bidder)**
+surface, run against [`docs/security-review-checklist.md`](./security-review-checklist.md).
+Scope is the coordinator, the GCP/Gemini and GCP/Orchestrator agents, JWKS
+publishing, pricing refresh, and CI. AWS/Nova and Azure/GPT are implemented
+in-tree but undeployed; their controls are reviewed at the source level only and
+re-reviewed when those stacks go live.
+
+- **Reviewer:** Josh Lopez (operator)
+- **Commit under review:** branch `harden/phase1-coordinator-invoker` (the
+  coordinator-only invoker change lands here).
+- **Method:** Terraform/code is the source of truth (CI applies it on every push
+  to `main`), supplemented by the one externally observable artifact (the public
+  JWKS document). Items needing live IAM/secret/audit-log export are flagged
+  **[live-pending]** — gcloud ADC was expired at review time (`invalid_rapt`);
+  capture them post-merge after `gcloud auth login`.
+
+## Headline change reviewed
+
+The GCP agents previously granted `roles/run.invoker` to `allUsers`; the
+application JWT was the only auth boundary. This review covers the switch to
+**coordinator-SA-only invoker** plus the coordinator's Google OIDC token in
+`X-Serverless-Authorization` (Cloud Run IAM) layered over the per-task RS256 JWT
+in `Authorization` (agent verification). Two independent gates now protect every
+agent call.
+
+## Evidence captured
+
+- Terraform source for all live modules (`infra/coordinator`, `infra/project`,
+  `infra/agent-gcp-gemini`, `infra/agent-gcp-orchestrator`).
+- JWKS document fetched from
+  `https://storage.googleapis.com/agent-tasker-dev-jwks-agent-tasker-lcd/jwks.json`
+  — one RS256 signing key, `use: sig`, `kid=fb2366ca-1b5b-47f4-8ce5-7cb2c683c264`.
+- CI run on `main` showing node typecheck+test, terraform fmt+validate, and the
+  build/push/deploy job all green (run 27448206097).
+- Coordinator + agent source for the auth path.
+
+## Findings against checklist
+
+### Coordinator — PASS (source)
+- Public `allUsers` invoker is intentional and scoped to the coordinator service
+  only (`infra/coordinator/cloud_run.tf`); it is the single-operator SPA/API
+  entry point. **[live-pending]** confirm no stray invoker bindings.
+- JWKS bucket has object versioning enabled (`infra/coordinator/jwks.tf:35`).
+- Callback delivery uses a coordinator-signed RS256 JWT with a stable
+  idempotency key; webhook failure does not roll back a completed task
+  (`coordinator/src/auction/webhook-delivery.ts`, covered by tests).
+
+### JWT and replay — PASS (source)
+- Task token TTL is 60s (`protocol/src/auth.ts:8`, `TOKEN_TTL_SECONDS`).
+- Agents verify issuer, audience, and phase before handler logic
+  (`agent/src/jwt/verify.ts`); `aud` is agent-specific so tokens can't be
+  replayed across agents; tokens are signed per request/phase.
+- Webhook tokens use the callback URL as `aud` and carry `event: task.completed`.
+
+### GCP agents — PASS (source), this PR
+- Distinct Cloud Run services and distinct runtime service accounts
+  (`agent-tasker-dev-gcp-gemini` vs an `…-orch` SA), verified by
+  `infra/test/gcp-agent-isolation.test.ts`.
+- **Both agents now grant `roles/run.invoker` only to the coordinator runtime
+  SA — no `allUsers`** (this PR; static test updated to assert it). Neither agent
+  can invoke the other.
+- GCP/Gemini has direct Vertex roles only and no GAEP roles; GCP/Orchestrator
+  holds the GAEP execution roles and runs via GAEP, not direct Vertex — asserted
+  by the isolation and runtime-separation tests.
+- Transport gate: coordinator sends a metadata-minted OIDC token (aud = agent
+  service URL) in `X-Serverless-Authorization`; Cloud Run validates it and
+  forwards `Authorization` (the task JWT) to the container unchanged.
+
+### AWS/Nova and Azure/GPT — source-only (undeployed)
+- Nova Bedrock permissions are scoped to Amazon Nova foundation-model ARNs only
+  (`infra/agent-aws-nova/iam.tf`), with `InvokeModel`/`InvokeModelWithResponseStream`.
+- Full review deferred until Phase 2/3 deploy; re-run this checklist then.
+
+### Secrets and rotation — PARTIAL
+- Coordinator private signing key lives in Secret Manager
+  (`agent-tasker-dev-coordinator-signing-key`), not committed or in Terraform
+  variables. **[live-pending]** secret inventory with owner/rotation/last-rotated
+  per secret; Grafana OTLP header sensitivity in TF state.
+
+### Ledger and auditability — PASS (source)
+- Bid records carry per-task pricing snapshots; sealed bids are never returned to
+  agents. Declines, execute failures, re-auctions, and callback failures are
+  distinguishable in the ledger (covered by coordinator tests).
+- **[live-pending]** pull one real task's announce→settle audit-log trail and one
+  denied request per agent.
+
+### CI and release gates — PASS
+- CI runs lint/format/typecheck/tests/build + terraform validate; infra static
+  tests still verify GCP agent isolation. New IAM grant carries a justification
+  comment in the Terraform.
+
+## Items to capture after merge (require `gcloud auth login`)
+
+1. `gcloud run services get-iam-policy` for both agents → confirm only the
+   coordinator SA holds `run.invoker`, and a denied anonymous call returns 403.
+2. Coordinator + both agent SA project-IAM exports → least privilege.
+3. Secret inventory (owner, rotation interval, last rotation) for the signing key
+   and any agent secrets.
+4. Audit-log sample: one successful task and one denied request per agent.
+5. Post-deploy smoke test: submit a task and confirm it settles end-to-end with
+   the new invoker IAM in force (proves the OIDC path works in prod).
+
+## Residual risks (carried forward)
+
+- Both GCP agents share one project; per-project split remains a future tightening
+  if IAM Conditions or audit needs become brittle.
+- JWKS is served from public GCS directly, not yet behind Cloud CDN / external LB.
+- Coordinator public API has no end-user auth layer — single-operator only.
+- Callback delivery is signed but does not prove the receiver is operator-owned;
+  keep an allowlist before accepting untrusted clients.
+
+## Sign-off
+
+Phase 1 deployed surface passes at the source/Terraform level, with the
+coordinator-only invoker change closing the main open finding from the prior
+state. Sign-off is **conditional** on capturing the five live-evidence items
+above after this PR's CI deploy completes.

--- a/infra/agent-gcp-gemini/cloud_run.tf
+++ b/infra/agent-gcp-gemini/cloud_run.tf
@@ -130,15 +130,18 @@ resource "google_cloud_run_v2_service" "agent" {
   ]
 }
 
-# Phase 1: public invoker so the coordinator can call the agent with its
-# custom JWT in the Authorization header without needing a GCP OIDC token.
-# Application-level JWT (RS256, coordinator-signed) is the auth boundary.
-# Future: switch to coordinator-SA-only invoker + X-Task-Token OIDC two-
-# token pattern once OIDC fetching is wired in HttpAuctionRunner.
-resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
+# `roles/run.invoker` is granted ONLY to the coordinator runtime SA, so no
+# other principal — including the sibling GCP/Orchestrator agent or any
+# external caller — can invoke this service. The coordinator presents a
+# Google-signed OIDC ID token in the `X-Serverless-Authorization` header
+# (minted from the metadata server, aud = this service URL); Cloud Run
+# validates it for this IAM check and forwards the `Authorization` header (the
+# per-task RS256 JWT) to the container unchanged. Two layers gate every call:
+# Cloud Run invoker IAM (this binding) and the agent's task-JWT verification.
+resource "google_cloud_run_v2_service_iam_member" "coordinator_invoker" {
   project  = google_cloud_run_v2_service.agent.project
   location = google_cloud_run_v2_service.agent.location
   name     = google_cloud_run_v2_service.agent.name
   role     = "roles/run.invoker"
-  member   = "allUsers"
+  member   = "serviceAccount:${var.coordinator_service_account_email}"
 }

--- a/infra/agent-gcp-orchestrator/cloud_run.tf
+++ b/infra/agent-gcp-orchestrator/cloud_run.tf
@@ -136,15 +136,18 @@ resource "google_cloud_run_v2_service" "agent" {
   ]
 }
 
-# Phase 1: public invoker so the coordinator can call the agent with its
-# custom JWT in the Authorization header without needing a GCP OIDC token.
-# Application-level JWT (RS256, coordinator-signed) is the auth boundary.
-# Future: switch to coordinator-SA-only invoker + X-Task-Token OIDC two-
-# token pattern once OIDC fetching is wired in HttpAuctionRunner.
-resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
+# `roles/run.invoker` is granted ONLY to the coordinator runtime SA, so no
+# other principal — including the sibling GCP/Gemini agent or any external
+# caller — can invoke this service. The coordinator presents a Google-signed
+# OIDC ID token in the `X-Serverless-Authorization` header (minted from the
+# metadata server, aud = this service URL); Cloud Run validates it for this IAM
+# check and forwards the `Authorization` header (the per-task RS256 JWT) to the
+# container unchanged. Two layers gate every call: Cloud Run invoker IAM (this
+# binding) and the agent's task-JWT verification.
+resource "google_cloud_run_v2_service_iam_member" "coordinator_invoker" {
   project  = google_cloud_run_v2_service.agent.project
   location = google_cloud_run_v2_service.agent.location
   name     = google_cloud_run_v2_service.agent.name
   role     = "roles/run.invoker"
-  member   = "allUsers"
+  member   = "serviceAccount:${var.coordinator_service_account_email}"
 }

--- a/infra/test/gcp-agent-isolation.test.ts
+++ b/infra/test/gcp-agent-isolation.test.ts
@@ -33,16 +33,16 @@ describe("GCP agent Terraform isolation", () => {
     );
   });
 
-  // Phase 1: agents use allUsers invoker so the coordinator can call them
-  // with a custom RS256 JWT without needing Cloud Run OIDC tokens. The agent
-  // middleware enforces the application-level JWT. Phase 2 will switch to
-  // coordinator-SA-only invoker + OIDC two-token pattern.
-  it("uses allUsers Cloud Run invoker (Phase 1) — application JWT is the auth boundary", () => {
+  // Cloud Run invoker is locked to the coordinator runtime SA only: no
+  // allUsers, and neither agent grants invoke to the other. The coordinator
+  // presents a Google OIDC token in X-Serverless-Authorization for this IAM
+  // check; the agent's task-JWT verification is the second, app-level layer.
+  it("grants Cloud Run invoker only to the coordinator service account — no allUsers", () => {
     for (const moduleText of [geminiInfra, orchestratorInfra]) {
-      expect(moduleText).toContain('member   = "allUsers"');
-      expect(moduleText).not.toContain(
-        'member   = "serviceAccount:${google_service_account.agent_runtime.email}"',
+      expect(moduleText).toContain(
+        'member   = "serviceAccount:${var.coordinator_service_account_email}"',
       );
+      expect(moduleText).not.toContain('member   = "allUsers"');
     }
   });
 


### PR DESCRIPTION
## What

Closes the main open finding from the deployed Phase 1 state: both GCP agents' Cloud Run `roles/run.invoker` was granted to `allUsers`, leaving the application JWT as the only auth boundary. This switches them to **coordinator-SA-only** invocation.

## How the two-token gate works

Cloud Run's IAM check now requires a Google-signed identity. The coordinator mints an OIDC ID token from the metadata server (`aud` = the agent's service URL) and sends it in **`X-Serverless-Authorization`**. Cloud Run validates that header and forwards `Authorization` (the per-task RS256 JWT) to the container unchanged — so the agent's JWT middleware is untouched. Two independent gates now protect every agent call: Cloud Run invoker IAM, then app-level task-JWT verification.

- OIDC token attached **only for GCP-leg agents**; AWS/Nova and Azure/GPT keep authenticating via the task JWT at their own edge.
- Provider gated on `K_SERVICE` (set only on Cloud Run), so local dev and tests call agents without it. Injectable for tests.

## Why one push is safe

CI applies the coordinator module **before** the agent modules, and the new `X-Serverless-Authorization` header is harmless while the invoker is still `allUsers`. So by the time the IAM flip applies, the coordinator is already sending the OIDC token — no broken window.

## Also in this PR

- **Docs:** CLAUDE.md/README updated from "greenfield" to the real deployed Phase 1 state; documented the transport gate in the auth section.
- **Security review:** added a dated Phase 1 sign-off (`docs/security-review-2026-06-19-phase1.md`) with source-level findings and the live-evidence items to capture post-deploy.
- **Tests:** new unit tests for the metadata ID-token provider; new integration test asserting GCP agents receive `X-Serverless-Authorization` while non-GCP don't; infra isolation test updated to assert coordinator-SA-only invoker.

## Validation

Local run of the full CI set — `pnpm lint`, `pnpm format`, `pnpm typecheck`, `pnpm test` (all suites), `terraform fmt -check -recursive infra`, and `terraform validate` on both changed agent modules — all green.

## Post-merge follow-up (needs `gcloud auth login`)

Per the security sign-off, capture live evidence after CI deploys: agent IAM policy export (confirm only coordinator SA has invoker + anonymous call returns 403), and an end-to-end smoke test proving the OIDC path works in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)