### PR TITLE
Make Key Vault deployer the CI service principal

### DIFF
--- a/infra/agent-azure-gpt/key_vault.tf
+++ b/infra/agent-azure-gpt/key_vault.tf
@@ -12,7 +12,7 @@ resource "azurerm_key_vault" "agent" {
 resource "azurerm_key_vault_access_policy" "deployer" {
   key_vault_id = azurerm_key_vault.agent.id
   tenant_id    = var.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
+  object_id    = var.deployer_object_id != null ? var.deployer_object_id : data.azurerm_client_config.current.object_id
 
   secret_permissions = [
     "Delete",

--- a/infra/agent-azure-gpt/terraform.tfvars
+++ b/infra/agent-azure-gpt/terraform.tfvars
@@ -16,9 +16,12 @@ azure_openai_api_version    = "2025-04-01-preview"
 # from the AZURE_OPENAI_API_KEY secret) so it is never committed.
 
 # From infra/azure-bootstrap apply (2026-06-20) + the Azure OpenAI resource.
-subscription_id       = "8db4717d-3d07-4714-9e42-913d1723d6d0"
-tenant_id             = "86c1ecd5-782f-4afe-81f1-385bd7abc649"
-resource_group_name   = "agent-tasker-dev-azure"
+subscription_id     = "8db4717d-3d07-4714-9e42-913d1723d6d0"
+tenant_id           = "86c1ecd5-782f-4afe-81f1-385bd7abc649"
+resource_group_name = "agent-tasker-dev-azure"
+# CI service principal (azure-bootstrap ci_object_id) — the steady-state
+# deployer that needs Key Vault secret access on every CI apply.
+deployer_object_id    = "f1b06116-7707-42c5-9a14-4b0cfd1074eb"
 azure_openai_endpoint = "https://agent-tasker-dev-aoai.openai.azure.com/"
 acr_login_server      = "agenttaskerdevazgptacr.azurecr.io"
 acr_resource_id       = "/subscriptions/8db4717d-3d07-4714-9e42-913d1723d6d0/resourceGroups/agent-tasker-dev-azure/providers/Microsoft.ContainerRegistry/registries/agenttaskerdevazgptacr"

--- a/infra/agent-azure-gpt/variables.tf
+++ b/infra/agent-azure-gpt/variables.tf
@@ -108,6 +108,12 @@ variable "azure_openai_api_version" {
   default     = "2025-04-01-preview"
 }
 
+variable "deployer_object_id" {
+  description = "Object ID of the identity that runs `terraform apply` and therefore needs Key Vault secret access (get/list/set/delete). Set to the CI service principal (azure-bootstrap `ci_object_id`) so CI is the steady-state deployer; defaults to the current client when null (local operator apply)."
+  type        = string
+  default     = null
+}
+
 variable "azure_openai_api_key_secret_name" {
   description = "Key Vault secret name that stores the Azure OpenAI API key."
   type        = string


### PR DESCRIPTION
CI's azure-gpt terraform apply 403'd refreshing the Azure OpenAI Key Vault secret: the KV `deployer` access policy was keyed to `data.azurerm_client_config` (whoever runs terraform), and since the module was bootstrapped locally it granted the operator, not the CI SP.

Adds a `deployer_object_id` variable (defaults to the current client for local applies) set in tfvars to the CI service principal, so CI is the steady-state deployer with secret get/list/set/delete. Already transitioned the live policy with one local apply (the operator still had KV access at refresh time, so it succeeded and replaced the policy with the CI SP).

This is the last fix — image build is green; this unblocks the agent terraform apply so CI fully deploys azure-gpt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)