### PR TITLE
Fix CI: set up pnpm/node in deploy job for off-cloud agent builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node/pnpm are only needed to build the off-cloud agent Lambda/container
+      # bundles (AWS/Nova zip, Azure/GPT image). The GCP images build via Docker
+      # and don't need them. Gated so GCP-only deploys stay lean.
+      - uses: pnpm/action-setup@v4
+        if: env.HAS_AWS == 'true' || env.HAS_AZURE == 'true'
+
+      - uses: actions/setup-node@v4
+        if: env.HAS_AWS == 'true' || env.HAS_AZURE == 'true'
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
       - id: auth
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
The deploy job's "Build Lambda zip" step (and the Azure image build) run `pnpm`, but the deploy job never set up pnpm/node — the GCP images build via Docker/Cloud Build, so Node was never needed on the runner. The step was dormant until `AWS_ROLE_ARN` was set; the first `HAS_AWS == true` run failed with `pnpm: command not found` (exit 127), so the real Nova Lambda never deployed over the placeholder.

Adds `pnpm/action-setup@v4` + `actions/setup-node@v4` (pnpm cache) right after checkout, gated on `HAS_AWS || HAS_AZURE` so GCP-only deploys stay lean.

No functional impact until merge re-runs the deploy, which will then build + deploy the real Nova Lambda and complete the 3-bidder rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)