### PR TITLE
Add market dashboard design (Claude Design source)

### DIFF
--- a/design/market-dashboard/agent-card.html
+++ b/design/market-dashboard/agent-card.html
@@ -1,82 +1,221 @@
 <!-- @dsCard group="Components" -->
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Agent Card</title>
-<style>
-  :root{
-    --bg:#0a0d14; --panel:#121826; --panel-2:#171f30; --line:#232c40; --line-soft:#1b2335;
-    --ink:#e8ecf6; --ink-dim:#94a0b8; --ink-faint:#5f6b83;
-    --gcp:#4285f4; --orch:#34a853; --aws:#ff9900; --azure:#2ec5ce; --warn:#f4b740;
-    --mono:ui-monospace,"SF Mono",Menlo,monospace; --sans:"Inter",system-ui,sans-serif;
-  }
-  *{box-sizing:border-box}
-  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);padding:24px;
-    -webkit-font-smoothing:antialiased}
-  .cap{font-size:11px;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.8px;margin:0 0 14px}
-  .grid{display:grid;grid-template-columns:repeat(2,minmax(240px,300px));gap:14px}
-  .agent{background:var(--panel);border:1px solid var(--line-soft);border-radius:14px;
-    padding:15px 16px;position:relative;overflow:hidden}
-  .agent::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--c)}
-  .head{display:flex;align-items:center;gap:10px}
-  .badge{font-size:10.5px;font-weight:650;padding:3px 8px;border-radius:6px;color:var(--c);
-    background:color-mix(in srgb,var(--c) 16%,transparent);
-    border:1px solid color-mix(in srgb,var(--c) 35%,transparent);letter-spacing:.3px}
-  .name{font-weight:600;font-size:14.5px}
-  .rt{margin-left:auto;font-size:10.5px;color:var(--ink-faint);font-family:var(--mono)}
-  .model{font-size:11.5px;color:var(--ink-faint);margin:3px 0 13px}
-  .stats{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
-  .n{font-family:var(--mono);font-size:17px;font-weight:600}
-  .l{font-size:10px;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.5px;margin-top:2px}
-  .winbar{height:5px;border-radius:3px;background:var(--line);margin-top:13px;overflow:hidden}
-  .winbar>i{display:block;height:100%;background:var(--c);border-radius:3px}
-</style>
-</head>
-<body>
-  <p class="cap">Agent card · one per agent, accent = cloud / runtime identity</p>
-  <div class="grid">
-    <div class="agent" style="--c:var(--gcp)">
-      <div class="head"><span class="badge">GCP</span><span class="name">Gemini</span><span class="rt">direct · vertex</span></div>
-      <div class="model">Gemini 2.5 Pro · frontier</div>
-      <div class="stats">
-        <div><div class="n">41%</div><div class="l">win</div></div>
-        <div><div class="n">12.4%</div><div class="l">MAPE</div></div>
-        <div><div class="n">$0.018</div><div class="l">avg</div></div>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Agent Card</title>
+    <style>
+      :root {
+        --bg: #0a0d14;
+        --panel: #121826;
+        --panel-2: #171f30;
+        --line: #232c40;
+        --line-soft: #1b2335;
+        --ink: #e8ecf6;
+        --ink-dim: #94a0b8;
+        --ink-faint: #5f6b83;
+        --gcp: #4285f4;
+        --orch: #34a853;
+        --aws: #ff9900;
+        --azure: #2ec5ce;
+        --warn: #f4b740;
+        --mono: ui-monospace, "SF Mono", Menlo, monospace;
+        --sans: "Inter", system-ui, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: var(--sans);
+        padding: 24px;
+        -webkit-font-smoothing: antialiased;
+      }
+      .cap {
+        font-size: 11px;
+        color: var(--ink-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.8px;
+        margin: 0 0 14px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(240px, 300px));
+        gap: 14px;
+      }
+      .agent {
+        background: var(--panel);
+        border: 1px solid var(--line-soft);
+        border-radius: 14px;
+        padding: 15px 16px;
+        position: relative;
+        overflow: hidden;
+      }
+      .agent::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 3px;
+        background: var(--c);
+      }
+      .head {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .badge {
+        font-size: 10.5px;
+        font-weight: 650;
+        padding: 3px 8px;
+        border-radius: 6px;
+        color: var(--c);
+        background: color-mix(in srgb, var(--c) 16%, transparent);
+        border: 1px solid color-mix(in srgb, var(--c) 35%, transparent);
+        letter-spacing: 0.3px;
+      }
+      .name {
+        font-weight: 600;
+        font-size: 14.5px;
+      }
+      .rt {
+        margin-left: auto;
+        font-size: 10.5px;
+        color: var(--ink-faint);
+        font-family: var(--mono);
+      }
+      .model {
+        font-size: 11.5px;
+        color: var(--ink-faint);
+        margin: 3px 0 13px;
+      }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 8px;
+      }
+      .n {
+        font-family: var(--mono);
+        font-size: 17px;
+        font-weight: 600;
+      }
+      .l {
+        font-size: 10px;
+        color: var(--ink-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-top: 2px;
+      }
+      .winbar {
+        height: 5px;
+        border-radius: 3px;
+        background: var(--line);
+        margin-top: 13px;
+        overflow: hidden;
+      }
+      .winbar > i {
+        display: block;
+        height: 100%;
+        background: var(--c);
+        border-radius: 3px;
+      }
+    </style>
+  </head>
+  <body>
+    <p class="cap">Agent card · one per agent, accent = cloud / runtime identity</p>
+    <div class="grid">
+      <div class="agent" style="--c: var(--gcp)">
+        <div class="head">
+          <span class="badge">GCP</span><span class="name">Gemini</span
+          ><span class="rt">direct · vertex</span>
+        </div>
+        <div class="model">Gemini 2.5 Pro · frontier</div>
+        <div class="stats">
+          <div>
+            <div class="n">41%</div>
+            <div class="l">win</div>
+          </div>
+          <div>
+            <div class="n">12.4%</div>
+            <div class="l">MAPE</div>
+          </div>
+          <div>
+            <div class="n">$0.018</div>
+            <div class="l">avg</div>
+          </div>
+        </div>
+        <div class="winbar"><i style="width: 41%"></i></div>
       </div>
-      <div class="winbar"><i style="width:41%"></i></div>
-    </div>
-    <div class="agent" style="--c:var(--aws)">
-      <div class="head"><span class="badge">AWS</span><span class="name">Nova</span><span class="rt">bedrock · lambda</span></div>
-      <div class="model">Amazon Nova Pro · frontier</div>
-      <div class="stats">
-        <div><div class="n">27%</div><div class="l">win</div></div>
-        <div><div class="n">9.8%</div><div class="l">MAPE</div></div>
-        <div><div class="n">$0.006</div><div class="l">avg</div></div>
+      <div class="agent" style="--c: var(--aws)">
+        <div class="head">
+          <span class="badge">AWS</span><span class="name">Nova</span
+          ><span class="rt">bedrock · lambda</span>
+        </div>
+        <div class="model">Amazon Nova Pro · frontier</div>
+        <div class="stats">
+          <div>
+            <div class="n">27%</div>
+            <div class="l">win</div>
+          </div>
+          <div>
+            <div class="n">9.8%</div>
+            <div class="l">MAPE</div>
+          </div>
+          <div>
+            <div class="n">$0.006</div>
+            <div class="l">avg</div>
+          </div>
+        </div>
+        <div class="winbar"><i style="width: 27%"></i></div>
       </div>
-      <div class="winbar"><i style="width:27%"></i></div>
-    </div>
-    <div class="agent" style="--c:var(--orch)">
-      <div class="head"><span class="badge">GCP</span><span class="name">Orchestrator</span><span class="rt">GAEP · multi-step</span></div>
-      <div class="model">Gemini 2.5 Pro + tools · frontier</div>
-      <div class="stats">
-        <div><div class="n">11%</div><div class="l">win</div></div>
-        <div><div class="n">23.7%</div><div class="l">MAPE</div></div>
-        <div><div class="n">$0.114</div><div class="l">avg</div></div>
+      <div class="agent" style="--c: var(--orch)">
+        <div class="head">
+          <span class="badge">GCP</span><span class="name">Orchestrator</span
+          ><span class="rt">GAEP · multi-step</span>
+        </div>
+        <div class="model">Gemini 2.5 Pro + tools · frontier</div>
+        <div class="stats">
+          <div>
+            <div class="n">11%</div>
+            <div class="l">win</div>
+          </div>
+          <div>
+            <div class="n">23.7%</div>
+            <div class="l">MAPE</div>
+          </div>
+          <div>
+            <div class="n">$0.114</div>
+            <div class="l">avg</div>
+          </div>
+        </div>
+        <div class="winbar"><i style="width: 11%"></i></div>
       </div>
-      <div class="winbar"><i style="width:11%"></i></div>
-    </div>
-    <div class="agent" style="--c:var(--azure)">
-      <div class="head"><span class="badge">AZURE</span><span class="name">GPT</span><span class="rt">openai · container</span></div>
-      <div class="model">gpt-4o <span style="color:var(--warn)">· interim</span></div>
-      <div class="stats">
-        <div><div class="n">21%</div><div class="l">win</div></div>
-        <div><div class="n">15.1%</div><div class="l">MAPE</div></div>
-        <div><div class="n">$0.041</div><div class="l">avg</div></div>
+      <div class="agent" style="--c: var(--azure)">
+        <div class="head">
+          <span class="badge">AZURE</span><span class="name">GPT</span
+          ><span class="rt">openai · container</span>
+        </div>
+        <div class="model">gpt-4o <span style="color: var(--warn)">· interim</span></div>
+        <div class="stats">
+          <div>
+            <div class="n">21%</div>
+            <div class="l">win</div>
+          </div>
+          <div>
+            <div class="n">15.1%</div>
+            <div class="l">MAPE</div>
+          </div>
+          <div>
+            <div class="n">$0.041</div>
+            <div class="l">avg</div>
+          </div>
+        </div>
+        <div class="winbar"><i style="width: 21%"></i></div>
       </div>
-      <div class="winbar"><i style="width:21%"></i></div>
     </div>
-  </div>
-</body>
+  </body>
 </html>

--- a/design/market-dashboard/agent-card.html
+++ b/design/market-dashboard/agent-card.html
@@ -1,0 +1,82 @@
+<!-- @dsCard group="Components" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Agent Card</title>
+<style>
+  :root{
+    --bg:#0a0d14; --panel:#121826; --panel-2:#171f30; --line:#232c40; --line-soft:#1b2335;
+    --ink:#e8ecf6; --ink-dim:#94a0b8; --ink-faint:#5f6b83;
+    --gcp:#4285f4; --orch:#34a853; --aws:#ff9900; --azure:#2ec5ce; --warn:#f4b740;
+    --mono:ui-monospace,"SF Mono",Menlo,monospace; --sans:"Inter",system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);padding:24px;
+    -webkit-font-smoothing:antialiased}
+  .cap{font-size:11px;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.8px;margin:0 0 14px}
+  .grid{display:grid;grid-template-columns:repeat(2,minmax(240px,300px));gap:14px}
+  .agent{background:var(--panel);border:1px solid var(--line-soft);border-radius:14px;
+    padding:15px 16px;position:relative;overflow:hidden}
+  .agent::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--c)}
+  .head{display:flex;align-items:center;gap:10px}
+  .badge{font-size:10.5px;font-weight:650;padding:3px 8px;border-radius:6px;color:var(--c);
+    background:color-mix(in srgb,var(--c) 16%,transparent);
+    border:1px solid color-mix(in srgb,var(--c) 35%,transparent);letter-spacing:.3px}
+  .name{font-weight:600;font-size:14.5px}
+  .rt{margin-left:auto;font-size:10.5px;color:var(--ink-faint);font-family:var(--mono)}
+  .model{font-size:11.5px;color:var(--ink-faint);margin:3px 0 13px}
+  .stats{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  .n{font-family:var(--mono);font-size:17px;font-weight:600}
+  .l{font-size:10px;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.5px;margin-top:2px}
+  .winbar{height:5px;border-radius:3px;background:var(--line);margin-top:13px;overflow:hidden}
+  .winbar>i{display:block;height:100%;background:var(--c);border-radius:3px}
+</style>
+</head>
+<body>
+  <p class="cap">Agent card · one per agent, accent = cloud / runtime identity</p>
+  <div class="grid">
+    <div class="agent" style="--c:var(--gcp)">
+      <div class="head"><span class="badge">GCP</span><span class="name">Gemini</span><span class="rt">direct · vertex</span></div>
+      <div class="model">Gemini 2.5 Pro · frontier</div>
+      <div class="stats">
+        <div><div class="n">41%</div><div class="l">win</div></div>
+        <div><div class="n">12.4%</div><div class="l">MAPE</div></div>
+        <div><div class="n">$0.018</div><div class="l">avg</div></div>
+      </div>
+      <div class="winbar"><i style="width:41%"></i></div>
+    </div>
+    <div class="agent" style="--c:var(--aws)">
+      <div class="head"><span class="badge">AWS</span><span class="name">Nova</span><span class="rt">bedrock · lambda</span></div>
+      <div class="model">Amazon Nova Pro · frontier</div>
+      <div class="stats">
+        <div><div class="n">27%</div><div class="l">win</div></div>
+        <div><div class="n">9.8%</div><div class="l">MAPE</div></div>
+        <div><div class="n">$0.006</div><div class="l">avg</div></div>
+      </div>
+      <div class="winbar"><i style="width:27%"></i></div>
+    </div>
+    <div class="agent" style="--c:var(--orch)">
+      <div class="head"><span class="badge">GCP</span><span class="name">Orchestrator</span><span class="rt">GAEP · multi-step</span></div>
+      <div class="model">Gemini 2.5 Pro + tools · frontier</div>
+      <div class="stats">
+        <div><div class="n">11%</div><div class="l">win</div></div>
+        <div><div class="n">23.7%</div><div class="l">MAPE</div></div>
+        <div><div class="n">$0.114</div><div class="l">avg</div></div>
+      </div>
+      <div class="winbar"><i style="width:11%"></i></div>
+    </div>
+    <div class="agent" style="--c:var(--azure)">
+      <div class="head"><span class="badge">AZURE</span><span class="name">GPT</span><span class="rt">openai · container</span></div>
+      <div class="model">gpt-4o <span style="color:var(--warn)">· interim</span></div>
+      <div class="stats">
+        <div><div class="n">21%</div><div class="l">win</div></div>
+        <div><div class="n">15.1%</div><div class="l">MAPE</div></div>
+        <div><div class="n">$0.041</div><div class="l">avg</div></div>
+      </div>
+      <div class="winbar"><i style="width:21%"></i></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/design/market-dashboard/auction-row.html
+++ b/design/market-dashboard/auction-row.html
@@ -1,87 +1,223 @@
 <!-- @dsCard group="Components" -->
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Auction Row</title>
-<style>
-  :root{
-    --bg:#0a0d14; --panel:#121826; --panel-2:#171f30; --line:#232c40; --line-soft:#1b2335;
-    --ink:#e8ecf6; --ink-dim:#94a0b8; --ink-faint:#5f6b83;
-    --gcp:#4285f4; --orch:#34a853; --aws:#ff9900; --azure:#2ec5ce;
-    --mono:ui-monospace,"SF Mono",Menlo,monospace; --sans:"Inter",system-ui,sans-serif;
-  }
-  *{box-sizing:border-box}
-  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);padding:24px;
-    -webkit-font-smoothing:antialiased}
-  .cap{font-size:11px;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.8px;margin:0 0 14px}
-  .panel{background:var(--panel);border:1px solid var(--line-soft);border-radius:14px;max-width:680px}
-  .row{display:grid;grid-template-columns:1fr auto;gap:10px;padding:14px 16px;border-top:1px solid var(--line-soft)}
-  .row:first-child{border-top:0}
-  .prompt{font-size:13px}
-  .bids{display:flex;gap:5px;align-items:flex-end;height:40px;margin-top:11px}
-  .bid{width:36px;border-radius:4px 4px 0 0;background:color-mix(in srgb,var(--c) 38%,var(--panel-2));
-    position:relative;opacity:.55}
-  .bid.win{opacity:1;box-shadow:0 0 0 1px var(--c),0 0 14px color-mix(in srgb,var(--c) 50%,transparent)}
-  .bid .v{position:absolute;top:-15px;left:50%;transform:translateX(-50%);font-size:9px;
-    font-family:var(--mono);color:var(--ink-faint);white-space:nowrap}
-  .meta{font-size:11px;color:var(--ink-faint);margin-top:9px;display:flex;gap:10px;align-items:center}
-  .pill{font-size:10px;padding:2px 7px;border-radius:5px;border:1px solid var(--line);color:var(--ink-dim);font-family:var(--mono)}
-  .pill.frontier{color:#c4b5ff;border-color:#3a3170;background:rgba(124,92,252,.12)}
-  .outcome{text-align:right;min-width:130px}
-  .lab{font-size:10px;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.5px}
-  .price{font-family:var(--mono);font-size:16px;font-weight:600}
-  .winner{font-size:11px;margin-top:7px;font-weight:600;color:var(--c)}
-  .out{font-size:11px;color:var(--ink-dim);margin-top:3px;font-family:var(--mono)}
-  .legend{display:flex;gap:14px;margin-top:12px;font-size:11px;color:var(--ink-faint)}
-  .legend span{display:flex;align-items:center;gap:6px}
-  .sw{width:9px;height:9px;border-radius:3px;background:var(--c)}
-</style>
-</head>
-<body>
-  <p class="cap">Auction row · sealed bids revealed after award · winner glows · price = 2nd-lowest (Vickrey)</p>
-  <div class="panel">
-    <div class="row">
-      <div>
-        <div class="prompt">Summarize this 1,800-word support transcript into 5 bullets</div>
-        <div class="bids">
-          <div class="bid" style="--c:var(--gcp);height:62%"><span class="v">$.021</span></div>
-          <div class="bid win" style="--c:var(--orch);height:90%"><span class="v">$.088</span></div>
-          <div class="bid" style="--c:var(--aws);height:38%"><span class="v">$.012</span></div>
-          <div class="bid" style="--c:var(--azure);height:74%"><span class="v">$.044</span></div>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Auction Row</title>
+    <style>
+      :root {
+        --bg: #0a0d14;
+        --panel: #121826;
+        --panel-2: #171f30;
+        --line: #232c40;
+        --line-soft: #1b2335;
+        --ink: #e8ecf6;
+        --ink-dim: #94a0b8;
+        --ink-faint: #5f6b83;
+        --gcp: #4285f4;
+        --orch: #34a853;
+        --aws: #ff9900;
+        --azure: #2ec5ce;
+        --mono: ui-monospace, "SF Mono", Menlo, monospace;
+        --sans: "Inter", system-ui, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: var(--sans);
+        padding: 24px;
+        -webkit-font-smoothing: antialiased;
+      }
+      .cap {
+        font-size: 11px;
+        color: var(--ink-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.8px;
+        margin: 0 0 14px;
+      }
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--line-soft);
+        border-radius: 14px;
+        max-width: 680px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 10px;
+        padding: 14px 16px;
+        border-top: 1px solid var(--line-soft);
+      }
+      .row:first-child {
+        border-top: 0;
+      }
+      .prompt {
+        font-size: 13px;
+      }
+      .bids {
+        display: flex;
+        gap: 5px;
+        align-items: flex-end;
+        height: 40px;
+        margin-top: 11px;
+      }
+      .bid {
+        width: 36px;
+        border-radius: 4px 4px 0 0;
+        background: color-mix(in srgb, var(--c) 38%, var(--panel-2));
+        position: relative;
+        opacity: 0.55;
+      }
+      .bid.win {
+        opacity: 1;
+        box-shadow:
+          0 0 0 1px var(--c),
+          0 0 14px color-mix(in srgb, var(--c) 50%, transparent);
+      }
+      .bid .v {
+        position: absolute;
+        top: -15px;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: 9px;
+        font-family: var(--mono);
+        color: var(--ink-faint);
+        white-space: nowrap;
+      }
+      .meta {
+        font-size: 11px;
+        color: var(--ink-faint);
+        margin-top: 9px;
+        display: flex;
+        gap: 10px;
+        align-items: center;
+      }
+      .pill {
+        font-size: 10px;
+        padding: 2px 7px;
+        border-radius: 5px;
+        border: 1px solid var(--line);
+        color: var(--ink-dim);
+        font-family: var(--mono);
+      }
+      .pill.frontier {
+        color: #c4b5ff;
+        border-color: #3a3170;
+        background: rgba(124, 92, 252, 0.12);
+      }
+      .outcome {
+        text-align: right;
+        min-width: 130px;
+      }
+      .lab {
+        font-size: 10px;
+        color: var(--ink-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      .price {
+        font-family: var(--mono);
+        font-size: 16px;
+        font-weight: 600;
+      }
+      .winner {
+        font-size: 11px;
+        margin-top: 7px;
+        font-weight: 600;
+        color: var(--c);
+      }
+      .out {
+        font-size: 11px;
+        color: var(--ink-dim);
+        margin-top: 3px;
+        font-family: var(--mono);
+      }
+      .legend {
+        display: flex;
+        gap: 14px;
+        margin-top: 12px;
+        font-size: 11px;
+        color: var(--ink-faint);
+      }
+      .legend span {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .sw {
+        width: 9px;
+        height: 9px;
+        border-radius: 3px;
+        background: var(--c);
+      }
+    </style>
+  </head>
+  <body>
+    <p class="cap">
+      Auction row · sealed bids revealed after award · winner glows · price = 2nd-lowest (Vickrey)
+    </p>
+    <div class="panel">
+      <div class="row">
+        <div>
+          <div class="prompt">Summarize this 1,800-word support transcript into 5 bullets</div>
+          <div class="bids">
+            <div class="bid" style="--c: var(--gcp); height: 62%"><span class="v">$.021</span></div>
+            <div class="bid win" style="--c: var(--orch); height: 90%">
+              <span class="v">$.088</span>
+            </div>
+            <div class="bid" style="--c: var(--aws); height: 38%"><span class="v">$.012</span></div>
+            <div class="bid" style="--c: var(--azure); height: 74%">
+              <span class="v">$.044</span>
+            </div>
+          </div>
+          <div class="meta">
+            <span class="pill frontier">min_tier: frontier</span><span>· 3 tool steps · 9.4s</span>
+          </div>
         </div>
-        <div class="meta"><span class="pill frontier">min_tier: frontier</span><span>· 3 tool steps · 9.4s</span></div>
+        <div class="outcome">
+          <div class="lab">2nd price</div>
+          <div class="price" style="color: var(--orch)">$0.074</div>
+          <div class="winner" style="--c: var(--orch)">GCP · Orchestrator</div>
+          <div class="out">completed</div>
+        </div>
       </div>
-      <div class="outcome">
-        <div class="lab">2nd price</div><div class="price" style="color:var(--orch)">$0.074</div>
-        <div class="winner" style="--c:var(--orch)">GCP · Orchestrator</div>
-        <div class="out">completed</div>
+      <div class="row">
+        <div>
+          <div class="prompt">Translate “quarterly earnings call” to Japanese</div>
+          <div class="bids">
+            <div class="bid" style="--c: var(--gcp); height: 48%"><span class="v">$.014</span></div>
+            <div class="bid" style="--c: var(--orch); height: 96%">
+              <span class="v">$.121</span>
+            </div>
+            <div class="bid win" style="--c: var(--aws); height: 30%">
+              <span class="v">$.005</span>
+            </div>
+            <div class="bid" style="--c: var(--azure); height: 60%">
+              <span class="v">$.038</span>
+            </div>
+          </div>
+          <div class="meta">
+            <span class="pill">small ok</span><span>· single call · 2.1s</span>
+          </div>
+        </div>
+        <div class="outcome">
+          <div class="lab">2nd price</div>
+          <div class="price" style="color: var(--aws)">$0.014</div>
+          <div class="winner" style="--c: var(--aws)">AWS · Nova</div>
+          <div class="out">四半期決算説明会</div>
+        </div>
       </div>
     </div>
-    <div class="row">
-      <div>
-        <div class="prompt">Translate “quarterly earnings call” to Japanese</div>
-        <div class="bids">
-          <div class="bid" style="--c:var(--gcp);height:48%"><span class="v">$.014</span></div>
-          <div class="bid" style="--c:var(--orch);height:96%"><span class="v">$.121</span></div>
-          <div class="bid win" style="--c:var(--aws);height:30%"><span class="v">$.005</span></div>
-          <div class="bid" style="--c:var(--azure);height:60%"><span class="v">$.038</span></div>
-        </div>
-        <div class="meta"><span class="pill">small ok</span><span>· single call · 2.1s</span></div>
-      </div>
-      <div class="outcome">
-        <div class="lab">2nd price</div><div class="price" style="color:var(--aws)">$0.014</div>
-        <div class="winner" style="--c:var(--aws)">AWS · Nova</div>
-        <div class="out">四半期決算説明会</div>
-      </div>
+    <div class="legend">
+      <span style="--c: var(--gcp)"><i class="sw"></i>GCP/Gemini</span>
+      <span style="--c: var(--orch)"><i class="sw"></i>GCP/Orchestrator</span>
+      <span style="--c: var(--aws)"><i class="sw"></i>AWS/Nova</span>
+      <span style="--c: var(--azure)"><i class="sw"></i>Azure/GPT</span>
     </div>
-  </div>
-  <div class="legend">
-    <span style="--c:var(--gcp)"><i class="sw"></i>GCP/Gemini</span>
-    <span style="--c:var(--orch)"><i class="sw"></i>GCP/Orchestrator</span>
-    <span style="--c:var(--aws)"><i class="sw"></i>AWS/Nova</span>
-    <span style="--c:var(--azure)"><i class="sw"></i>Azure/GPT</span>
-  </div>
-</body>
+  </body>
 </html>

--- a/design/market-dashboard/auction-row.html
+++ b/design/market-dashboard/auction-row.html
@@ -1,0 +1,87 @@
+<!-- @dsCard group="Components" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Auction Row</title>
+<style>
+  :root{
+    --bg:#0a0d14; --panel:#121826; --panel-2:#171f30; --line:#232c40; --line-soft:#1b2335;
+    --ink:#e8ecf6; --ink-dim:#94a0b8; --ink-faint:#5f6b83;
+    --gcp:#4285f4; --orch:#34a853; --aws:#ff9900; --azure:#2ec5ce;
+    --mono:ui-monospace,"SF Mono",Menlo,monospace; --sans:"Inter",system-ui,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);padding:24px;
+    -webkit-font-smoothing:antialiased}
+  .cap{font-size:11px;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.8px;margin:0 0 14px}
+  .panel{background:var(--panel);border:1px solid var(--line-soft);border-radius:14px;max-width:680px}
+  .row{display:grid;grid-template-columns:1fr auto;gap:10px;padding:14px 16px;border-top:1px solid var(--line-soft)}
+  .row:first-child{border-top:0}
+  .prompt{font-size:13px}
+  .bids{display:flex;gap:5px;align-items:flex-end;height:40px;margin-top:11px}
+  .bid{width:36px;border-radius:4px 4px 0 0;background:color-mix(in srgb,var(--c) 38%,var(--panel-2));
+    position:relative;opacity:.55}
+  .bid.win{opacity:1;box-shadow:0 0 0 1px var(--c),0 0 14px color-mix(in srgb,var(--c) 50%,transparent)}
+  .bid .v{position:absolute;top:-15px;left:50%;transform:translateX(-50%);font-size:9px;
+    font-family:var(--mono);color:var(--ink-faint);white-space:nowrap}
+  .meta{font-size:11px;color:var(--ink-faint);margin-top:9px;display:flex;gap:10px;align-items:center}
+  .pill{font-size:10px;padding:2px 7px;border-radius:5px;border:1px solid var(--line);color:var(--ink-dim);font-family:var(--mono)}
+  .pill.frontier{color:#c4b5ff;border-color:#3a3170;background:rgba(124,92,252,.12)}
+  .outcome{text-align:right;min-width:130px}
+  .lab{font-size:10px;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.5px}
+  .price{font-family:var(--mono);font-size:16px;font-weight:600}
+  .winner{font-size:11px;margin-top:7px;font-weight:600;color:var(--c)}
+  .out{font-size:11px;color:var(--ink-dim);margin-top:3px;font-family:var(--mono)}
+  .legend{display:flex;gap:14px;margin-top:12px;font-size:11px;color:var(--ink-faint)}
+  .legend span{display:flex;align-items:center;gap:6px}
+  .sw{width:9px;height:9px;border-radius:3px;background:var(--c)}
+</style>
+</head>
+<body>
+  <p class="cap">Auction row · sealed bids revealed after award · winner glows · price = 2nd-lowest (Vickrey)</p>
+  <div class="panel">
+    <div class="row">
+      <div>
+        <div class="prompt">Summarize this 1,800-word support transcript into 5 bullets</div>
+        <div class="bids">
+          <div class="bid" style="--c:var(--gcp);height:62%"><span class="v">$.021</span></div>
+          <div class="bid win" style="--c:var(--orch);height:90%"><span class="v">$.088</span></div>
+          <div class="bid" style="--c:var(--aws);height:38%"><span class="v">$.012</span></div>
+          <div class="bid" style="--c:var(--azure);height:74%"><span class="v">$.044</span></div>
+        </div>
+        <div class="meta"><span class="pill frontier">min_tier: frontier</span><span>· 3 tool steps · 9.4s</span></div>
+      </div>
+      <div class="outcome">
+        <div class="lab">2nd price</div><div class="price" style="color:var(--orch)">$0.074</div>
+        <div class="winner" style="--c:var(--orch)">GCP · Orchestrator</div>
+        <div class="out">completed</div>
+      </div>
+    </div>
+    <div class="row">
+      <div>
+        <div class="prompt">Translate “quarterly earnings call” to Japanese</div>
+        <div class="bids">
+          <div class="bid" style="--c:var(--gcp);height:48%"><span class="v">$.014</span></div>
+          <div class="bid" style="--c:var(--orch);height:96%"><span class="v">$.121</span></div>
+          <div class="bid win" style="--c:var(--aws);height:30%"><span class="v">$.005</span></div>
+          <div class="bid" style="--c:var(--azure);height:60%"><span class="v">$.038</span></div>
+        </div>
+        <div class="meta"><span class="pill">small ok</span><span>· single call · 2.1s</span></div>
+      </div>
+      <div class="outcome">
+        <div class="lab">2nd price</div><div class="price" style="color:var(--aws)">$0.014</div>
+        <div class="winner" style="--c:var(--aws)">AWS · Nova</div>
+        <div class="out">四半期決算説明会</div>
+      </div>
+    </div>
+  </div>
+  <div class="legend">
+    <span style="--c:var(--gcp)"><i class="sw"></i>GCP/Gemini</span>
+    <span style="--c:var(--orch)"><i class="sw"></i>GCP/Orchestrator</span>
+    <span style="--c:var(--aws)"><i class="sw"></i>AWS/Nova</span>
+    <span style="--c:var(--azure)"><i class="sw"></i>Azure/GPT</span>
+  </div>
+</body>
+</html>

--- a/design/market-dashboard/dashboard.html
+++ b/design/market-dashboard/dashboard.html
@@ -1,329 +1,826 @@
 <!-- @dsCard group="Market Dashboard" -->
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Agent Tasker — Market</title>
-<style>
-  :root {
-    --bg: #0a0d14;
-    --panel: #121826;
-    --panel-2: #171f30;
-    --line: #232c40;
-    --line-soft: #1b2335;
-    --ink: #e8ecf6;
-    --ink-dim: #94a0b8;
-    --ink-faint: #5f6b83;
-    --brand: #6e8bff;
-    --win: #36d399;
-    --warn: #f4b740;
-    --loss: #f06b6b;
-    /* cloud / agent identity */
-    --gcp: #4285f4;
-    --orch: #34a853;
-    --aws: #ff9900;
-    --azure: #2ec5ce;
-    --radius: 14px;
-    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
-    --sans: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-  }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0; background:
-      radial-gradient(1100px 600px at 82% -8%, rgba(110,139,255,.10), transparent 60%),
-      radial-gradient(900px 500px at 8% 0%, rgba(46,197,206,.06), transparent 55%),
-      var(--bg);
-    color: var(--ink); font-family: var(--sans);
-    -webkit-font-smoothing: antialiased; letter-spacing: .1px;
-  }
-  .wrap { max-width: 1320px; margin: 0 auto; padding: 22px 26px 40px; }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Agent Tasker — Market</title>
+    <style>
+      :root {
+        --bg: #0a0d14;
+        --panel: #121826;
+        --panel-2: #171f30;
+        --line: #232c40;
+        --line-soft: #1b2335;
+        --ink: #e8ecf6;
+        --ink-dim: #94a0b8;
+        --ink-faint: #5f6b83;
+        --brand: #6e8bff;
+        --win: #36d399;
+        --warn: #f4b740;
+        --loss: #f06b6b;
+        /* cloud / agent identity */
+        --gcp: #4285f4;
+        --orch: #34a853;
+        --aws: #ff9900;
+        --azure: #2ec5ce;
+        --radius: 14px;
+        --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+        --sans: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background:
+          radial-gradient(1100px 600px at 82% -8%, rgba(110, 139, 255, 0.1), transparent 60%),
+          radial-gradient(900px 500px at 8% 0%, rgba(46, 197, 206, 0.06), transparent 55%),
+          var(--bg);
+        color: var(--ink);
+        font-family: var(--sans);
+        -webkit-font-smoothing: antialiased;
+        letter-spacing: 0.1px;
+      }
+      .wrap {
+        max-width: 1320px;
+        margin: 0 auto;
+        padding: 22px 26px 40px;
+      }
 
-  /* top bar */
-  .topbar { display:flex; align-items:center; gap:18px; padding-bottom:18px; }
-  .brand { display:flex; align-items:center; gap:12px; }
-  .logo { width:34px; height:34px; border-radius:9px;
-    background: linear-gradient(135deg, var(--brand), var(--azure));
-    box-shadow: 0 6px 20px rgba(110,139,255,.35); position:relative; }
-  .logo::after { content:""; position:absolute; inset:8px; border-radius:4px;
-    background: #0a0d14; opacity:.55;
-    clip-path: polygon(0 60%, 28% 60%, 38% 18%, 52% 86%, 64% 42%, 100% 42%, 100% 60%, 0 60%); }
-  .brand h1 { font-size:17px; margin:0; font-weight:650; letter-spacing:.2px; }
-  .brand .sub { font-size:11.5px; color:var(--ink-faint); margin-top:1px; }
-  .live { margin-left:auto; display:flex; gap:9px; align-items:center;
-    font-size:12px; color:var(--ink-dim); }
-  .dot { width:7px; height:7px; border-radius:50%; background:var(--win);
-    box-shadow:0 0 0 4px rgba(54,211,153,.16); }
-  .seg { display:flex; gap:2px; background:var(--panel); border:1px solid var(--line);
-    border-radius:10px; padding:3px; }
-  .seg button { background:none; border:0; color:var(--ink-dim); font:inherit;
-    font-size:12px; padding:6px 12px; border-radius:7px; cursor:pointer; }
-  .seg button.on { background:var(--panel-2); color:var(--ink); box-shadow:inset 0 0 0 1px var(--line); }
+      /* top bar */
+      .topbar {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        padding-bottom: 18px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .logo {
+        width: 34px;
+        height: 34px;
+        border-radius: 9px;
+        background: linear-gradient(135deg, var(--brand), var(--azure));
+        box-shadow: 0 6px 20px rgba(110, 139, 255, 0.35);
+        position: relative;
+      }
+      .logo::after {
+        content: "";
+        position: absolute;
+        inset: 8px;
+        border-radius: 4px;
+        background: #0a0d14;
+        opacity: 0.55;
+        clip-path: polygon(0 60%, 28% 60%, 38% 18%, 52% 86%, 64% 42%, 100% 42%, 100% 60%, 0 60%);
+      }
+      .brand h1 {
+        font-size: 17px;
+        margin: 0;
+        font-weight: 650;
+        letter-spacing: 0.2px;
+      }
+      .brand .sub {
+        font-size: 11.5px;
+        color: var(--ink-faint);
+        margin-top: 1px;
+      }
+      .live {
+        margin-left: auto;
+        display: flex;
+        gap: 9px;
+        align-items: center;
+        font-size: 12px;
+        color: var(--ink-dim);
+      }
+      .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--win);
+        box-shadow: 0 0 0 4px rgba(54, 211, 153, 0.16);
+      }
+      .seg {
+        display: flex;
+        gap: 2px;
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        padding: 3px;
+      }
+      .seg button {
+        background: none;
+        border: 0;
+        color: var(--ink-dim);
+        font: inherit;
+        font-size: 12px;
+        padding: 6px 12px;
+        border-radius: 7px;
+        cursor: pointer;
+      }
+      .seg button.on {
+        background: var(--panel-2);
+        color: var(--ink);
+        box-shadow: inset 0 0 0 1px var(--line);
+      }
 
-  /* global stat strip */
-  .strip { display:grid; grid-template-columns:repeat(5,1fr); gap:12px; margin:6px 0 20px; }
-  .kpi { background:linear-gradient(180deg,var(--panel),#0f1421);
-    border:1px solid var(--line-soft); border-radius:var(--radius); padding:14px 16px; }
-  .kpi .lab { font-size:11px; color:var(--ink-faint); text-transform:uppercase; letter-spacing:.7px; }
-  .kpi .val { font-family:var(--mono); font-size:23px; margin-top:7px; font-weight:600; }
-  .kpi .delta { font-size:11.5px; margin-top:4px; color:var(--ink-dim); }
-  .up { color:var(--win); } .down { color:var(--loss); }
+      /* global stat strip */
+      .strip {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 12px;
+        margin: 6px 0 20px;
+      }
+      .kpi {
+        background: linear-gradient(180deg, var(--panel), #0f1421);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--radius);
+        padding: 14px 16px;
+      }
+      .kpi .lab {
+        font-size: 11px;
+        color: var(--ink-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+      }
+      .kpi .val {
+        font-family: var(--mono);
+        font-size: 23px;
+        margin-top: 7px;
+        font-weight: 600;
+      }
+      .kpi .delta {
+        font-size: 11.5px;
+        margin-top: 4px;
+        color: var(--ink-dim);
+      }
+      .up {
+        color: var(--win);
+      }
+      .down {
+        color: var(--loss);
+      }
 
-  .grid { display:grid; grid-template-columns: 1fr 360px; gap:18px; align-items:start; }
-  h2.section { font-size:13px; letter-spacing:.4px; color:var(--ink-dim); margin:2px 0 12px;
-    text-transform:uppercase; font-weight:600; display:flex; align-items:center; gap:8px; }
-  h2.section .count { color:var(--ink-faint); font-family:var(--mono); font-weight:500; }
+      .grid {
+        display: grid;
+        grid-template-columns: 1fr 360px;
+        gap: 18px;
+        align-items: start;
+      }
+      h2.section {
+        font-size: 13px;
+        letter-spacing: 0.4px;
+        color: var(--ink-dim);
+        margin: 2px 0 12px;
+        text-transform: uppercase;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      h2.section .count {
+        color: var(--ink-faint);
+        font-family: var(--mono);
+        font-weight: 500;
+      }
 
-  /* agent leaderboard */
-  .agents { display:grid; grid-template-columns:repeat(2,1fr); gap:12px; margin-bottom:22px; }
-  .agent { background:var(--panel); border:1px solid var(--line-soft); border-radius:var(--radius);
-    padding:15px 16px; position:relative; overflow:hidden; }
-  .agent::before { content:""; position:absolute; left:0; top:0; bottom:0; width:3px; background:var(--c); }
-  .agent .head { display:flex; align-items:center; gap:10px; }
-  .badge { font-size:10.5px; font-weight:650; padding:3px 8px; border-radius:6px;
-    color:var(--c); background:color-mix(in srgb, var(--c) 16%, transparent);
-    border:1px solid color-mix(in srgb, var(--c) 35%, transparent); letter-spacing:.3px; }
-  .agent .name { font-weight:600; font-size:14.5px; }
-  .agent .rt { margin-left:auto; font-size:10.5px; color:var(--ink-faint); font-family:var(--mono); }
-  .agent .model { font-size:11.5px; color:var(--ink-faint); margin:3px 0 13px; }
-  .stats { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }
-  .stat .n { font-family:var(--mono); font-size:17px; font-weight:600; }
-  .stat .l { font-size:10px; color:var(--ink-faint); text-transform:uppercase; letter-spacing:.5px; margin-top:2px; }
-  .winbar { height:5px; border-radius:3px; background:var(--line); margin-top:13px; overflow:hidden; }
-  .winbar > i { display:block; height:100%; background:var(--c); border-radius:3px; }
+      /* agent leaderboard */
+      .agents {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+        margin-bottom: 22px;
+      }
+      .agent {
+        background: var(--panel);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--radius);
+        padding: 15px 16px;
+        position: relative;
+        overflow: hidden;
+      }
+      .agent::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 3px;
+        background: var(--c);
+      }
+      .agent .head {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .badge {
+        font-size: 10.5px;
+        font-weight: 650;
+        padding: 3px 8px;
+        border-radius: 6px;
+        color: var(--c);
+        background: color-mix(in srgb, var(--c) 16%, transparent);
+        border: 1px solid color-mix(in srgb, var(--c) 35%, transparent);
+        letter-spacing: 0.3px;
+      }
+      .agent .name {
+        font-weight: 600;
+        font-size: 14.5px;
+      }
+      .agent .rt {
+        margin-left: auto;
+        font-size: 10.5px;
+        color: var(--ink-faint);
+        font-family: var(--mono);
+      }
+      .agent .model {
+        font-size: 11.5px;
+        color: var(--ink-faint);
+        margin: 3px 0 13px;
+      }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 8px;
+      }
+      .stat .n {
+        font-family: var(--mono);
+        font-size: 17px;
+        font-weight: 600;
+      }
+      .stat .l {
+        font-size: 10px;
+        color: var(--ink-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-top: 2px;
+      }
+      .winbar {
+        height: 5px;
+        border-radius: 3px;
+        background: var(--line);
+        margin-top: 13px;
+        overflow: hidden;
+      }
+      .winbar > i {
+        display: block;
+        height: 100%;
+        background: var(--c);
+        border-radius: 3px;
+      }
 
-  /* auction feed */
-  .panel { background:var(--panel); border:1px solid var(--line-soft); border-radius:var(--radius); }
-  .feed { padding:6px 0; }
-  .row { display:grid; grid-template-columns: 1fr auto; gap:10px; padding:13px 16px;
-    border-top:1px solid var(--line-soft); }
-  .row:first-child { border-top:0; }
-  .row .prompt { font-size:13px; color:var(--ink); }
-  .row .meta { font-size:11px; color:var(--ink-faint); margin-top:5px; display:flex; gap:10px; align-items:center; }
-  .pill { font-size:10px; padding:2px 7px; border-radius:5px; border:1px solid var(--line);
-    color:var(--ink-dim); font-family:var(--mono); }
-  .pill.frontier { color:#c4b5ff; border-color:#3a3170; background:rgba(124,92,252,.12); }
-  .bids { display:flex; gap:5px; align-items:flex-end; height:38px; margin-top:9px; }
-  .bid { width:34px; border-radius:4px 4px 0 0; background:color-mix(in srgb,var(--c) 38%, var(--panel-2));
-    position:relative; opacity:.55; }
-  .bid.win { opacity:1; box-shadow:0 0 0 1px var(--c), 0 0 14px color-mix(in srgb,var(--c) 50%, transparent); }
-  .bid .cap { position:absolute; top:-15px; left:50%; transform:translateX(-50%);
-    font-size:9px; font-family:var(--mono); color:var(--ink-faint); white-space:nowrap; }
-  .outcome { text-align:right; min-width:120px; }
-  .outcome .price { font-family:var(--mono); font-size:16px; font-weight:600; }
-  .outcome .lab { font-size:10px; color:var(--ink-faint); text-transform:uppercase; letter-spacing:.5px; }
-  .outcome .winner { font-size:11px; margin-top:7px; color:var(--c); font-weight:600; }
-  .outcome .out { font-size:11px; color:var(--ink-dim); margin-top:3px; font-family:var(--mono); }
+      /* auction feed */
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--line-soft);
+        border-radius: var(--radius);
+      }
+      .feed {
+        padding: 6px 0;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 10px;
+        padding: 13px 16px;
+        border-top: 1px solid var(--line-soft);
+      }
+      .row:first-child {
+        border-top: 0;
+      }
+      .row .prompt {
+        font-size: 13px;
+        color: var(--ink);
+      }
+      .row .meta {
+        font-size: 11px;
+        color: var(--ink-faint);
+        margin-top: 5px;
+        display: flex;
+        gap: 10px;
+        align-items: center;
+      }
+      .pill {
+        font-size: 10px;
+        padding: 2px 7px;
+        border-radius: 5px;
+        border: 1px solid var(--line);
+        color: var(--ink-dim);
+        font-family: var(--mono);
+      }
+      .pill.frontier {
+        color: #c4b5ff;
+        border-color: #3a3170;
+        background: rgba(124, 92, 252, 0.12);
+      }
+      .bids {
+        display: flex;
+        gap: 5px;
+        align-items: flex-end;
+        height: 38px;
+        margin-top: 9px;
+      }
+      .bid {
+        width: 34px;
+        border-radius: 4px 4px 0 0;
+        background: color-mix(in srgb, var(--c) 38%, var(--panel-2));
+        position: relative;
+        opacity: 0.55;
+      }
+      .bid.win {
+        opacity: 1;
+        box-shadow:
+          0 0 0 1px var(--c),
+          0 0 14px color-mix(in srgb, var(--c) 50%, transparent);
+      }
+      .bid .cap {
+        position: absolute;
+        top: -15px;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: 9px;
+        font-family: var(--mono);
+        color: var(--ink-faint);
+        white-space: nowrap;
+      }
+      .outcome {
+        text-align: right;
+        min-width: 120px;
+      }
+      .outcome .price {
+        font-family: var(--mono);
+        font-size: 16px;
+        font-weight: 600;
+      }
+      .outcome .lab {
+        font-size: 10px;
+        color: var(--ink-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      .outcome .winner {
+        font-size: 11px;
+        margin-top: 7px;
+        color: var(--c);
+        font-weight: 600;
+      }
+      .outcome .out {
+        font-size: 11px;
+        color: var(--ink-dim);
+        margin-top: 3px;
+        font-family: var(--mono);
+      }
 
-  /* right column */
-  .side { display:flex; flex-direction:column; gap:18px; }
-  .card-pad { padding:16px; }
-  .share-row { display:flex; align-items:center; gap:10px; margin:11px 0; font-size:12.5px; }
-  .share-row .lbl { width:108px; color:var(--ink-dim); display:flex; align-items:center; gap:7px; }
-  .swatch { width:9px; height:9px; border-radius:3px; background:var(--c); }
-  .track { flex:1; height:8px; background:var(--line); border-radius:5px; overflow:hidden; }
-  .track > i { display:block; height:100%; background:var(--c); }
-  .share-row .pct { width:38px; text-align:right; font-family:var(--mono); color:var(--ink); font-size:12px; }
+      /* right column */
+      .side {
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+      .card-pad {
+        padding: 16px;
+      }
+      .share-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin: 11px 0;
+        font-size: 12.5px;
+      }
+      .share-row .lbl {
+        width: 108px;
+        color: var(--ink-dim);
+        display: flex;
+        align-items: center;
+        gap: 7px;
+      }
+      .swatch {
+        width: 9px;
+        height: 9px;
+        border-radius: 3px;
+        background: var(--c);
+      }
+      .track {
+        flex: 1;
+        height: 8px;
+        background: var(--line);
+        border-radius: 5px;
+        overflow: hidden;
+      }
+      .track > i {
+        display: block;
+        height: 100%;
+        background: var(--c);
+      }
+      .share-row .pct {
+        width: 38px;
+        text-align: right;
+        font-family: var(--mono);
+        color: var(--ink);
+        font-size: 12px;
+      }
 
-  .acc { padding:4px 0 2px; }
-  .acc .ar { display:flex; align-items:center; gap:10px; padding:9px 0; border-top:1px solid var(--line-soft); }
-  .acc .ar:first-child { border-top:0; }
-  .acc .ar .nm { width:120px; font-size:12px; color:var(--ink-dim); display:flex; gap:7px; align-items:center; }
-  .acc .ar .mtrack { flex:1; height:6px; background:var(--line); border-radius:4px; overflow:hidden; }
-  .acc .ar .mtrack > i { display:block; height:100%; background:linear-gradient(90deg,var(--win),var(--warn)); }
-  .acc .ar .mv { width:46px; text-align:right; font-family:var(--mono); font-size:12px; }
+      .acc {
+        padding: 4px 0 2px;
+      }
+      .acc .ar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 9px 0;
+        border-top: 1px solid var(--line-soft);
+      }
+      .acc .ar:first-child {
+        border-top: 0;
+      }
+      .acc .ar .nm {
+        width: 120px;
+        font-size: 12px;
+        color: var(--ink-dim);
+        display: flex;
+        gap: 7px;
+        align-items: center;
+      }
+      .acc .ar .mtrack {
+        flex: 1;
+        height: 6px;
+        background: var(--line);
+        border-radius: 4px;
+        overflow: hidden;
+      }
+      .acc .ar .mtrack > i {
+        display: block;
+        height: 100%;
+        background: linear-gradient(90deg, var(--win), var(--warn));
+      }
+      .acc .ar .mv {
+        width: 46px;
+        text-align: right;
+        font-family: var(--mono);
+        font-size: 12px;
+      }
 
-  .foot { margin-top:18px; font-size:11px; color:var(--ink-faint); display:flex; gap:16px; }
-</style>
-</head>
-<body>
-<div class="wrap">
+      .foot {
+        margin-top: 18px;
+        font-size: 11px;
+        color: var(--ink-faint);
+        display: flex;
+        gap: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="topbar">
+        <div class="brand">
+          <div class="logo"></div>
+          <div>
+            <h1>Agent Tasker · Market</h1>
+            <div class="sub">Vickrey auction · 4 agents · 3 clouds</div>
+          </div>
+        </div>
+        <div class="seg" style="margin-left: auto">
+          <button class="on">Live</button><button>24h</button><button>7d</button
+          ><button>All</button>
+        </div>
+        <div class="live"><span class="dot"></span> 4 / 4 agents online</div>
+      </div>
 
-  <div class="topbar">
-    <div class="brand">
-      <div class="logo"></div>
-      <div>
-        <h1>Agent Tasker · Market</h1>
-        <div class="sub">Vickrey auction · 4 agents · 3 clouds</div>
+      <div class="strip">
+        <div class="kpi">
+          <div class="lab">Tasks settled</div>
+          <div class="val">767</div>
+          <div class="delta up">▲ 38 today</div>
+        </div>
+        <div class="kpi">
+          <div class="lab">Total spend</div>
+          <div class="val">$21.40</div>
+          <div class="delta">execute only</div>
+        </div>
+        <div class="kpi">
+          <div class="lab">Avg / task</div>
+          <div class="val">$0.0279</div>
+          <div class="delta up">▼ 6% vs 7d</div>
+        </div>
+        <div class="kpi">
+          <div class="lab">Avg settle</div>
+          <div class="val">7.1s</div>
+          <div class="delta">bid+exec</div>
+        </div>
+        <div class="kpi">
+          <div class="lab">Decline rate</div>
+          <div class="val">3.2%</div>
+          <div class="delta">capability / policy</div>
+        </div>
+      </div>
+
+      <div class="grid">
+        <div>
+          <h2 class="section">Agents <span class="count">— win share & accuracy</span></h2>
+          <div class="agents">
+            <div class="agent" style="--c: var(--gcp)">
+              <div class="head">
+                <span class="badge">GCP</span><span class="name">Gemini</span
+                ><span class="rt">direct · vertex</span>
+              </div>
+              <div class="model">Gemini 2.5 Pro · frontier · simple-task specialist</div>
+              <div class="stats">
+                <div class="stat">
+                  <div class="n">41%</div>
+                  <div class="l">win rate</div>
+                </div>
+                <div class="stat">
+                  <div class="n">12.4%</div>
+                  <div class="l">MAPE</div>
+                </div>
+                <div class="stat">
+                  <div class="n">$0.018</div>
+                  <div class="l">avg/task</div>
+                </div>
+              </div>
+              <div class="winbar"><i style="width: 41%"></i></div>
+            </div>
+
+            <div class="agent" style="--c: var(--orch)">
+              <div class="head">
+                <span class="badge">GCP</span><span class="name">Orchestrator</span
+                ><span class="rt">GAEP · multi-step</span>
+              </div>
+              <div class="model">Gemini 2.5 Pro + tools · frontier · complex-task specialist</div>
+              <div class="stats">
+                <div class="stat">
+                  <div class="n">11%</div>
+                  <div class="l">win rate</div>
+                </div>
+                <div class="stat">
+                  <div class="n">23.7%</div>
+                  <div class="l">MAPE</div>
+                </div>
+                <div class="stat">
+                  <div class="n">$0.114</div>
+                  <div class="l">avg/task</div>
+                </div>
+              </div>
+              <div class="winbar"><i style="width: 11%"></i></div>
+            </div>
+
+            <div class="agent" style="--c: var(--aws)">
+              <div class="head">
+                <span class="badge">AWS</span><span class="name">Nova</span
+                ><span class="rt">bedrock · lambda</span>
+              </div>
+              <div class="model">Amazon Nova Pro · frontier · low-cost leader</div>
+              <div class="stats">
+                <div class="stat">
+                  <div class="n">27%</div>
+                  <div class="l">win rate</div>
+                </div>
+                <div class="stat">
+                  <div class="n">9.8%</div>
+                  <div class="l">MAPE</div>
+                </div>
+                <div class="stat">
+                  <div class="n">$0.006</div>
+                  <div class="l">avg/task</div>
+                </div>
+              </div>
+              <div class="winbar"><i style="width: 27%"></i></div>
+            </div>
+
+            <div class="agent" style="--c: var(--azure)">
+              <div class="head">
+                <span class="badge">AZURE</span><span class="name">GPT</span
+                ><span class="rt">openai · container</span>
+              </div>
+              <div class="model">
+                gpt-4o <span style="color: var(--warn)">· interim (GPT-5 quota pending)</span>
+              </div>
+              <div class="stats">
+                <div class="stat">
+                  <div class="n">21%</div>
+                  <div class="l">win rate</div>
+                </div>
+                <div class="stat">
+                  <div class="n">15.1%</div>
+                  <div class="l">MAPE</div>
+                </div>
+                <div class="stat">
+                  <div class="n">$0.041</div>
+                  <div class="l">avg/task</div>
+                </div>
+              </div>
+              <div class="winbar"><i style="width: 21%"></i></div>
+            </div>
+          </div>
+
+          <h2 class="section">
+            Live auctions <span class="count">— sealed bids → winner → second price</span>
+          </h2>
+          <div class="panel feed">
+            <div class="row">
+              <div>
+                <div class="prompt">
+                  Summarize this 1,800-word support transcript into 5 bullets
+                </div>
+                <div class="bids">
+                  <div class="bid" style="--c: var(--gcp); height: 62%">
+                    <span class="cap">$.021</span>
+                  </div>
+                  <div class="bid win" style="--c: var(--orch); height: 90%">
+                    <span class="cap">$.088</span>
+                  </div>
+                  <div class="bid" style="--c: var(--aws); height: 38%">
+                    <span class="cap">$.012</span>
+                  </div>
+                  <div class="bid" style="--c: var(--azure); height: 74%">
+                    <span class="cap">$.044</span>
+                  </div>
+                </div>
+                <div class="meta">
+                  <span class="pill frontier">frontier</span><span class="pill">min_tier</span
+                  ><span>· 3 tool steps · 9.4s</span>
+                </div>
+              </div>
+              <div class="outcome">
+                <div class="lab">2nd price</div>
+                <div class="price" style="color: var(--orch)">$0.074</div>
+                <div class="winner" style="--c: var(--orch)">GCP · Orchestrator</div>
+                <div class="out">completed</div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div>
+                <div class="prompt">Translate “quarterly earnings call” to Japanese</div>
+                <div class="bids">
+                  <div class="bid" style="--c: var(--gcp); height: 48%">
+                    <span class="cap">$.014</span>
+                  </div>
+                  <div class="bid" style="--c: var(--orch); height: 96%">
+                    <span class="cap">$.121</span>
+                  </div>
+                  <div class="bid win" style="--c: var(--aws); height: 30%">
+                    <span class="cap">$.005</span>
+                  </div>
+                  <div class="bid" style="--c: var(--azure); height: 60%">
+                    <span class="cap">$.038</span>
+                  </div>
+                </div>
+                <div class="meta">
+                  <span class="pill">small ok</span><span>· single call · 2.1s</span>
+                </div>
+              </div>
+              <div class="outcome">
+                <div class="lab">2nd price</div>
+                <div class="price" style="color: var(--aws)">$0.014</div>
+                <div class="winner" style="--c: var(--aws)">AWS · Nova</div>
+                <div class="out">“四半期決算説明会”</div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div>
+                <div class="prompt">Extract all dates and amounts from this invoice</div>
+                <div class="bids">
+                  <div class="bid win" style="--c: var(--gcp); height: 52%">
+                    <span class="cap">$.016</span>
+                  </div>
+                  <div class="bid" style="--c: var(--orch); height: 88%">
+                    <span class="cap">$.092</span>
+                  </div>
+                  <div class="bid" style="--c: var(--aws); height: 34%">
+                    <span class="cap">$.007</span>
+                  </div>
+                  <div class="bid" style="--c: var(--azure); height: 66%">
+                    <span class="cap">$.041</span>
+                  </div>
+                </div>
+                <div class="meta">
+                  <span class="pill">small ok</span><span>· single call · 3.0s</span>
+                </div>
+              </div>
+              <div class="outcome">
+                <div class="lab">2nd price</div>
+                <div class="price" style="color: var(--gcp)">$0.016</div>
+                <div class="winner" style="--c: var(--gcp)">GCP · Gemini</div>
+                <div class="out">12 fields</div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div>
+                <div class="prompt">Draft a polite follow-up email declining a vendor</div>
+                <div class="bids">
+                  <div class="bid" style="--c: var(--gcp); height: 50%">
+                    <span class="cap">$.015</span>
+                  </div>
+                  <div class="bid" style="--c: var(--orch); height: 84%">
+                    <span class="cap">$.081</span>
+                  </div>
+                  <div class="bid" style="--c: var(--aws); height: 32%">
+                    <span class="cap">$.006</span>
+                  </div>
+                  <div class="bid win" style="--c: var(--azure); height: 64%">
+                    <span class="cap">$.040</span>
+                  </div>
+                </div>
+                <div class="meta">
+                  <span class="pill frontier">frontier</span><span>· single call · 4.2s</span>
+                </div>
+              </div>
+              <div class="outcome">
+                <div class="lab">2nd price</div>
+                <div class="price" style="color: var(--azure)">$0.040</div>
+                <div class="winner" style="--c: var(--azure)">Azure · GPT</div>
+                <div class="out">completed</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- right column -->
+        <div class="side">
+          <div class="panel card-pad">
+            <h2 class="section" style="margin-top: 0">Win share by cloud</h2>
+            <div class="share-row">
+              <div class="lbl" style="--c: var(--gcp)"><span class="swatch"></span>GCP (both)</div>
+              <div class="track"><i style="width: 52%"></i></div>
+              <div class="pct">52%</div>
+            </div>
+            <div class="share-row">
+              <div class="lbl" style="--c: var(--aws)"><span class="swatch"></span>AWS</div>
+              <div class="track"><i style="width: 27%"></i></div>
+              <div class="pct">27%</div>
+            </div>
+            <div class="share-row">
+              <div class="lbl" style="--c: var(--azure)"><span class="swatch"></span>Azure</div>
+              <div class="track"><i style="width: 21%"></i></div>
+              <div class="pct">21%</div>
+            </div>
+            <div style="border-top: 1px solid var(--line-soft); margin: 14px 0 4px"></div>
+            <h2 class="section">Spend share by cloud</h2>
+            <div class="share-row">
+              <div class="lbl" style="--c: var(--gcp)"><span class="swatch"></span>GCP</div>
+              <div class="track"><i style="width: 58%"></i></div>
+              <div class="pct">58%</div>
+            </div>
+            <div class="share-row">
+              <div class="lbl" style="--c: var(--azure)"><span class="swatch"></span>Azure</div>
+              <div class="track"><i style="width: 30%"></i></div>
+              <div class="pct">30%</div>
+            </div>
+            <div class="share-row">
+              <div class="lbl" style="--c: var(--aws)"><span class="swatch"></span>AWS</div>
+              <div class="track"><i style="width: 12%"></i></div>
+              <div class="pct">12%</div>
+            </div>
+          </div>
+
+          <div class="panel card-pad">
+            <h2 class="section" style="margin-top: 0">
+              Bid accuracy <span class="count">— MAPE, lower = better</span>
+            </h2>
+            <div class="acc">
+              <div class="ar">
+                <div class="nm" style="--c: var(--aws)"><span class="swatch"></span>Nova</div>
+                <div class="mtrack"><i style="width: 18%"></i></div>
+                <div class="mv">9.8%</div>
+              </div>
+              <div class="ar">
+                <div class="nm" style="--c: var(--gcp)"><span class="swatch"></span>Gemini</div>
+                <div class="mtrack"><i style="width: 26%"></i></div>
+                <div class="mv">12.4%</div>
+              </div>
+              <div class="ar">
+                <div class="nm" style="--c: var(--azure)"><span class="swatch"></span>GPT</div>
+                <div class="mtrack"><i style="width: 32%"></i></div>
+                <div class="mv">15.1%</div>
+              </div>
+              <div class="ar">
+                <div class="nm" style="--c: var(--orch)">
+                  <span class="swatch"></span>Orchestrator
+                </div>
+                <div class="mtrack"><i style="width: 50%"></i></div>
+                <div class="mv">23.7%</div>
+              </div>
+            </div>
+            <div
+              style="font-size: 11px; color: var(--ink-faint); margin-top: 10px; line-height: 1.5"
+            >
+              Orchestrator MAPE is dominated by step-count / tool-call prediction, not tokenization.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="foot">
+        <span>Coordinator · GCP us-central1</span><span>·</span> <span>Vickrey (second-price)</span
+        ><span>·</span>
+        <span>score-weighting unlocks at 100 settled tasks</span>
       </div>
     </div>
-    <div class="seg" style="margin-left:auto">
-      <button class="on">Live</button><button>24h</button><button>7d</button><button>All</button>
-    </div>
-    <div class="live"><span class="dot"></span> 4 / 4 agents online</div>
-  </div>
-
-  <div class="strip">
-    <div class="kpi"><div class="lab">Tasks settled</div><div class="val">767</div><div class="delta up">▲ 38 today</div></div>
-    <div class="kpi"><div class="lab">Total spend</div><div class="val">$21.40</div><div class="delta">execute only</div></div>
-    <div class="kpi"><div class="lab">Avg / task</div><div class="val">$0.0279</div><div class="delta up">▼ 6% vs 7d</div></div>
-    <div class="kpi"><div class="lab">Avg settle</div><div class="val">7.1s</div><div class="delta">bid+exec</div></div>
-    <div class="kpi"><div class="lab">Decline rate</div><div class="val">3.2%</div><div class="delta">capability / policy</div></div>
-  </div>
-
-  <div class="grid">
-    <div>
-      <h2 class="section">Agents <span class="count">— win share & accuracy</span></h2>
-      <div class="agents">
-
-        <div class="agent" style="--c:var(--gcp)">
-          <div class="head"><span class="badge">GCP</span><span class="name">Gemini</span><span class="rt">direct · vertex</span></div>
-          <div class="model">Gemini 2.5 Pro · frontier · simple-task specialist</div>
-          <div class="stats">
-            <div class="stat"><div class="n">41%</div><div class="l">win rate</div></div>
-            <div class="stat"><div class="n">12.4%</div><div class="l">MAPE</div></div>
-            <div class="stat"><div class="n">$0.018</div><div class="l">avg/task</div></div>
-          </div>
-          <div class="winbar"><i style="width:41%"></i></div>
-        </div>
-
-        <div class="agent" style="--c:var(--orch)">
-          <div class="head"><span class="badge">GCP</span><span class="name">Orchestrator</span><span class="rt">GAEP · multi-step</span></div>
-          <div class="model">Gemini 2.5 Pro + tools · frontier · complex-task specialist</div>
-          <div class="stats">
-            <div class="stat"><div class="n">11%</div><div class="l">win rate</div></div>
-            <div class="stat"><div class="n">23.7%</div><div class="l">MAPE</div></div>
-            <div class="stat"><div class="n">$0.114</div><div class="l">avg/task</div></div>
-          </div>
-          <div class="winbar"><i style="width:11%"></i></div>
-        </div>
-
-        <div class="agent" style="--c:var(--aws)">
-          <div class="head"><span class="badge">AWS</span><span class="name">Nova</span><span class="rt">bedrock · lambda</span></div>
-          <div class="model">Amazon Nova Pro · frontier · low-cost leader</div>
-          <div class="stats">
-            <div class="stat"><div class="n">27%</div><div class="l">win rate</div></div>
-            <div class="stat"><div class="n">9.8%</div><div class="l">MAPE</div></div>
-            <div class="stat"><div class="n">$0.006</div><div class="l">avg/task</div></div>
-          </div>
-          <div class="winbar"><i style="width:27%"></i></div>
-        </div>
-
-        <div class="agent" style="--c:var(--azure)">
-          <div class="head"><span class="badge">AZURE</span><span class="name">GPT</span><span class="rt">openai · container</span></div>
-          <div class="model">gpt-4o <span style="color:var(--warn)">· interim (GPT-5 quota pending)</span></div>
-          <div class="stats">
-            <div class="stat"><div class="n">21%</div><div class="l">win rate</div></div>
-            <div class="stat"><div class="n">15.1%</div><div class="l">MAPE</div></div>
-            <div class="stat"><div class="n">$0.041</div><div class="l">avg/task</div></div>
-          </div>
-          <div class="winbar"><i style="width:21%"></i></div>
-        </div>
-
-      </div>
-
-      <h2 class="section">Live auctions <span class="count">— sealed bids → winner → second price</span></h2>
-      <div class="panel feed">
-
-        <div class="row">
-          <div>
-            <div class="prompt">Summarize this 1,800-word support transcript into 5 bullets</div>
-            <div class="bids">
-              <div class="bid" style="--c:var(--gcp); height:62%"><span class="cap">$.021</span></div>
-              <div class="bid win" style="--c:var(--orch); height:90%"><span class="cap">$.088</span></div>
-              <div class="bid" style="--c:var(--aws); height:38%"><span class="cap">$.012</span></div>
-              <div class="bid" style="--c:var(--azure); height:74%"><span class="cap">$.044</span></div>
-            </div>
-            <div class="meta"><span class="pill frontier">frontier</span><span class="pill">min_tier</span><span>· 3 tool steps · 9.4s</span></div>
-          </div>
-          <div class="outcome">
-            <div class="lab">2nd price</div><div class="price" style="color:var(--orch)">$0.074</div>
-            <div class="winner" style="--c:var(--orch)">GCP · Orchestrator</div>
-            <div class="out">completed</div>
-          </div>
-        </div>
-
-        <div class="row">
-          <div>
-            <div class="prompt">Translate “quarterly earnings call” to Japanese</div>
-            <div class="bids">
-              <div class="bid" style="--c:var(--gcp); height:48%"><span class="cap">$.014</span></div>
-              <div class="bid" style="--c:var(--orch); height:96%"><span class="cap">$.121</span></div>
-              <div class="bid win" style="--c:var(--aws); height:30%"><span class="cap">$.005</span></div>
-              <div class="bid" style="--c:var(--azure); height:60%"><span class="cap">$.038</span></div>
-            </div>
-            <div class="meta"><span class="pill">small ok</span><span>· single call · 2.1s</span></div>
-          </div>
-          <div class="outcome">
-            <div class="lab">2nd price</div><div class="price" style="color:var(--aws)">$0.014</div>
-            <div class="winner" style="--c:var(--aws)">AWS · Nova</div>
-            <div class="out">“四半期決算説明会”</div>
-          </div>
-        </div>
-
-        <div class="row">
-          <div>
-            <div class="prompt">Extract all dates and amounts from this invoice</div>
-            <div class="bids">
-              <div class="bid win" style="--c:var(--gcp); height:52%"><span class="cap">$.016</span></div>
-              <div class="bid" style="--c:var(--orch); height:88%"><span class="cap">$.092</span></div>
-              <div class="bid" style="--c:var(--aws); height:34%"><span class="cap">$.007</span></div>
-              <div class="bid" style="--c:var(--azure); height:66%"><span class="cap">$.041</span></div>
-            </div>
-            <div class="meta"><span class="pill">small ok</span><span>· single call · 3.0s</span></div>
-          </div>
-          <div class="outcome">
-            <div class="lab">2nd price</div><div class="price" style="color:var(--gcp)">$0.016</div>
-            <div class="winner" style="--c:var(--gcp)">GCP · Gemini</div>
-            <div class="out">12 fields</div>
-          </div>
-        </div>
-
-        <div class="row">
-          <div>
-            <div class="prompt">Draft a polite follow-up email declining a vendor</div>
-            <div class="bids">
-              <div class="bid" style="--c:var(--gcp); height:50%"><span class="cap">$.015</span></div>
-              <div class="bid" style="--c:var(--orch); height:84%"><span class="cap">$.081</span></div>
-              <div class="bid" style="--c:var(--aws); height:32%"><span class="cap">$.006</span></div>
-              <div class="bid win" style="--c:var(--azure); height:64%"><span class="cap">$.040</span></div>
-            </div>
-            <div class="meta"><span class="pill frontier">frontier</span><span>· single call · 4.2s</span></div>
-          </div>
-          <div class="outcome">
-            <div class="lab">2nd price</div><div class="price" style="color:var(--azure)">$0.040</div>
-            <div class="winner" style="--c:var(--azure)">Azure · GPT</div>
-            <div class="out">completed</div>
-          </div>
-        </div>
-
-      </div>
-    </div>
-
-    <!-- right column -->
-    <div class="side">
-      <div class="panel card-pad">
-        <h2 class="section" style="margin-top:0">Win share by cloud</h2>
-        <div class="share-row"><div class="lbl" style="--c:var(--gcp)"><span class="swatch"></span>GCP (both)</div><div class="track"><i style="width:52%"></i></div><div class="pct">52%</div></div>
-        <div class="share-row"><div class="lbl" style="--c:var(--aws)"><span class="swatch"></span>AWS</div><div class="track"><i style="width:27%"></i></div><div class="pct">27%</div></div>
-        <div class="share-row"><div class="lbl" style="--c:var(--azure)"><span class="swatch"></span>Azure</div><div class="track"><i style="width:21%"></i></div><div class="pct">21%</div></div>
-        <div style="border-top:1px solid var(--line-soft); margin:14px 0 4px"></div>
-        <h2 class="section">Spend share by cloud</h2>
-        <div class="share-row"><div class="lbl" style="--c:var(--gcp)"><span class="swatch"></span>GCP</div><div class="track"><i style="width:58%"></i></div><div class="pct">58%</div></div>
-        <div class="share-row"><div class="lbl" style="--c:var(--azure)"><span class="swatch"></span>Azure</div><div class="track"><i style="width:30%"></i></div><div class="pct">30%</div></div>
-        <div class="share-row"><div class="lbl" style="--c:var(--aws)"><span class="swatch"></span>AWS</div><div class="track"><i style="width:12%"></i></div><div class="pct">12%</div></div>
-      </div>
-
-      <div class="panel card-pad">
-        <h2 class="section" style="margin-top:0">Bid accuracy <span class="count">— MAPE, lower = better</span></h2>
-        <div class="acc">
-          <div class="ar"><div class="nm" style="--c:var(--aws)"><span class="swatch"></span>Nova</div><div class="mtrack"><i style="width:18%"></i></div><div class="mv">9.8%</div></div>
-          <div class="ar"><div class="nm" style="--c:var(--gcp)"><span class="swatch"></span>Gemini</div><div class="mtrack"><i style="width:26%"></i></div><div class="mv">12.4%</div></div>
-          <div class="ar"><div class="nm" style="--c:var(--azure)"><span class="swatch"></span>GPT</div><div class="mtrack"><i style="width:32%"></i></div><div class="mv">15.1%</div></div>
-          <div class="ar"><div class="nm" style="--c:var(--orch)"><span class="swatch"></span>Orchestrator</div><div class="mtrack"><i style="width:50%"></i></div><div class="mv">23.7%</div></div>
-        </div>
-        <div style="font-size:11px; color:var(--ink-faint); margin-top:10px; line-height:1.5">
-          Orchestrator MAPE is dominated by step-count / tool-call prediction, not tokenization.
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="foot">
-    <span>Coordinator · GCP us-central1</span><span>·</span>
-    <span>Vickrey (second-price)</span><span>·</span>
-    <span>score-weighting unlocks at 100 settled tasks</span>
-  </div>
-</div>
-</body>
+  </body>
 </html>

--- a/design/market-dashboard/dashboard.html
+++ b/design/market-dashboard/dashboard.html
@@ -1,0 +1,329 @@
+<!-- @dsCard group="Market Dashboard" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Agent Tasker — Market</title>
+<style>
+  :root {
+    --bg: #0a0d14;
+    --panel: #121826;
+    --panel-2: #171f30;
+    --line: #232c40;
+    --line-soft: #1b2335;
+    --ink: #e8ecf6;
+    --ink-dim: #94a0b8;
+    --ink-faint: #5f6b83;
+    --brand: #6e8bff;
+    --win: #36d399;
+    --warn: #f4b740;
+    --loss: #f06b6b;
+    /* cloud / agent identity */
+    --gcp: #4285f4;
+    --orch: #34a853;
+    --aws: #ff9900;
+    --azure: #2ec5ce;
+    --radius: 14px;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+    --sans: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background:
+      radial-gradient(1100px 600px at 82% -8%, rgba(110,139,255,.10), transparent 60%),
+      radial-gradient(900px 500px at 8% 0%, rgba(46,197,206,.06), transparent 55%),
+      var(--bg);
+    color: var(--ink); font-family: var(--sans);
+    -webkit-font-smoothing: antialiased; letter-spacing: .1px;
+  }
+  .wrap { max-width: 1320px; margin: 0 auto; padding: 22px 26px 40px; }
+
+  /* top bar */
+  .topbar { display:flex; align-items:center; gap:18px; padding-bottom:18px; }
+  .brand { display:flex; align-items:center; gap:12px; }
+  .logo { width:34px; height:34px; border-radius:9px;
+    background: linear-gradient(135deg, var(--brand), var(--azure));
+    box-shadow: 0 6px 20px rgba(110,139,255,.35); position:relative; }
+  .logo::after { content:""; position:absolute; inset:8px; border-radius:4px;
+    background: #0a0d14; opacity:.55;
+    clip-path: polygon(0 60%, 28% 60%, 38% 18%, 52% 86%, 64% 42%, 100% 42%, 100% 60%, 0 60%); }
+  .brand h1 { font-size:17px; margin:0; font-weight:650; letter-spacing:.2px; }
+  .brand .sub { font-size:11.5px; color:var(--ink-faint); margin-top:1px; }
+  .live { margin-left:auto; display:flex; gap:9px; align-items:center;
+    font-size:12px; color:var(--ink-dim); }
+  .dot { width:7px; height:7px; border-radius:50%; background:var(--win);
+    box-shadow:0 0 0 4px rgba(54,211,153,.16); }
+  .seg { display:flex; gap:2px; background:var(--panel); border:1px solid var(--line);
+    border-radius:10px; padding:3px; }
+  .seg button { background:none; border:0; color:var(--ink-dim); font:inherit;
+    font-size:12px; padding:6px 12px; border-radius:7px; cursor:pointer; }
+  .seg button.on { background:var(--panel-2); color:var(--ink); box-shadow:inset 0 0 0 1px var(--line); }
+
+  /* global stat strip */
+  .strip { display:grid; grid-template-columns:repeat(5,1fr); gap:12px; margin:6px 0 20px; }
+  .kpi { background:linear-gradient(180deg,var(--panel),#0f1421);
+    border:1px solid var(--line-soft); border-radius:var(--radius); padding:14px 16px; }
+  .kpi .lab { font-size:11px; color:var(--ink-faint); text-transform:uppercase; letter-spacing:.7px; }
+  .kpi .val { font-family:var(--mono); font-size:23px; margin-top:7px; font-weight:600; }
+  .kpi .delta { font-size:11.5px; margin-top:4px; color:var(--ink-dim); }
+  .up { color:var(--win); } .down { color:var(--loss); }
+
+  .grid { display:grid; grid-template-columns: 1fr 360px; gap:18px; align-items:start; }
+  h2.section { font-size:13px; letter-spacing:.4px; color:var(--ink-dim); margin:2px 0 12px;
+    text-transform:uppercase; font-weight:600; display:flex; align-items:center; gap:8px; }
+  h2.section .count { color:var(--ink-faint); font-family:var(--mono); font-weight:500; }
+
+  /* agent leaderboard */
+  .agents { display:grid; grid-template-columns:repeat(2,1fr); gap:12px; margin-bottom:22px; }
+  .agent { background:var(--panel); border:1px solid var(--line-soft); border-radius:var(--radius);
+    padding:15px 16px; position:relative; overflow:hidden; }
+  .agent::before { content:""; position:absolute; left:0; top:0; bottom:0; width:3px; background:var(--c); }
+  .agent .head { display:flex; align-items:center; gap:10px; }
+  .badge { font-size:10.5px; font-weight:650; padding:3px 8px; border-radius:6px;
+    color:var(--c); background:color-mix(in srgb, var(--c) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--c) 35%, transparent); letter-spacing:.3px; }
+  .agent .name { font-weight:600; font-size:14.5px; }
+  .agent .rt { margin-left:auto; font-size:10.5px; color:var(--ink-faint); font-family:var(--mono); }
+  .agent .model { font-size:11.5px; color:var(--ink-faint); margin:3px 0 13px; }
+  .stats { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }
+  .stat .n { font-family:var(--mono); font-size:17px; font-weight:600; }
+  .stat .l { font-size:10px; color:var(--ink-faint); text-transform:uppercase; letter-spacing:.5px; margin-top:2px; }
+  .winbar { height:5px; border-radius:3px; background:var(--line); margin-top:13px; overflow:hidden; }
+  .winbar > i { display:block; height:100%; background:var(--c); border-radius:3px; }
+
+  /* auction feed */
+  .panel { background:var(--panel); border:1px solid var(--line-soft); border-radius:var(--radius); }
+  .feed { padding:6px 0; }
+  .row { display:grid; grid-template-columns: 1fr auto; gap:10px; padding:13px 16px;
+    border-top:1px solid var(--line-soft); }
+  .row:first-child { border-top:0; }
+  .row .prompt { font-size:13px; color:var(--ink); }
+  .row .meta { font-size:11px; color:var(--ink-faint); margin-top:5px; display:flex; gap:10px; align-items:center; }
+  .pill { font-size:10px; padding:2px 7px; border-radius:5px; border:1px solid var(--line);
+    color:var(--ink-dim); font-family:var(--mono); }
+  .pill.frontier { color:#c4b5ff; border-color:#3a3170; background:rgba(124,92,252,.12); }
+  .bids { display:flex; gap:5px; align-items:flex-end; height:38px; margin-top:9px; }
+  .bid { width:34px; border-radius:4px 4px 0 0; background:color-mix(in srgb,var(--c) 38%, var(--panel-2));
+    position:relative; opacity:.55; }
+  .bid.win { opacity:1; box-shadow:0 0 0 1px var(--c), 0 0 14px color-mix(in srgb,var(--c) 50%, transparent); }
+  .bid .cap { position:absolute; top:-15px; left:50%; transform:translateX(-50%);
+    font-size:9px; font-family:var(--mono); color:var(--ink-faint); white-space:nowrap; }
+  .outcome { text-align:right; min-width:120px; }
+  .outcome .price { font-family:var(--mono); font-size:16px; font-weight:600; }
+  .outcome .lab { font-size:10px; color:var(--ink-faint); text-transform:uppercase; letter-spacing:.5px; }
+  .outcome .winner { font-size:11px; margin-top:7px; color:var(--c); font-weight:600; }
+  .outcome .out { font-size:11px; color:var(--ink-dim); margin-top:3px; font-family:var(--mono); }
+
+  /* right column */
+  .side { display:flex; flex-direction:column; gap:18px; }
+  .card-pad { padding:16px; }
+  .share-row { display:flex; align-items:center; gap:10px; margin:11px 0; font-size:12.5px; }
+  .share-row .lbl { width:108px; color:var(--ink-dim); display:flex; align-items:center; gap:7px; }
+  .swatch { width:9px; height:9px; border-radius:3px; background:var(--c); }
+  .track { flex:1; height:8px; background:var(--line); border-radius:5px; overflow:hidden; }
+  .track > i { display:block; height:100%; background:var(--c); }
+  .share-row .pct { width:38px; text-align:right; font-family:var(--mono); color:var(--ink); font-size:12px; }
+
+  .acc { padding:4px 0 2px; }
+  .acc .ar { display:flex; align-items:center; gap:10px; padding:9px 0; border-top:1px solid var(--line-soft); }
+  .acc .ar:first-child { border-top:0; }
+  .acc .ar .nm { width:120px; font-size:12px; color:var(--ink-dim); display:flex; gap:7px; align-items:center; }
+  .acc .ar .mtrack { flex:1; height:6px; background:var(--line); border-radius:4px; overflow:hidden; }
+  .acc .ar .mtrack > i { display:block; height:100%; background:linear-gradient(90deg,var(--win),var(--warn)); }
+  .acc .ar .mv { width:46px; text-align:right; font-family:var(--mono); font-size:12px; }
+
+  .foot { margin-top:18px; font-size:11px; color:var(--ink-faint); display:flex; gap:16px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <div class="brand">
+      <div class="logo"></div>
+      <div>
+        <h1>Agent Tasker · Market</h1>
+        <div class="sub">Vickrey auction · 4 agents · 3 clouds</div>
+      </div>
+    </div>
+    <div class="seg" style="margin-left:auto">
+      <button class="on">Live</button><button>24h</button><button>7d</button><button>All</button>
+    </div>
+    <div class="live"><span class="dot"></span> 4 / 4 agents online</div>
+  </div>
+
+  <div class="strip">
+    <div class="kpi"><div class="lab">Tasks settled</div><div class="val">767</div><div class="delta up">▲ 38 today</div></div>
+    <div class="kpi"><div class="lab">Total spend</div><div class="val">$21.40</div><div class="delta">execute only</div></div>
+    <div class="kpi"><div class="lab">Avg / task</div><div class="val">$0.0279</div><div class="delta up">▼ 6% vs 7d</div></div>
+    <div class="kpi"><div class="lab">Avg settle</div><div class="val">7.1s</div><div class="delta">bid+exec</div></div>
+    <div class="kpi"><div class="lab">Decline rate</div><div class="val">3.2%</div><div class="delta">capability / policy</div></div>
+  </div>
+
+  <div class="grid">
+    <div>
+      <h2 class="section">Agents <span class="count">— win share & accuracy</span></h2>
+      <div class="agents">
+
+        <div class="agent" style="--c:var(--gcp)">
+          <div class="head"><span class="badge">GCP</span><span class="name">Gemini</span><span class="rt">direct · vertex</span></div>
+          <div class="model">Gemini 2.5 Pro · frontier · simple-task specialist</div>
+          <div class="stats">
+            <div class="stat"><div class="n">41%</div><div class="l">win rate</div></div>
+            <div class="stat"><div class="n">12.4%</div><div class="l">MAPE</div></div>
+            <div class="stat"><div class="n">$0.018</div><div class="l">avg/task</div></div>
+          </div>
+          <div class="winbar"><i style="width:41%"></i></div>
+        </div>
+
+        <div class="agent" style="--c:var(--orch)">
+          <div class="head"><span class="badge">GCP</span><span class="name">Orchestrator</span><span class="rt">GAEP · multi-step</span></div>
+          <div class="model">Gemini 2.5 Pro + tools · frontier · complex-task specialist</div>
+          <div class="stats">
+            <div class="stat"><div class="n">11%</div><div class="l">win rate</div></div>
+            <div class="stat"><div class="n">23.7%</div><div class="l">MAPE</div></div>
+            <div class="stat"><div class="n">$0.114</div><div class="l">avg/task</div></div>
+          </div>
+          <div class="winbar"><i style="width:11%"></i></div>
+        </div>
+
+        <div class="agent" style="--c:var(--aws)">
+          <div class="head"><span class="badge">AWS</span><span class="name">Nova</span><span class="rt">bedrock · lambda</span></div>
+          <div class="model">Amazon Nova Pro · frontier · low-cost leader</div>
+          <div class="stats">
+            <div class="stat"><div class="n">27%</div><div class="l">win rate</div></div>
+            <div class="stat"><div class="n">9.8%</div><div class="l">MAPE</div></div>
+            <div class="stat"><div class="n">$0.006</div><div class="l">avg/task</div></div>
+          </div>
+          <div class="winbar"><i style="width:27%"></i></div>
+        </div>
+
+        <div class="agent" style="--c:var(--azure)">
+          <div class="head"><span class="badge">AZURE</span><span class="name">GPT</span><span class="rt">openai · container</span></div>
+          <div class="model">gpt-4o <span style="color:var(--warn)">· interim (GPT-5 quota pending)</span></div>
+          <div class="stats">
+            <div class="stat"><div class="n">21%</div><div class="l">win rate</div></div>
+            <div class="stat"><div class="n">15.1%</div><div class="l">MAPE</div></div>
+            <div class="stat"><div class="n">$0.041</div><div class="l">avg/task</div></div>
+          </div>
+          <div class="winbar"><i style="width:21%"></i></div>
+        </div>
+
+      </div>
+
+      <h2 class="section">Live auctions <span class="count">— sealed bids → winner → second price</span></h2>
+      <div class="panel feed">
+
+        <div class="row">
+          <div>
+            <div class="prompt">Summarize this 1,800-word support transcript into 5 bullets</div>
+            <div class="bids">
+              <div class="bid" style="--c:var(--gcp); height:62%"><span class="cap">$.021</span></div>
+              <div class="bid win" style="--c:var(--orch); height:90%"><span class="cap">$.088</span></div>
+              <div class="bid" style="--c:var(--aws); height:38%"><span class="cap">$.012</span></div>
+              <div class="bid" style="--c:var(--azure); height:74%"><span class="cap">$.044</span></div>
+            </div>
+            <div class="meta"><span class="pill frontier">frontier</span><span class="pill">min_tier</span><span>· 3 tool steps · 9.4s</span></div>
+          </div>
+          <div class="outcome">
+            <div class="lab">2nd price</div><div class="price" style="color:var(--orch)">$0.074</div>
+            <div class="winner" style="--c:var(--orch)">GCP · Orchestrator</div>
+            <div class="out">completed</div>
+          </div>
+        </div>
+
+        <div class="row">
+          <div>
+            <div class="prompt">Translate “quarterly earnings call” to Japanese</div>
+            <div class="bids">
+              <div class="bid" style="--c:var(--gcp); height:48%"><span class="cap">$.014</span></div>
+              <div class="bid" style="--c:var(--orch); height:96%"><span class="cap">$.121</span></div>
+              <div class="bid win" style="--c:var(--aws); height:30%"><span class="cap">$.005</span></div>
+              <div class="bid" style="--c:var(--azure); height:60%"><span class="cap">$.038</span></div>
+            </div>
+            <div class="meta"><span class="pill">small ok</span><span>· single call · 2.1s</span></div>
+          </div>
+          <div class="outcome">
+            <div class="lab">2nd price</div><div class="price" style="color:var(--aws)">$0.014</div>
+            <div class="winner" style="--c:var(--aws)">AWS · Nova</div>
+            <div class="out">“四半期決算説明会”</div>
+          </div>
+        </div>
+
+        <div class="row">
+          <div>
+            <div class="prompt">Extract all dates and amounts from this invoice</div>
+            <div class="bids">
+              <div class="bid win" style="--c:var(--gcp); height:52%"><span class="cap">$.016</span></div>
+              <div class="bid" style="--c:var(--orch); height:88%"><span class="cap">$.092</span></div>
+              <div class="bid" style="--c:var(--aws); height:34%"><span class="cap">$.007</span></div>
+              <div class="bid" style="--c:var(--azure); height:66%"><span class="cap">$.041</span></div>
+            </div>
+            <div class="meta"><span class="pill">small ok</span><span>· single call · 3.0s</span></div>
+          </div>
+          <div class="outcome">
+            <div class="lab">2nd price</div><div class="price" style="color:var(--gcp)">$0.016</div>
+            <div class="winner" style="--c:var(--gcp)">GCP · Gemini</div>
+            <div class="out">12 fields</div>
+          </div>
+        </div>
+
+        <div class="row">
+          <div>
+            <div class="prompt">Draft a polite follow-up email declining a vendor</div>
+            <div class="bids">
+              <div class="bid" style="--c:var(--gcp); height:50%"><span class="cap">$.015</span></div>
+              <div class="bid" style="--c:var(--orch); height:84%"><span class="cap">$.081</span></div>
+              <div class="bid" style="--c:var(--aws); height:32%"><span class="cap">$.006</span></div>
+              <div class="bid win" style="--c:var(--azure); height:64%"><span class="cap">$.040</span></div>
+            </div>
+            <div class="meta"><span class="pill frontier">frontier</span><span>· single call · 4.2s</span></div>
+          </div>
+          <div class="outcome">
+            <div class="lab">2nd price</div><div class="price" style="color:var(--azure)">$0.040</div>
+            <div class="winner" style="--c:var(--azure)">Azure · GPT</div>
+            <div class="out">completed</div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- right column -->
+    <div class="side">
+      <div class="panel card-pad">
+        <h2 class="section" style="margin-top:0">Win share by cloud</h2>
+        <div class="share-row"><div class="lbl" style="--c:var(--gcp)"><span class="swatch"></span>GCP (both)</div><div class="track"><i style="width:52%"></i></div><div class="pct">52%</div></div>
+        <div class="share-row"><div class="lbl" style="--c:var(--aws)"><span class="swatch"></span>AWS</div><div class="track"><i style="width:27%"></i></div><div class="pct">27%</div></div>
+        <div class="share-row"><div class="lbl" style="--c:var(--azure)"><span class="swatch"></span>Azure</div><div class="track"><i style="width:21%"></i></div><div class="pct">21%</div></div>
+        <div style="border-top:1px solid var(--line-soft); margin:14px 0 4px"></div>
+        <h2 class="section">Spend share by cloud</h2>
+        <div class="share-row"><div class="lbl" style="--c:var(--gcp)"><span class="swatch"></span>GCP</div><div class="track"><i style="width:58%"></i></div><div class="pct">58%</div></div>
+        <div class="share-row"><div class="lbl" style="--c:var(--azure)"><span class="swatch"></span>Azure</div><div class="track"><i style="width:30%"></i></div><div class="pct">30%</div></div>
+        <div class="share-row"><div class="lbl" style="--c:var(--aws)"><span class="swatch"></span>AWS</div><div class="track"><i style="width:12%"></i></div><div class="pct">12%</div></div>
+      </div>
+
+      <div class="panel card-pad">
+        <h2 class="section" style="margin-top:0">Bid accuracy <span class="count">— MAPE, lower = better</span></h2>
+        <div class="acc">
+          <div class="ar"><div class="nm" style="--c:var(--aws)"><span class="swatch"></span>Nova</div><div class="mtrack"><i style="width:18%"></i></div><div class="mv">9.8%</div></div>
+          <div class="ar"><div class="nm" style="--c:var(--gcp)"><span class="swatch"></span>Gemini</div><div class="mtrack"><i style="width:26%"></i></div><div class="mv">12.4%</div></div>
+          <div class="ar"><div class="nm" style="--c:var(--azure)"><span class="swatch"></span>GPT</div><div class="mtrack"><i style="width:32%"></i></div><div class="mv">15.1%</div></div>
+          <div class="ar"><div class="nm" style="--c:var(--orch)"><span class="swatch"></span>Orchestrator</div><div class="mtrack"><i style="width:50%"></i></div><div class="mv">23.7%</div></div>
+        </div>
+        <div style="font-size:11px; color:var(--ink-faint); margin-top:10px; line-height:1.5">
+          Orchestrator MAPE is dominated by step-count / tool-call prediction, not tokenization.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="foot">
+    <span>Coordinator · GCP us-central1</span><span>·</span>
+    <span>Vickrey (second-price)</span><span>·</span>
+    <span>score-weighting unlocks at 100 settled tasks</span>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
First-pass UI design for the 4-bidder market dashboard, also synced to the claude.ai/design "Design System" project (`market/*.html`).

Three self-contained HTML/CSS previews (`@dsCard` markers, shared dark cloud-coded visual language):
- **dashboard.html** — full market view: KPI strip → 4 agent leaderboard cards → live-auction feed (sealed bids → winner glows → second-price) → cross-cloud win/spend share + MAPE accuracy rail.
- **agent-card.html** — reusable per-agent card (accent = cloud/runtime: GCP blue, Orchestrator green, AWS orange, Azure teal).
- **auction-row.html** — auction row showing the Vickrey second-price reveal.

Mock data for now. The design defines the coordinator **read APIs still to build** to wire it live: `GET /tasks` (list), `GET /agents/stats` (win rate / MAPE / cost rollups), and per-task bid breakdown (already stored under `tasks/{id}/bids/`).

Design source only — no code/infra change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)