### PR TITLE
Fix CI: build azure-gpt image via az acr build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   AWS_REGION: us-east-1
   AWS_LAMBDA_ARTIFACTS_BUCKET: agent-tasker-dev-aws-nova-artifacts
   AZURE_GPT_ACR_LOGIN_SERVER: agentaskerdevazgptacr.azurecr.io
+  AZURE_GPT_ACR_NAME: agentaskerdevazgptacr
   AZURE_GPT_REPO: agentaskerdevazgptacr.azurecr.io/azure-gpt
 
 jobs:
@@ -223,11 +224,14 @@ jobs:
 
       - name: Build and push azure-gpt
         if: env.HAS_AZURE == 'true'
+        # Build remotely in ACR rather than docker build + az acr login on the
+        # runner: `az acr login --name <login-server>` does an ARM lookup that
+        # fails on the FQDN, and the remote build needs neither Docker nor a
+        # registry login (the OIDC session already holds AcrPush).
         run: |
-          az acr login --name ${{ env.AZURE_GPT_ACR_LOGIN_SERVER }}
-          docker build -f agent/azure-gpt/Dockerfile \
-            -t ${{ env.AZURE_GPT_REPO }}:${{ github.sha }} .
-          docker push ${{ env.AZURE_GPT_REPO }}:${{ github.sha }}
+          az acr build --registry ${{ env.AZURE_GPT_ACR_NAME }} \
+            --image azure-gpt:${{ github.sha }} \
+            -f agent/azure-gpt/Dockerfile .
 
       - name: Terraform apply — azure-gpt agent
         if: env.HAS_AZURE == 'true'


### PR DESCRIPTION
The Phase 3 deploy's `Build and push azure-gpt` step failed: `az acr login --name agentaskerdevazgptacr.azurecr.io` does an ARM lookup that fails on the login-server FQDN, so the image never built and the agent apply was skipped.

Switches to `az acr build` (remote build in ACR) — no Docker on the runner, no `az acr login` (the OIDC session already holds AcrPush), and it matches how the image was bootstrapped. Adds `AZURE_GPT_ACR_NAME` for the registry name.

The 4-bidder auction is already live (the coordinator points at the running agent; azure-gpt wins and executes via Azure OpenAI). This just makes CI green so future deploys rebuild the agent image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)