### PR TITLE
Phase 2: bring AWS/Nova online (3-bidder auction)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pnpm-debug.log*
 *.tfstate
 *.tfstate.*
 *.tfplan
+tfplan
 crash.log
 crash.*.log
 override.tf

--- a/infra/agent-aws-nova/cicd.tf
+++ b/infra/agent-aws-nova/cicd.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "cicd_assume_role" {
 
 resource "aws_iam_role" "cicd" {
   name               = "${local.agent_name}-cicd"
-  description        = "CI/CD role for GitHub Actions — manages this module's Lambda, API Gateway, IAM, and S3 resources."
+  description        = "CI/CD role for GitHub Actions - manages this module's Lambda, API Gateway, IAM, and S3 resources."
   assume_role_policy = data.aws_iam_policy_document.cicd_assume_role.json
 }
 

--- a/infra/agent-aws-nova/lambda.tf
+++ b/infra/agent-aws-nova/lambda.tf
@@ -27,8 +27,8 @@ resource "aws_lambda_function" "agent" {
       AWS_NOVA_EXEC_MODEL_ID      = var.bedrock_execute_model_id
       JWKS_URL                    = var.jwks_url
       NODE_OPTIONS                = "--enable-source-maps"
-      OTEL_EXPORTER_OTLP_ENDPOINT = coalesce(var.otel_exporter_otlp_endpoint, "")
-      OTEL_EXPORTER_OTLP_HEADERS  = coalesce(var.otel_exporter_otlp_headers, "")
+      OTEL_EXPORTER_OTLP_ENDPOINT = var.otel_exporter_otlp_endpoint != null ? var.otel_exporter_otlp_endpoint : ""
+      OTEL_EXPORTER_OTLP_HEADERS  = var.otel_exporter_otlp_headers != null ? var.otel_exporter_otlp_headers : ""
       OTEL_SERVICE_NAME           = "agent-tasker-aws-nova"
       OTEL_TRACES_EXPORTER        = var.otel_exporter_otlp_endpoint == null ? "none" : "otlp"
       POWERTOOLS_SERVICE_NAME     = "agent-aws-nova"

--- a/infra/coordinator/terraform.tfvars
+++ b/infra/coordinator/terraform.tfvars
@@ -13,8 +13,8 @@ coordinator_min_instances = 1
 gcp_gemini_agent_url       = "https://agent-tasker-dev-gcp-gemini-n6ey4mj4ma-uc.a.run.app"
 gcp_orchestrator_agent_url = "https://agent-tasker-dev-gcp-orchestrator-n6ey4mj4ma-uc.a.run.app"
 
-# Set to the agent_api_endpoint output from infra/agent-aws-nova after Phase 2 bootstrap.
-aws_nova_agent_url = ""
+# agent_api_endpoint output from infra/agent-aws-nova (Phase 2 bootstrap, 2026-06-19).
+aws_nova_agent_url = "https://63iwfo9eek.execute-api.us-east-1.amazonaws.com"
 
 # Set to the agent_url output from infra/agent-azure-gpt after Phase 3 bootstrap.
 azure_gpt_agent_url = ""


### PR DESCRIPTION
Brings the AWS/Nova agent live, taking the auction from 2 to 3 bidders.

## What's already done (out-of-band, before this PR)
- **Bootstrapped `infra/agent-aws-nova` locally** (the CI role is created *by* this module, so the first apply can't run in CI). Created: GitHub OIDC provider, `cicd` role (AdministratorAccess), Nova-scoped runtime role, S3 artifacts bucket, placeholder Lambda, API Gateway → `https://63iwfo9eek.execute-api.us-east-1.amazonaws.com`. Account `794661977072`, us-east-1.
- **Set the `AWS_ROLE_ARN` GitHub secret** ← `cicd_role_arn`, so CI's `HAS_AWS` gate is now true.

## What this PR does
- **coordinator:** sets `aws_nova_agent_url` to the API Gateway endpoint so `HttpAuctionRunner` adds `aws-nova` to the pool. On merge, CI redeploys the coordinator with the third bidder.
- **Two latent bug fixes** surfaced by the module's first-ever apply:
  - `lambda.tf`: `coalesce(var.x, "")` → null-safe ternary for the OTLP env vars (coalesce rejects null+empty; errored at plan with no exporter configured — matches the GCP agents' pattern).
  - `cicd.tf`: removed a non-ASCII em-dash from the CI role `description` (IAM `CreateRole` enforces ASCII-only).
- `.gitignore`: also ignore bare `tfplan` (only `*.tfplan` was covered).

## On merge, CI will
1. Build the real Nova Lambda zip and upload it to S3, then `terraform apply` `agent-aws-nova` to deploy it over the placeholder.
2. `terraform apply` the coordinator with `aws_nova_agent_url` set.

Then I'll run the 3-bidder smoke test (Bedrock Nova model access is already enabled for the account).

## Notes
- Bidding works immediately on `FALLBACK_PRICING` (Nova micro/lite/pro are already in `/protocol`). The live AWS Bedrock pricing parser (build-order item 9) is a non-blocking follow-up.
- This is the first cross-cloud egress leg (GCP coordinator → AWS agent); cost is fractions of a cent per task at these payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)