### PR TITLE
Complete Phase 1 security sign-off with post-deploy evidence

### DIFF
--- a/docs/security-review-2026-06-19-phase1.md
+++ b/docs/security-review-2026-06-19-phase1.md
@@ -73,34 +73,59 @@ agent call.
   (`infra/agent-aws-nova/iam.tf`), with `InvokeModel`/`InvokeModelWithResponseStream`.
 - Full review deferred until Phase 2/3 deploy; re-run this checklist then.
 
-### Secrets and rotation — PARTIAL
-- Coordinator private signing key lives in Secret Manager
-  (`agent-tasker-dev-coordinator-signing-key`), not committed or in Terraform
-  variables. **[live-pending]** secret inventory with owner/rotation/last-rotated
-  per secret; Grafana OTLP header sensitivity in TF state.
+### Secrets and rotation — PASS (live)
+- Only one secret exists: `agent-tasker-dev-coordinator-signing-key` (created
+  2026-05-30, single enabled version `1`, never rotated). Not committed or in
+  Terraform variables. Read access is via the coordinator SA's
+  `roles/secretmanager.secretAccessor`. **Follow-up:** the accessor grant is
+  project-level, not secret-scoped — acceptable with one secret, tighten if more
+  land; and establish a rotation cadence for the signing key (see JWKS
+  dual-publish in the checklist).
 
-### Ledger and auditability — PASS (source)
+### Ledger and auditability — PASS (live + source)
 - Bid records carry per-task pricing snapshots; sealed bids are never returned to
   agents. Declines, execute failures, re-auctions, and callback failures are
   distinguishable in the ledger (covered by coordinator tests).
-- **[live-pending]** pull one real task's announce→settle audit-log trail and one
-  denied request per agent.
+- Audit-log samples captured post-deploy (see appendix): a successful task
+  (gemini `/bid`+`/execute` 200, orchestrator `/bid` 200) and denied requests
+  (anonymous `/health` 403; a transient post-deploy propagation 403 on the
+  orchestrator).
 
 ### CI and release gates — PASS
 - CI runs lint/format/typecheck/tests/build + terraform validate; infra static
   tests still verify GCP agent isolation. New IAM grant carries a justification
   comment in the Terraform.
 
-## Items to capture after merge (require `gcloud auth login`)
+## Post-deploy live evidence (captured 2026-06-19)
 
-1. `gcloud run services get-iam-policy` for both agents → confirm only the
-   coordinator SA holds `run.invoker`, and a denied anonymous call returns 403.
-2. Coordinator + both agent SA project-IAM exports → least privilege.
-3. Secret inventory (owner, rotation interval, last rotation) for the signing key
-   and any agent secrets.
-4. Audit-log sample: one successful task and one denied request per agent.
-5. Post-deploy smoke test: submit a task and confirm it settles end-to-end with
-   the new invoker IAM in force (proves the OIDC path works in prod).
+Captured after the merge of #171 deployed via CI:
+
+1. **Invoker IAM** — `run.invoker` on both agents resolves to exactly
+   `serviceAccount:agent-tasker-dev-coordinator@agent-tasker-lcd.iam.gserviceaccount.com`;
+   no `allUsers`. Anonymous `GET /health` on each agent returns **403**.
+2. **Runtime SA least privilege** (project IAM):
+   - Coordinator (`agent-tasker-dev-coordinator`): `datastore.user`,
+     `secretmanager.secretAccessor`, `logging.logWriter`. No project-level
+     storage role → JWKS bucket write is bucket-scoped, not project-wide.
+   - GCP/Gemini (`agent-tasker-dev-gcp-gemini`): `aiplatform.user`,
+     `logging.logWriter`. No GAEP roles. (No publisher IAM Condition on
+     `aiplatform.user` — optional defense-in-depth per design; runtime + SA
+     separation is the load-bearing isolation. **Follow-up:** consider adding
+     the `publishers/google/` condition.)
+   - GCP/Orchestrator (`agent-tasker-dev-orch`): `aiplatform.user`,
+     `discoveryengine.agentspaceUser` (GAEP), `logging.logWriter`. Holds the
+     GAEP role the Gemini agent lacks — separation confirmed.
+3. **Secrets** — see "Secrets and rotation" above.
+4. **Audit-log sample** — see "Ledger and auditability" above.
+5. **End-to-end smoke test** — two tasks submitted to the prod coordinator
+   settled `completed`; the second was a genuine two-bidder Vickrey auction
+   (`winning_bid 4.875e-5` < `auction_price 3.125e-4`), proving the coordinator's
+   OIDC path reaches both locked-down agents for `/bid` and `/execute`.
+
+**Operational note:** the IAM flip has ~60–95s propagation lag. The first
+post-deploy task 403'd the orchestrator (its binding applied last in the CI
+deploy); the next task ~95s later was clean. Expect a brief self-healing window
+after any future invoker/IAM change — not a bug.
 
 ## Residual risks (carried forward)
 
@@ -110,10 +135,18 @@ agent call.
 - Coordinator public API has no end-user auth layer — single-operator only.
 - Callback delivery is signed but does not prove the receiver is operator-owned;
   keep an allowlist before accepting untrusted clients.
+- Coordinator `secretmanager.secretAccessor` is project-level, not secret-scoped;
+  the signing key has a single never-rotated version. Tighten the grant and set a
+  rotation cadence as the secret set grows.
+- GCP/Gemini `aiplatform.user` carries no `publishers/google/` IAM Condition
+  (optional belt-and-suspenders).
 
 ## Sign-off
 
-Phase 1 deployed surface passes at the source/Terraform level, with the
-coordinator-only invoker change closing the main open finding from the prior
-state. Sign-off is **conditional** on capturing the five live-evidence items
-above after this PR's CI deploy completes.
+**Phase 1 deployed surface is signed off.** Source/Terraform controls pass, the
+coordinator-only invoker change closed the main open finding, and all five
+live-evidence items were captured post-deploy and confirm the intended posture
+(coordinator-only invocation, runtime SA least privilege, working OIDC transport
+gate). Remaining items are tracked as residual-risk follow-ups above, not
+blockers. Re-run this checklist when Phase 2 (AWS/Nova) or Phase 3 (Azure/GPT)
+deploys.


### PR DESCRIPTION
Closes out the remaining open items from the Phase 1 hardening work (#171): the conditional security sign-off's five live-evidence items.

Captured post-deploy against prod (`agent-tasker-lcd`):
- **Invoker IAM** — both agents resolve `run.invoker` to the coordinator SA only; anonymous `/health` returns 403.
- **Runtime SA least privilege** — coordinator (`datastore.user`, `secretmanager.secretAccessor`, `logging.logWriter`; no project storage role → JWKS write is bucket-scoped); gemini (`aiplatform.user` + logging, no GAEP); orchestrator (`aiplatform.user` + `discoveryengine.agentspaceUser` + logging). Separation confirmed.
- **Secrets** — one secret (signing key), single never-rotated version.
- **Audit-log samples** — successful task + denied requests.
- **Smoke test** — two-bidder Vickrey auction settles end to end, proving the OIDC transport gate reaches both locked-down agents.

Sign-off flipped from **conditional → complete**. New residual-risk follow-ups recorded (secret-scoping the accessor grant, signing-key rotation cadence, optional `publishers/google/` IAM Condition on the Gemini agent). Also documents the ~60–95s IAM-propagation lag observed at deploy.

Docs-only; no code or infra change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)