### PR TITLE
Fix Nova Lambda handler path (dist/server.handler)

### DIFF
--- a/infra/agent-aws-nova/lambda.tf
+++ b/infra/agent-aws-nova/lambda.tf
@@ -9,8 +9,10 @@ resource "aws_lambda_function" "agent" {
 
   role = aws_iam_role.agent_runtime.arn
 
-  runtime     = "nodejs22.x"
-  handler     = "server.handler"
+  runtime = "nodejs22.x"
+  # tsc emits the entry at dist/server.js (ESM; package is "type":"module"),
+  # so the handler path is dist-prefixed — not bare "server.handler".
+  handler     = "dist/server.handler"
   memory_size = var.agent_memory_mb
   timeout     = var.agent_timeout_seconds
 


### PR DESCRIPTION
The deployed Nova Lambda failed at init with `Runtime.ImportModuleError: Cannot find module 'server'` — every `/health` and `/bid` returned 500, so Nova silently declined and the auction stayed 2-bidder.

`tsc` emits the entry at `dist/server.js` (exporting `handler`), but `lambda.tf` set `handler = "server.handler"` (package root). Fixed to `dist/server.handler`. The package is ESM (`"type":"module"`), which Node 22 Lambda loads natively.

On merge the deploy redeploys the function; then the 3-bidder smoke test should show Nova bidding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)