### PR TITLE
Fix azure-gpt ACR name typo + token-exchange tenant param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ env:
   GCP_ORCHESTRATOR_REPO: us-central1-docker.pkg.dev/agent-tasker-lcd/agent-tasker-dev-gcp-orchestrator/gcp-orchestrator
   AWS_REGION: us-east-1
   AWS_LAMBDA_ARTIFACTS_BUCKET: agent-tasker-dev-aws-nova-artifacts
-  AZURE_GPT_ACR_LOGIN_SERVER: agentaskerdevazgptacr.azurecr.io
-  AZURE_GPT_REPO: agentaskerdevazgptacr.azurecr.io/azure-gpt
+  AZURE_GPT_ACR_LOGIN_SERVER: agenttaskerdevazgptacr.azurecr.io
+  AZURE_GPT_REPO: agenttaskerdevazgptacr.azurecr.io/azure-gpt
 
 jobs:
   node:
@@ -233,7 +233,7 @@ jobs:
           REFRESH_TOKEN=$(curl -s -X POST \
             "https://${{ env.AZURE_GPT_ACR_LOGIN_SERVER }}/oauth2/exchange" \
             -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=access_token&service=${{ env.AZURE_GPT_ACR_LOGIN_SERVER }}&access_token=${ACCESS_TOKEN}" \
+            -d "grant_type=access_token&service=${{ env.AZURE_GPT_ACR_LOGIN_SERVER }}&tenant=${{ secrets.AZURE_TENANT_ID }}&access_token=${ACCESS_TOKEN}" \
             | jq -r .refresh_token)
           echo "$REFRESH_TOKEN" | docker login "${{ env.AZURE_GPT_ACR_LOGIN_SERVER }}" \
             --username 00000000-0000-0000-0000-000000000000 --password-stdin

--- a/infra/azure-bootstrap/outputs.tf
+++ b/infra/azure-bootstrap/outputs.tf
@@ -39,7 +39,7 @@ output "agent_service_principal_object_id" {
 }
 
 output "acr_login_server" {
-  description = "ACR login server hostname (e.g. agentaskerdevazgptacr.azurecr.io). Set as AZURE_GPT_ACR_LOGIN_SERVER in ci.yml and acr_login_server in infra/agent-azure-gpt/terraform.tfvars."
+  description = "ACR login server hostname (e.g. agenttaskerdevazgptacr.azurecr.io). Set as AZURE_GPT_ACR_LOGIN_SERVER in ci.yml and acr_login_server in infra/agent-azure-gpt/terraform.tfvars."
   value       = azurerm_container_registry.agent.login_server
 }
 


### PR DESCRIPTION
**Root cause of all the azure-gpt build failures: a typo.** ci.yml hardcoded the ACR name as `agentaskerdevazgptacr` (single t), but bootstrap creates `agenttaskerdevazgptacr` (agent + tasker = double t). Every `az acr` lookup / token exchange returned "could not be found in subscription". (The subscription-Reader and `az acr build` detours were chasing a permissions problem that didn't exist.)

- Correct `AZURE_GPT_ACR_LOGIN_SERVER` and `AZURE_GPT_REPO` to the double-t name (+ the bootstrap output description example).
- Add the required `tenant` param to the ACR `oauth2/exchange` call — without it the exchange returns no refresh_token and `docker login` fails. Validated locally: the corrected name + tenant returns a refresh token.

The agent tfvars/coordinator URL already use the correct name (copied from the bootstrap output), so only CI was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)