### PR TITLE
Phase 3: bring Azure/GPT online (4-bidder auction)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Keep the Docker build context small. The agent Dockerfiles COPY source dirs
+# and run `pnpm install` + build inside the image, so none of these are needed
+# in the context — excluding them speeds local, CI, and `az acr build` uploads.
+**/node_modules
+**/dist
+**/.turbo
+**/*.tsbuildinfo
+.git
+.github
+.pnpm-store
+**/.terraform
+**/terraform.tfstate*
+**/tfplan
+**/*.log
+operator-console
+docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,15 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           ARM_USE_OIDC: "true"
+          # The CI service principal is RG-scoped and can't register
+          # subscription resource providers; they are pre-registered out of band.
+          ARM_RESOURCE_PROVIDER_REGISTRATIONS: "none"
+          # State storage has shared-key auth disabled; use AAD (CI SP holds
+          # Storage Blob Data Contributor on the state account from bootstrap).
+          ARM_STORAGE_USE_AZUREAD: "true"
+          # Supplied so re-applies don't reset the Container App secret to the
+          # "replace-me" placeholder. Never committed.
+          TF_VAR_azure_openai_api_key: ${{ secrets.AZURE_OPENAI_API_KEY }}
         run: |
           terraform init -backend-config=backend.hcl -input=false -no-color
           terraform apply -auto-approve -input=false -no-color \

--- a/agent/azure-gpt/package.json
+++ b/agent/azure-gpt/package.json
@@ -16,6 +16,7 @@
     "@agent-tasker/protocol": "workspace:*",
     "@hono/node-server": "^2.0.3",
     "hono": "^4.12.21",
-    "jose": "^6.2.3"
+    "jose": "^6.2.3",
+    "zod": "^3.25.76"
   }
 }

--- a/infra/agent-azure-gpt/backend.hcl
+++ b/infra/agent-azure-gpt/backend.hcl
@@ -1,0 +1,10 @@
+# Copy to backend.hcl per environment and pass to:
+#   terraform init -backend-config=backend.hcl
+#
+# Uses the Azure Storage account/container created by infra/azure-bootstrap.
+
+resource_group_name  = "agent-tasker-dev-azure"
+storage_account_name = "agenttaskerdevtfstate"
+container_name       = "tfstate"
+key                  = "agent-azure-gpt/dev.tfstate"
+use_azuread_auth     = true

--- a/infra/agent-azure-gpt/container_app.tf
+++ b/infra/agent-azure-gpt/container_app.tf
@@ -23,8 +23,13 @@ resource "azurerm_container_app" "agent" {
   tags                         = local.common_tags
 
   identity {
-    type = "SystemAssigned"
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.agent.id]
   }
+
+  # The image pull needs AcrPull on the user-assigned identity to be in place
+  # before the first revision provisions, or the pull 401s and the app fails.
+  depends_on = [azurerm_role_assignment.agent_acr_pull]
 
   secret {
     name  = var.azure_openai_api_key_secret_name
@@ -32,13 +37,16 @@ resource "azurerm_container_app" "agent" {
   }
 
   secret {
-    name  = "otel-exporter-otlp-headers"
-    value = coalesce(var.otel_exporter_otlp_headers, "")
+    name = "otel-exporter-otlp-headers"
+    # Azure Container Apps rejects empty-string secret values, so fall back to a
+    # non-empty sentinel when no OTLP headers are configured. Harmless because
+    # OTEL_TRACES_EXPORTER is "none" whenever the OTLP endpoint is unset.
+    value = var.otel_exporter_otlp_headers != null ? var.otel_exporter_otlp_headers : "none"
   }
 
   registry {
     server   = var.acr_login_server
-    identity = "System"
+    identity = azurerm_user_assigned_identity.agent.id
   }
 
   ingress {
@@ -119,7 +127,7 @@ resource "azurerm_container_app" "agent" {
 
       env {
         name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
-        value = coalesce(var.otel_exporter_otlp_endpoint, "")
+        value = var.otel_exporter_otlp_endpoint != null ? var.otel_exporter_otlp_endpoint : ""
       }
 
       env {

--- a/infra/agent-azure-gpt/iam.tf
+++ b/infra/agent-azure-gpt/iam.tf
@@ -1,8 +1,24 @@
-# Grant the Container App's system-assigned managed identity AcrPull on the
-# ACR so it can pull images without a stored credential. The ACR resource is
-# managed in infra/azure-bootstrap; its ID is threaded in via var.acr_resource_id.
+# Identity for the Azure/GPT Container App.
+#
+# A user-assigned managed identity (not system-assigned) is required to break a
+# deadlock: a system-assigned identity only exists once the Container App is
+# created, but the app cannot provision its first revision without AcrPull to
+# pull the image from ACR — so the app fails before the role can be granted.
+# A user-assigned identity exists independently, so AcrPull is granted before
+# the app provisions. The Container App and Key Vault policy reference this
+# identity, and the app `depends_on` the role assignment below.
+resource "azurerm_user_assigned_identity" "agent" {
+  name                = "${local.name_prefix}-azure-gpt-id"
+  location            = data.azurerm_resource_group.agent.location
+  resource_group_name = data.azurerm_resource_group.agent.name
+  tags                = local.common_tags
+}
+
+# Grant the agent's user-assigned identity AcrPull on the ACR so it can pull
+# images without a stored credential. The ACR resource is managed in
+# infra/azure-bootstrap; its ID is threaded in via var.acr_resource_id.
 resource "azurerm_role_assignment" "agent_acr_pull" {
   scope                = var.acr_resource_id
   role_definition_name = "AcrPull"
-  principal_id         = azurerm_container_app.agent.identity[0].principal_id
+  principal_id         = azurerm_user_assigned_identity.agent.principal_id
 }

--- a/infra/agent-azure-gpt/key_vault.tf
+++ b/infra/agent-azure-gpt/key_vault.tf
@@ -25,7 +25,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
 resource "azurerm_key_vault_access_policy" "agent" {
   key_vault_id = azurerm_key_vault.agent.id
   tenant_id    = var.tenant_id
-  object_id    = azurerm_container_app.agent.identity[0].principal_id
+  object_id    = azurerm_user_assigned_identity.agent.principal_id
 
   secret_permissions = [
     "Get",

--- a/infra/agent-azure-gpt/outputs.tf
+++ b/infra/agent-azure-gpt/outputs.tf
@@ -1,11 +1,14 @@
 output "agent_url" {
   description = "Public HTTPS URL for the Azure/GPT Container App. Coordinator per-agent endpoint config points at this."
-  value       = "https://${azurerm_container_app.agent.latest_revision_fqdn}"
+  # Stable ingress FQDN (revision_mode = Single routes it to the latest
+  # revision). Not latest_revision_fqdn, which changes on every new revision and
+  # would break the coordinator's pinned endpoint on each deploy.
+  value = "https://${azurerm_container_app.agent.ingress[0].fqdn}"
 }
 
 output "agent_principal_id" {
-  description = "Managed identity principal ID for the Azure/GPT Container App."
-  value       = azurerm_container_app.agent.identity[0].principal_id
+  description = "User-assigned managed identity principal ID for the Azure/GPT Container App."
+  value       = azurerm_user_assigned_identity.agent.principal_id
 }
 
 output "key_vault_uri" {

--- a/infra/agent-azure-gpt/terraform.tfvars
+++ b/infra/agent-azure-gpt/terraform.tfvars
@@ -2,17 +2,23 @@ env = "dev"
 
 jwks_url = "https://storage.googleapis.com/agent-tasker-dev-jwks-agent-tasker-lcd/jwks.json"
 
-azure_openai_deployment     = "gpt-5"
-azure_openai_bid_deployment = "gpt-5-mini"
+# Interim: the GPT-5 family has 0 quota on this new subscription (needs an Azure
+# support request). gpt-4o has default Standard quota and deploys now, so both
+# bid and execute point at the single gpt-4o deployment. Swap to gpt-5 /
+# gpt-5-mini here once the GPT-5 quota increase is granted.
+azure_openai_deployment     = "gpt-4o"
+azure_openai_bid_deployment = "gpt-4o"
 azure_openai_api_version    = "2025-04-01-preview"
 
 # agent_image is intentionally absent — CI passes it as
 # -var="agent_image=ACR_LOGIN_SERVER/azure-gpt:SHA".
+# azure_openai_api_key is passed out-of-band (TF_VAR_azure_openai_api_key in CI
+# from the AZURE_OPENAI_API_KEY secret) so it is never committed.
 
-# These require infra/azure-bootstrap to be applied first:
-# subscription_id    = "..."   # az account show --query id -o tsv
-# tenant_id          = "..."   # az account show --query tenantId -o tsv
-# resource_group_name = "..."  # resource_group_name output from azure-bootstrap
-# azure_openai_endpoint = "..." # your Azure OpenAI endpoint
-# acr_login_server   = "..."   # acr_login_server output from azure-bootstrap
-# acr_resource_id    = "..."   # acr_resource_id output from azure-bootstrap
+# From infra/azure-bootstrap apply (2026-06-20) + the Azure OpenAI resource.
+subscription_id       = "8db4717d-3d07-4714-9e42-913d1723d6d0"
+tenant_id             = "86c1ecd5-782f-4afe-81f1-385bd7abc649"
+resource_group_name   = "agent-tasker-dev-azure"
+azure_openai_endpoint = "https://agent-tasker-dev-aoai.openai.azure.com/"
+acr_login_server      = "agenttaskerdevazgptacr.azurecr.io"
+acr_resource_id       = "/subscriptions/8db4717d-3d07-4714-9e42-913d1723d6d0/resourceGroups/agent-tasker-dev-azure/providers/Microsoft.ContainerRegistry/registries/agenttaskerdevazgptacr"

--- a/infra/coordinator/terraform.tfvars
+++ b/infra/coordinator/terraform.tfvars
@@ -16,5 +16,5 @@ gcp_orchestrator_agent_url = "https://agent-tasker-dev-gcp-orchestrator-n6ey4mj4
 # agent_api_endpoint output from infra/agent-aws-nova (Phase 2 bootstrap, 2026-06-19).
 aws_nova_agent_url = "https://63iwfo9eek.execute-api.us-east-1.amazonaws.com"
 
-# Set to the agent_url output from infra/agent-azure-gpt after Phase 3 bootstrap.
-azure_gpt_agent_url = ""
+# Stable Container App ingress FQDN from infra/agent-azure-gpt (Phase 3, 2026-06-20).
+azure_gpt_agent_url = "https://agent-tasker-dev-azure-gpt.bravemeadow-b7cdd17b.eastus.azurecontainerapps.io"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   agent/gcp-gemini:
     dependencies:


### PR DESCRIPTION
Brings the Azure/GPT agent live, completing the 4-bidder market. The agent is deployed and healthy in Azure; this PR registers it with the coordinator and lands the fixes the first-ever apply surfaced.

## Done out of band (operator Azure creds, local)
- `infra/azure-bootstrap` applied → RG `agent-tasker-dev-azure`, TF-state storage, ACR `agenttaskerdevazgptacr`, GitHub-OIDC CI service principal, agent Entra app. Account `8db4717d…`, eastus.
- Created an Azure OpenAI resource (`agent-tasker-dev-aoai`) with a **gpt-4o** deployment. **GPT-5 has 0 quota** on the new pay-as-you-go subscription (needs a support request), so gpt-4o is the interim model for both bid and execute; swap to gpt-5/gpt-5-mini via tfvars once quota lands.
- Set `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` / `AZURE_OPENAI_API_KEY` secrets → CI `HAS_AZURE` gate is now true.
- Agent verified live: `/health` → `{"ok":true,"agent_id":"azure-gpt"}`, `/bid` without a token → 401.

## This PR
- **coordinator:** `azure_gpt_agent_url` → the Container App's stable ingress FQDN (4th bidder registered on merge).
- **CI azure apply:** pass the OpenAI key via `TF_VAR` (so re-applies don't reset the secret), disable provider auto-registration, use AAD storage auth.

## Latent bug fixes (module never applied before)
- **User-assigned managed identity** replaces system-assigned: a system identity only exists *after* the app is created, but the app can't provision without AcrPull to pull its image — a deadlock. The UAMI is granted AcrPull first; the app `depends_on` it.
- Container Apps rejects **empty-string secret values** → non-empty sentinel for the OTLP-headers secret; `coalesce(null,"")` on the OTLP endpoint → null-safe ternary.
- `agent_url`/Key Vault policy reference the UAMI (a UserAssigned app doesn't populate `identity[0].principal_id`); `agent_url` uses the **stable** ingress FQDN, not the per-revision one.
- **`zod` added as a direct dep** of agent-azure-gpt — `estimator.ts` imports it but it was only transitive, so `pnpm deploy` left it unresolvable in the image (same class as the AWS/jose fix).
- **`.dockerignore`** added (excludes node_modules/caches/.git) — big build-context speedup for docker/`az acr build`/CI.

## On merge, CI will
Build & push the azure-gpt image to ACR, `terraform apply` the agent (updates to the CI-built image), and re-apply the coordinator with `azure_gpt_agent_url` set. Then I'll smoke-test the 4-bidder auction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)