### PR TITLE
Fix CI: preserve symlinks when zipping the Nova Lambda bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,11 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm --filter '@agent-tasker/agent-aws-nova...' build
           pnpm --filter @agent-tasker/agent-aws-nova deploy --prod /tmp/aws-nova-deploy
-          cd /tmp/aws-nova-deploy && zip -r "$GITHUB_WORKSPACE/aws-nova.zip" .
+          # -y preserves pnpm's symlinked node_modules. Without it, zip
+          # dereferences every .pnpm symlink into a full copy, inflating the
+          # unzipped bundle ~9x (822MB) past Lambda's 250MB limit; with it the
+          # bundle stays ~59MB. Lambda resolves the relative symlinks fine.
+          cd /tmp/aws-nova-deploy && zip -r -y "$GITHUB_WORKSPACE/aws-nova.zip" .
 
       - name: Configure AWS credentials
         if: env.HAS_AWS == 'true'


### PR DESCRIPTION
The deploy job's `Terraform apply — aws-nova agent` step failed with `InvalidParameterValueException: Unzipped size must be smaller than 262144000 bytes`.

Root cause: `pnpm deploy --prod` yields a `node_modules` that is mostly symlinks into `.pnpm/`. `zip -r` (no `-y`) follows each symlink and writes a full duplicate copy, so the **unzipped** bundle balloons to ~822MB — over Lambda's 250MB limit.

Measured locally:
- `zip -r` (deref symlinks): **822 MB** unzipped
- `zip -r -y` (keep symlinks): **59 MB** unzipped

Adding `-y` stores the symlinks as links; Lambda resolves pnpm's relative symlinks at runtime (standard pnpm-on-Lambda pattern). On merge, the deploy re-runs and should finally deploy the real Nova Lambda over the placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)