### PR TITLE
Add jose as a direct dependency of agent-aws-nova

### DIFF
--- a/agent/aws-nova/package.json
+++ b/agent/aws-nova/package.json
@@ -16,6 +16,7 @@
     "@agent-tasker/protocol": "workspace:*",
     "@aws-sdk/client-bedrock-runtime": "^3.950.0",
     "hono": "^4.12.21",
+    "jose": "^6.2.3",
     "zod": "^3.25.76"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       hono:
         specifier: ^4.12.21
         version: 4.12.21
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       zod:
         specifier: ^3.25.76
         version: 3.25.76


### PR DESCRIPTION
The Nova Lambda failed at init with `ERR_MODULE_NOT_FOUND: Cannot find package 'jose' imported from /var/task/dist/server.js`.

`agent/aws-nova/src/server.ts` imports `createRemoteJWKSet` from `jose`, but `jose` was only a *transitive* dep (via `@agent-tasker/agent`). `pnpm deploy` only creates a resolvable top-level `node_modules` entry for **direct** deps, so jose wasn't resolvable in the Lambda bundle. The GCP agents already pin jose directly for exactly this reason (Phase 1).

Pins `jose@^6.2.3` in `agent/aws-nova/package.json` + lockfile. Verified the rebuilt `pnpm deploy` bundle now contains a resolvable `node_modules/jose` symlink.

On merge → redeploy → 3-bidder smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)